### PR TITLE
Rename all asm with __asm__.

### DIFF
--- a/include/fast_io_driver/linux_kernel_impl/kpr.h
+++ b/include/fast_io_driver/linux_kernel_impl/kpr.h
@@ -3,7 +3,7 @@
 namespace fast_io
 {
 
-extern int linux_kernel_printk(char const* fmt, ...) noexcept asm("printk");
+extern int linux_kernel_printk(char const* fmt, ...) noexcept __asm__("printk");
 
 enum class kern
 {

--- a/include/fast_io_hosted/filesystem/posix_at.h
+++ b/include/fast_io_hosted/filesystem/posix_at.h
@@ -5,18 +5,18 @@ namespace fast_io
 
 namespace posix
 {
-extern int libc_faccessat(int dirfd,char const* pathname,int mode, int flags) noexcept asm("faccessat");
-extern int libc_renameat(int olddirfd,char const* oldpath,int newdirfd, char const* newpath) noexcept asm("renameat");
-extern int libc_linkat(int olddirfd,char const* oldpath,int newdirfd, char const* newpath,int flags) noexcept asm("linkat");
-extern int libc_symlinkat(char const* oldpath, int newdirfd, char const *newpath) noexcept asm("symlinkat");
-extern int libc_fchmodat(int dirfd, char const *pathname, mode_t mode, int flags) noexcept asm("fchmodat");
-extern int libc_utimensat(int dirfd, char const *pathname,struct timespec const* times, int flags) noexcept asm("utimensat");
-extern int libc_fchownat(int dirfd, char const *pathname,uid_t owner, gid_t group, int flags) noexcept asm("fchownat");
-extern int libc_fstatat(int dirfd, char const *pathname, struct stat *buf,int flags) noexcept asm("fstatat");
-extern int libc_mkdirat(int dirfd, char const* pathname, mode_t mode) noexcept asm("mkdirat");
-extern int libc_mknodat(int dirfd, char const* pathname, mode_t mode, dev_t dev) noexcept asm("mknodat");
-extern int libc_unlinkat(int dirfd, char const*pathname, int flags) noexcept asm("unlinkat");
-extern int libc_readlinkat(int dirfd, char const *pathname,char *buf, std::size_t bufsiz) noexcept asm("readlinkat");
+extern int libc_faccessat(int dirfd,char const* pathname,int mode, int flags) noexcept __asm__("faccessat");
+extern int libc_renameat(int olddirfd,char const* oldpath,int newdirfd, char const* newpath) noexcept __asm__("renameat");
+extern int libc_linkat(int olddirfd,char const* oldpath,int newdirfd, char const* newpath,int flags) noexcept __asm__("linkat");
+extern int libc_symlinkat(char const* oldpath, int newdirfd, char const *newpath) noexcept __asm__("symlinkat");
+extern int libc_fchmodat(int dirfd, char const *pathname, mode_t mode, int flags) noexcept __asm__("fchmodat");
+extern int libc_utimensat(int dirfd, char const *pathname,struct timespec const* times, int flags) noexcept __asm__("utimensat");
+extern int libc_fchownat(int dirfd, char const *pathname,uid_t owner, gid_t group, int flags) noexcept __asm__("fchownat");
+extern int libc_fstatat(int dirfd, char const *pathname, struct stat *buf,int flags) noexcept __asm__("fstatat");
+extern int libc_mkdirat(int dirfd, char const* pathname, mode_t mode) noexcept __asm__("mkdirat");
+extern int libc_mknodat(int dirfd, char const* pathname, mode_t mode, dev_t dev) noexcept __asm__("mknodat");
+extern int libc_unlinkat(int dirfd, char const*pathname, int flags) noexcept __asm__("unlinkat");
+extern int libc_readlinkat(int dirfd, char const *pathname,char *buf, std::size_t bufsiz) noexcept __asm__("readlinkat");
 }
 
 namespace details

--- a/include/fast_io_hosted/platforms/systemcall_details.h
+++ b/include/fast_io_hosted/platforms/systemcall_details.h
@@ -4,12 +4,12 @@ namespace fast_io::details
 {
 
 #ifdef __MSDOS__
-extern int dup(int) noexcept asm("dup");
-extern int dup2(int,int) noexcept asm("dup2");
-extern int _close(int) noexcept asm("_close");
+extern int dup(int) noexcept __asm__("dup");
+extern int dup2(int,int) noexcept __asm__("dup2");
+extern int _close(int) noexcept __asm__("_close");
 #elif defined(__wasi__)
-extern int dup(int) noexcept asm("dup");
-extern int dup2(int,int) noexcept asm("dup2");
+extern int dup(int) noexcept __asm__("dup");
+extern int dup2(int,int) noexcept __asm__("dup2");
 #endif
 
 inline int sys_dup(int old_fd)

--- a/include/fast_io_hosted/platforms/win32_network/win32_9x_dns.h
+++ b/include/fast_io_hosted/platforms/win32_network/win32_9x_dns.h
@@ -23,12 +23,12 @@ extern hostent* __stdcall gethostbyname(char const*) noexcept
 #if defined(__clang__) || defined(__GNUC__)
 #if SIZE_MAX<=UINT_LEAST32_MAX &&(defined(__x86__) || defined(_M_IX86) || defined(__i386__))
 #if !defined(__clang__)
-asm("gethostbyname@4")
+__asm__("gethostbyname@4")
 #else
-asm("_gethostbyname@4")
+__asm__("_gethostbyname@4")
 #endif
 #else
-asm("gethostbyname")
+__asm__("gethostbyname")
 #endif
 #endif
 ;

--- a/include/fast_io_hosted/time.h
+++ b/include/fast_io_hosted/time.h
@@ -645,7 +645,7 @@ inline iso8601_timestamp to_iso8601_local_impl(std::int_least64_t seconds,std::u
 #if __has_cpp_attribute(__gnu__::__dllimport__)&&defined(__CYGWIN__)
 [[__gnu__::__dllimport__]]
 #endif
-extern void m_tzset() noexcept asm("tzset");
+extern void m_tzset() noexcept __asm__("tzset");
 #endif
 }
 

--- a/include/fast_io_legacy_impl/c/done.h
+++ b/include/fast_io_legacy_impl/c/done.h
@@ -7,8 +7,8 @@ namespace details
 {
 
 #if defined(__CYGWIN__)
-[[__gnu__::__dllimport__]] extern std::size_t __cdecl my_cygwin_fwrite_unlocked(void const* __restrict buffer,std::size_t size,std::size_t count,FILE* __restrict) noexcept asm("fwrite_unlocked");
-[[__gnu__::__dllimport__]] extern std::size_t __cdecl my_cygwin_fread_unlocked(void* __restrict buffer,std::size_t size,std::size_t count,FILE* __restrict) noexcept asm("fread_unlocked");
+[[__gnu__::__dllimport__]] extern std::size_t __cdecl my_cygwin_fwrite_unlocked(void const* __restrict buffer,std::size_t size,std::size_t count,FILE* __restrict) noexcept __asm__("fwrite_unlocked");
+[[__gnu__::__dllimport__]] extern std::size_t __cdecl my_cygwin_fread_unlocked(void* __restrict buffer,std::size_t size,std::size_t count,FILE* __restrict) noexcept __asm__("fread_unlocked");
 #endif
 
 inline std::size_t c_fwrite_unlocked_impl(void const* __restrict begin,std::size_t type_size,std::size_t count,FILE* __restrict fp)

--- a/include/fast_io_legacy_impl/c/glibc.h
+++ b/include/fast_io_legacy_impl/c/glibc.h
@@ -167,7 +167,7 @@ inline void ibuffer_set_curr(wc_io_observer_unlocked cio,wchar_t* ptr) noexcept
 
 namespace details
 {
-extern std::uint_least32_t glibc_wunderflow (FILE *) noexcept asm("__wunderflow");
+extern std::uint_least32_t glibc_wunderflow (FILE *) noexcept __asm__("__wunderflow");
 }
 #if WCHAR_MAX == UINT_LEAST32_MAX
 inline bool ibuffer_underflow(wc_io_observer_unlocked cio) noexcept
@@ -198,7 +198,7 @@ inline void obuffer_set_curr(wc_io_observer_unlocked cio,wchar_t* ptr) noexcept
 #endif
 namespace details
 {
-extern std::uint_least32_t glibc_woverflow (FILE *,std::uint_least32_t) noexcept asm("__woverflow");
+extern std::uint_least32_t glibc_woverflow (FILE *,std::uint_least32_t) noexcept __asm__("__woverflow");
 }
 
 inline void obuffer_overflow(wc_io_observer_unlocked cio,wchar_t ch)
@@ -262,7 +262,7 @@ inline void obuffer_overflow(u32c_io_observer_unlocked cio,char32_t ch)
 
 namespace details
 {
-extern int glibc_flbf(FILE* fp) noexcept asm("__flbf");
+extern int glibc_flbf(FILE* fp) noexcept __asm__("__flbf");
 }
 
 template<std::integral ch_type>

--- a/include/fast_io_legacy_impl/c/impl.h
+++ b/include/fast_io_legacy_impl/c/impl.h
@@ -173,29 +173,29 @@ namespace details
 {
 
 #if defined(__MSDOS__)
-extern int fileno(FILE*) noexcept asm("_fileno");
-extern FILE* fdopen(int,char const*) noexcept asm("_fdopen");
+extern int fileno(FILE*) noexcept __asm__("_fileno");
+extern FILE* fdopen(int,char const*) noexcept __asm__("_fdopen");
 #elif defined(__CYGWIN__)
 [[__gnu__::__dllimport__]] extern int fileno(FILE*) noexcept 
 #if SIZE_MAX<=UINT_LEAST32_MAX &&(defined(__x86__) || defined(_M_IX86) || defined(__i386__))
 #if defined(__GNUC__)
-asm("fileno")
+__asm__("fileno")
 #else
-asm("_fileno")
+__asm__("_fileno")
 #endif
 #else
-asm("fileno")
+__asm__("fileno")
 #endif
 ;
 [[__gnu__::__dllimport__]] extern FILE* fdopen(int,char const*) noexcept
 #if SIZE_MAX<=UINT_LEAST32_MAX &&(defined(__x86__) || defined(_M_IX86) || defined(__i386__))
 #if defined(__GNUC__)
-asm("fdopen")
+__asm__("fdopen")
 #else
-asm("_fdopen")
+__asm__("_fdopen")
 #endif
 #else
-asm("fdopen")
+__asm__("fdopen")
 #endif
 ;
 
@@ -207,24 +207,24 @@ asm("fdopen")
 [[__gnu__::__dllimport__]] extern void my_cygwin_pthread_mutex_lock(void*) noexcept
 #if SIZE_MAX<=UINT_LEAST32_MAX &&(defined(__x86__) || defined(_M_IX86) || defined(__i386__))
 #if defined(__GNUC__)
-asm("pthread_mutex_lock")
+__asm__("pthread_mutex_lock")
 #else
-asm("_pthread_mutex_lock")
+__asm__("_pthread_mutex_lock")
 #endif
 #else
-asm("pthread_mutex_lock")
+__asm__("pthread_mutex_lock")
 #endif
 ;
 
 [[__gnu__::__dllimport__]] extern void my_cygwin_pthread_mutex_unlock(void*) noexcept
 #if SIZE_MAX<=UINT_LEAST32_MAX &&(defined(__x86__) || defined(_M_IX86) || defined(__i386__))
 #if defined(__GNUC__)
-asm("pthread_mutex_unlock")
+__asm__("pthread_mutex_unlock")
 #else
-asm("_pthread_mutex_unlock")
+__asm__("_pthread_mutex_unlock")
 #endif
 #else
-asm("pthread_mutex_unlock")
+__asm__("pthread_mutex_unlock")
 #endif
 ;
 
@@ -377,7 +377,7 @@ inline int my_fclose_impl(FILE* fp) noexcept
 #if !defined(__NEWLIB__) || defined(__CYGWIN__)
 
 #if defined(__GLIBC__)
-extern size_t glibc_fbufsize(FILE *stream) noexcept asm("__fbufsize");
+extern size_t glibc_fbufsize(FILE *stream) noexcept __asm__("__fbufsize");
 #endif
 
 inline FILE* my_fdopen(int fd,char const* mode) noexcept

--- a/include/fast_io_legacy_impl/c/msvcrt_lock.h
+++ b/include/fast_io_legacy_impl/c/msvcrt_lock.h
@@ -16,12 +16,12 @@ extern void __cdecl _lock(int) noexcept
 #if defined(__clang__) || defined(__GNUC__)
 #if SIZE_MAX<=UINT_LEAST32_MAX &&(defined(__x86__) || defined(_M_IX86) || defined(__i386__))
 #if !defined(__clang__)
-asm("_lock")
+__asm__("_lock")
 #else
-asm("__lock")
+__asm__("__lock")
 #endif
 #else
-asm("_lock")
+__asm__("_lock")
 #endif
 #endif
 ;
@@ -33,12 +33,12 @@ extern void __cdecl _unlock(int) noexcept
 #if defined(__clang__) || defined(__GNUC__)
 #if SIZE_MAX<=UINT_LEAST32_MAX &&(defined(__x86__) || defined(_M_IX86) || defined(__i386__))
 #if !defined(__clang__)
-asm("_unlock")
+__asm__("_unlock")
 #else
-asm("__unlock")
+__asm__("__unlock")
 #endif
 #else
-asm("_unlock")
+__asm__("_unlock")
 #endif
 #endif
 ;

--- a/include/fast_io_legacy_impl/c/musl.h
+++ b/include/fast_io_legacy_impl/c/musl.h
@@ -180,7 +180,7 @@ char8_t* ptr) noexcept
 
 namespace details::fp_hack
 {
-extern int libc_uflow (FILE *) noexcept asm("__uflow");
+extern int libc_uflow (FILE *) noexcept __asm__("__uflow");
 
 inline bool musl_fp_underflow_impl(FILE* fp)
 {
@@ -258,7 +258,7 @@ char8_t* ptr) noexcept
 
 namespace details
 {
-extern int libc_overflow(_IO_FILE *, int) noexcept asm("__overflow");
+extern int libc_overflow(_IO_FILE *, int) noexcept __asm__("__overflow");
 }
 
 inline void obuffer_overflow(c_io_observer_unlocked cio,char ch)

--- a/include/fast_io_legacy_impl/c/unix.h
+++ b/include/fast_io_legacy_impl/c/unix.h
@@ -191,10 +191,10 @@ T* ptr) noexcept
 }
 
 #if defined(__BSD_VISIBLE) ||defined(__DARWIN_C_LEVEL)
-extern int bsd_srget(FILE *) noexcept asm("__srget");
+extern int bsd_srget(FILE *) noexcept __asm__("__srget");
 #elif defined(__MSDOS__)
-extern int _filbuf(FILE *) noexcept asm("__filbuf");
-extern int _flsbuf(int, FILE*) noexcept asm("__flsbuf");
+extern int _filbuf(FILE *) noexcept __asm__("__filbuf");
+extern int _flsbuf(int, FILE*) noexcept __asm__("__flsbuf");
 #elif defined(_MSC_VER)
 //extern "C" int __cdecl __acrt_stdio_refill_and_read_narrow_nolock(FILE*);
 #endif


### PR DESCRIPTION
asm() is a compiler extension, which will break with compilation toggle. Replace them with __asm__