### PR TITLE
add missing cond manipulator

### DIFF
--- a/include/fast_io.h
+++ b/include/fast_io.h
@@ -428,7 +428,7 @@ requires (sizeof...(Args)!=0)
 }
 
 //Allow debug print
-#ifndef NDEBUG
+#if !defined(NDEBUG) || defined(FAST_IO_ENABLE_DEBUG_PRINT)
 //With debugging. We output to POSIX fd or Win32 Handle directly instead of C's stdout.
 template<typename T,typename... Args>
 inline constexpr void debug_print(T&& t,Args&& ...args)

--- a/include/fast_io_core_impl/integers/pointer.h
+++ b/include/fast_io_core_impl/integers/pointer.h
@@ -89,6 +89,25 @@ inline constexpr ::std::underlying_type_t<enumtype> enum_int_view(enumtype enm) 
 	return static_cast<::std::underlying_type_t<enumtype>>(enm);
 }
 
+template<typename T1,typename T2>
+inline constexpr decltype(auto) cond(bool pred,T1&& t1,T2&& t2) noexcept
+{
+	constexpr bool type_error{::std::same_as<decltype(fast_io::io_print_alias(t1)),
+		decltype(fast_io::io_print_alias(t2))>};
+static_assert(type_error,"type not same for cond");
+	if constexpr(type_error)
+	{
+		if(pred)
+		{
+			return fast_io::io_print_alias(t1);
+		}
+		else
+		{
+			return fast_io::io_print_alias(t2);
+		}
+	}
+}
+
 }
 
 template<std::integral char_type>


### PR DESCRIPTION
Add FAST_IO_ENABLE_DEBUG_PRINT to forcibly enable debug_print and debug_println since cmake would enable NDEBUG by default for release.