### PR TITLE
Change natural male:female ratio at birth to 103:100

### DIFF
--- a/examples/0014.random/sexratio.cc
+++ b/examples/0014.random/sexratio.cc
@@ -14,7 +14,7 @@ int main(int argc,char** argv)
 		perr("Usage: ",os_c_str(*argv)," N\n");
 		return 1;
 	}
-	constexpr auto natural_male_to_female_ratio{1.05};
+	constexpr auto natural_male_to_female_ratio{1.03};
 	constexpr auto total_ratio{natural_male_to_female_ratio+1.0};
 	constexpr auto male_probability{natural_male_to_female_ratio/total_ratio};
 	fast_io::ibuf_white_hole_engine engine;

--- a/examples/0014.random/stop_born_child_until_boy.cc
+++ b/examples/0014.random/stop_born_child_until_boy.cc
@@ -15,7 +15,7 @@ int main(int argc,char** argv)
 		perr("Usage: ",os_c_str(*argv)," N\n");
 		return 1;
 	}
-	constexpr auto natural_male_to_female_ratio{1.05};
+	constexpr auto natural_male_to_female_ratio{1.03};
 	constexpr auto total_ratio{natural_male_to_female_ratio+1.0};
 	constexpr auto male_probability{natural_male_to_female_ratio/total_ratio};
 	fast_io::ibuf_white_hole_engine engine;


### PR DESCRIPTION
UN data that referenced from 105:100 in the United States is wrong since Chinese Americans abort female babies. Particularly at the 2nd child. The sex ratio is 150:100 which is ridiculous