### PR TITLE
wasi should use memchr under no simd option too

### DIFF
--- a/include/fast_io_core_impl/simd_find.h
+++ b/include/fast_io_core_impl/simd_find.h
@@ -268,6 +268,8 @@ inline constexpr char_type const* find_simd_constant_common_impl(char_type const
 //For glibc >= 2.26, we use glibc's memchr implementation under hosted environment
 	!findnot
 #endif
+#elif defined(__wasi__)
+	!findnot&&!::fast_io::details::optimal_simd_vector_run_with_cpu_instruction_size
 #endif
 #endif
 	};


### PR DESCRIPTION
To do optimize find without simd like musl's memchr does