### PR TITLE
Add a new environmental variable L10N to set fast_io's locale without…

### DIFF
--- a/include/fast_io_i18n/locale/posix.h
+++ b/include/fast_io_i18n/locale/posix.h
@@ -36,13 +36,17 @@ inline void* posix_load_l10n_common_impl(char8_t const* cstr,std::size_t n,lc_lo
 	}
 	else if(n==0)
 	{
-		char const* lc_all_env{my_u8getenv(u8"LC_ALL")};
+		char const* lc_all_env{my_u8getenv(u8"FAST_IO_LC_ALL")};
 		if(lc_all_env==nullptr)
 		{
-			lc_all_env=my_u8getenv(u8"LANG");
+			lc_all_env=my_u8getenv(u8"LC_ALL");
 			if(lc_all_env==nullptr)
 			{
-				lc_all_env=reinterpret_cast<char const*>(u8"C");
+				lc_all_env=my_u8getenv(u8"LANG");
+				if(lc_all_env==nullptr)
+				{
+					lc_all_env=reinterpret_cast<char const*>(u8"C");
+				}
 			}
 		}
 		cstr=reinterpret_cast<native_char_type_may_alias_const_ptr>(lc_all_env);


### PR DESCRIPTION
… affecting POSIX locale system itself