### PR TITLE
Enable table based implementation of is_c_space

### DIFF
--- a/include/fast_io_core_impl/integers/sto/sto_contiguous.h
+++ b/include/fast_io_core_impl/integers/sto/sto_contiguous.h
@@ -338,11 +338,15 @@ inline simd_parse_result sse_parse(char unsigned const* buffer,char unsigned con
 			case 4:
 			{
 				constexpr std::uint_least64_t risky_value{UINT_LEAST64_MAX/UINT64_C(10000)};
-				constexpr std::uint_least32_t risky_mod{static_cast<std::uint_least32_t>(UINT_LEAST64_MAX%UINT64_C(10000))};
+				constexpr std::uint_fast16_t risky_mod{UINT_LEAST64_MAX%UINT64_C(10000)};
 				if(result>risky_value)
 					return {20,parse_code::overflow};
-				auto partial{(buffer[16]-zero_constant)*UINT16_C(1000)+(buffer[17]-zero_constant)*UINT16_C(100)
-				+(buffer[18]-zero_constant)*UINT16_C(10)+(buffer[19]-zero_constant)};
+				std::uint_fast16_t partial{
+				static_cast<std::uint_fast16_t>(
+				static_cast<std::uint_fast16_t>(buffer[16]-zero_constant)*UINT16_C(1000)+
+				static_cast<std::uint_fast8_t>(buffer[17]-zero_constant)*UINT16_C(100)+
+				static_cast<std::uint_fast8_t>(buffer[18]-zero_constant)*UINT16_C(10)+
+				static_cast<std::uint_fast8_t>(buffer[19]-zero_constant))};
 				if(result==risky_value&&risky_mod<partial)
 					return {20,parse_code::overflow};
 				res=result*UINT16_C(10000)+partial;

--- a/include/fast_io_core_impl/simd/generic.h
+++ b/include/fast_io_core_impl/simd/generic.h
@@ -8,7 +8,14 @@ namespace intrinsics
 
 template<typename T,std::size_t N>
 struct
-#if defined(_MSC_VER)
+#if defined(__has_declspec_attribute)
+#if __has_declspec_attribute(intrin_type)
+__declspec(intrin_type)
+#endif
+#if __has_declspec_attribute(align)
+__declspec(align(sizeof(T)*N/2))
+#endif
+#elif defined(_MSC_VER)
 __declspec(intrin_type) __declspec(align(sizeof(T)*N/2))
 #endif
 simd_vector

--- a/include/fast_io_core_impl/simd/generic_operations.h
+++ b/include/fast_io_core_impl/simd/generic_operations.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#if !defined(_MSC_VER)
+#if !defined(_MSC_VER) || defined(__clang__)
 #include <immintrin.h>
 #endif
 
@@ -11,7 +11,14 @@ namespace intrinsics
 {
 template<typename T,std::size_t N>
 struct
-#if defined(_MSC_VER)
+#if defined(__has_declspec_attribute)
+#if __has_declspec_attribute(intrin_type)
+__declspec(intrin_type)
+#endif
+#if __has_declspec_attribute(align)
+__declspec(align(sizeof(T)*N/2))
+#endif
+#elif defined(_MSC_VER)
 __declspec(intrin_type) __declspec(align(sizeof(T)*N/2))
 #endif
 simd_vector;
@@ -125,8 +132,8 @@ template<typename T,typename Func>
 inline constexpr T generic_simd_comparision_common_impl(T const& a,
 	T const& b,Func func) noexcept
 {
-	using value_type = std::remove_cvref_t<T>::value_type;
-	return ::fast_io::details::generic_simd_create_op_impl(a,b,[&](value_type va,value_type vb)->value_type
+	using value_type = typename std::remove_cvref_t<T>::value_type;
+	return ::fast_io::details::generic_simd_create_op_impl(a,b,[&](value_type va,value_type vb) noexcept ->value_type
 	{
 		bool t{func(va,vb)};
 		constexpr auto mx{create_value_mx<value_type>()};
@@ -180,13 +187,16 @@ inline constexpr ::fast_io::intrinsics::simd_vector<T,N> wrap_add_common(::fast_
 			}
 			else if constexpr(std::floating_point<T>)
 			{
+#if !defined(__clang__)
 				if constexpr(sizeof(T)==sizeof(float)/2)
 				{
 					__m128h amm = __builtin_bit_cast(__m128h,a);
 					__m128h bmm = __builtin_bit_cast(__m128h,b);
 					return __builtin_bit_cast(vec_type,_mm_add_ph(amm,bmm));
 				}
-				else if constexpr(sizeof(T)==sizeof(float))
+				else
+#endif
+				if constexpr(sizeof(T)==sizeof(float))
 				{
 					__m128 amm = __builtin_bit_cast(__m128,a);
 					__m128 bmm = __builtin_bit_cast(__m128,b);
@@ -225,13 +235,16 @@ inline constexpr ::fast_io::intrinsics::simd_vector<T,N> wrap_add_common(::fast_
 			}
 			else if constexpr(std::floating_point<T>)
 			{
+#if !defined(__clang__)
 				if constexpr(sizeof(T)==sizeof(float)/2)
 				{
 					__m256h amm = __builtin_bit_cast(__m256h,a);
 					__m256h bmm = __builtin_bit_cast(__m256h,b);
 					return __builtin_bit_cast(vec_type,_mm256_add_ph(amm,bmm));
 				}
-				else if constexpr(sizeof(T)==sizeof(float))
+				else
+#endif
+				if constexpr(sizeof(T)==sizeof(float))
 				{
 					__m256 amm = __builtin_bit_cast(__m256,a);
 					__m256 bmm = __builtin_bit_cast(__m256,b);
@@ -270,13 +283,16 @@ inline constexpr ::fast_io::intrinsics::simd_vector<T,N> wrap_add_common(::fast_
 			}
 			else if constexpr(std::floating_point<T>&&::fast_io::details::cpu_flags::avx512f_supported)
 			{
+#if !defined(__clang__)
 				if constexpr(sizeof(T)==sizeof(float)/2)
 				{
 					__m512h amm = __builtin_bit_cast(__m512h,a);
 					__m512h bmm = __builtin_bit_cast(__m512h,b);
 					return __builtin_bit_cast(vec_type,_mm512_add_ph(amm,bmm));
 				}
-				else if constexpr(sizeof(T)==sizeof(float))
+				else
+#endif
+				if constexpr(sizeof(T)==sizeof(float))
 				{
 					__m512 amm = __builtin_bit_cast(__m512,a);
 					__m512 bmm = __builtin_bit_cast(__m512,b);
@@ -342,13 +358,16 @@ inline constexpr ::fast_io::intrinsics::simd_vector<T,N> wrap_minus_common(::fas
 			}
 			else if constexpr(std::floating_point<T>)
 			{
+#if !defined(__clang__)
 				if constexpr(sizeof(T)==sizeof(float)/2)
 				{
 					__m128h amm = __builtin_bit_cast(__m128h,a);
 					__m128h bmm = __builtin_bit_cast(__m128h,b);
 					return __builtin_bit_cast(vec_type,_mm_sub_ph(amm,bmm));
 				}
-				else if constexpr(sizeof(T)==sizeof(float))
+				else
+#endif
+				if constexpr(sizeof(T)==sizeof(float))
 				{
 					__m128 amm = __builtin_bit_cast(__m128,a);
 					__m128 bmm = __builtin_bit_cast(__m128,b);
@@ -387,13 +406,16 @@ inline constexpr ::fast_io::intrinsics::simd_vector<T,N> wrap_minus_common(::fas
 			}
 			else if constexpr(std::floating_point<T>)
 			{
+#if !defined(__clang__)
 				if constexpr(sizeof(T)==sizeof(float)/2)
 				{
 					__m256h amm = __builtin_bit_cast(__m256h,a);
 					__m256h bmm = __builtin_bit_cast(__m256h,b);
 					return __builtin_bit_cast(vec_type,_mm256_sub_ph(amm,bmm));
 				}
-				else if constexpr(sizeof(T)==sizeof(float))
+				else
+#endif
+				if constexpr(sizeof(T)==sizeof(float))
 				{
 					__m256 amm = __builtin_bit_cast(__m256,a);
 					__m256 bmm = __builtin_bit_cast(__m256,b);
@@ -432,13 +454,16 @@ inline constexpr ::fast_io::intrinsics::simd_vector<T,N> wrap_minus_common(::fas
 			}
 			else if constexpr(std::floating_point<T>&&::fast_io::details::cpu_flags::avx512f_supported)
 			{
+#if !defined(__clang__)
 				if constexpr(sizeof(T)==sizeof(float)/2)
 				{
 					__m512h amm = __builtin_bit_cast(__m512h,a);
 					__m512h bmm = __builtin_bit_cast(__m512h,b);
 					return __builtin_bit_cast(vec_type,_mm512_sub_ph(amm,bmm));
 				}
-				else if constexpr(sizeof(T)==sizeof(float))
+				else
+#endif
+				if constexpr(sizeof(T)==sizeof(float))
 				{
 					__m512 amm = __builtin_bit_cast(__m512,a);
 					__m512 bmm = __builtin_bit_cast(__m512,b);
@@ -560,13 +585,16 @@ inline constexpr simd_vector<T,N> operator*(simd_vector<T,N> const& a,simd_vecto
 			}
 			else if constexpr(std::floating_point<T>)
 			{
+#if !defined(__clang__)
 				if constexpr(sizeof(T)==sizeof(float)/2)
 				{
 					__m128h amm = __builtin_bit_cast(__m128h,a);
 					__m128h bmm = __builtin_bit_cast(__m128h,b);
 					return __builtin_bit_cast(vec_type,_mm_mul_ph(amm,bmm));
 				}
-				else if constexpr(sizeof(T)==sizeof(float))
+				else
+#endif
+				if constexpr(sizeof(T)==sizeof(float))
 				{
 					__m128 amm = __builtin_bit_cast(__m128,a);
 					__m128 bmm = __builtin_bit_cast(__m128,b);
@@ -603,13 +631,16 @@ inline constexpr simd_vector<T,N> operator*(simd_vector<T,N> const& a,simd_vecto
 			}
 			else if constexpr(std::floating_point<T>)
 			{
+#if !defined(__clang__)
 				if constexpr(sizeof(T)==sizeof(float)/2)
 				{
 					__m256h amm = __builtin_bit_cast(__m256h,a);
 					__m256h bmm = __builtin_bit_cast(__m256h,b);
 					return __builtin_bit_cast(vec_type,_mm256_mul_ph(amm,bmm));
 				}
-				else if constexpr(sizeof(T)==sizeof(float))
+				else
+#endif
+				if constexpr(sizeof(T)==sizeof(float))
 				{
 					__m256 amm = __builtin_bit_cast(__m256,a);
 					__m256 bmm = __builtin_bit_cast(__m256,b);
@@ -646,13 +677,16 @@ inline constexpr simd_vector<T,N> operator*(simd_vector<T,N> const& a,simd_vecto
 			}
 			else if constexpr(std::floating_point<T>&&::fast_io::details::cpu_flags::avx512f_supported)
 			{
+#if !defined(__clang__)
 				if constexpr(sizeof(T)==sizeof(float)/2)
 				{
 					__m512h amm = __builtin_bit_cast(__m512h,a);
 					__m512h bmm = __builtin_bit_cast(__m512h,b);
 					return __builtin_bit_cast(vec_type,_mm512_mul_ph(amm,bmm));
 				}
-				else if constexpr(sizeof(T)==sizeof(float))
+				else
+#endif
+				if constexpr(sizeof(T)==sizeof(float))
 				{
 					__m512 amm = __builtin_bit_cast(__m512,a);
 					__m512 bmm = __builtin_bit_cast(__m512,b);
@@ -668,7 +702,7 @@ inline constexpr simd_vector<T,N> operator*(simd_vector<T,N> const& a,simd_vecto
 		}
 	}
 #endif
-	return ::fast_io::details::generic_simd_create_op_impl(a,b,[](T va,T vb)
+	return ::fast_io::details::generic_simd_create_op_impl(a,b,[](T va,T vb) noexcept -> T
 	{
 		return va*vb;
 	});
@@ -717,13 +751,16 @@ inline constexpr simd_vector<T,N> operator/(simd_vector<T,N> const& a,simd_vecto
 			}
 			else if constexpr(std::floating_point<T>)
 			{
+#if !defined(__clang__)
 				if constexpr(sizeof(T)==sizeof(float)/2)
 				{
 					__m128h amm = __builtin_bit_cast(__m128h,a);
 					__m128h bmm = __builtin_bit_cast(__m128h,b);
 					return __builtin_bit_cast(vec_type,_mm_div_ph(amm,bmm));
 				}
-				else if constexpr(sizeof(T)==sizeof(float))
+				else
+#endif
+				if constexpr(sizeof(T)==sizeof(float))
 				{
 					__m128 amm = __builtin_bit_cast(__m128,a);
 					__m128 bmm = __builtin_bit_cast(__m128,b);
@@ -769,13 +806,16 @@ inline constexpr simd_vector<T,N> operator/(simd_vector<T,N> const& a,simd_vecto
 			}
 			else if constexpr(std::floating_point<T>)
 			{
+#if !defined(__clang__)
 				if constexpr(sizeof(T)==sizeof(float)/2)
 				{
 					__m256h amm = __builtin_bit_cast(__m256h,a);
 					__m256h bmm = __builtin_bit_cast(__m256h,b);
 					return __builtin_bit_cast(vec_type,_mm256_div_ph(amm,bmm));
 				}
-				else if constexpr(sizeof(T)==sizeof(float))
+				else
+#endif
+				if constexpr(sizeof(T)==sizeof(float))
 				{
 					__m256 amm = __builtin_bit_cast(__m256,a);
 					__m256 bmm = __builtin_bit_cast(__m256,b);
@@ -821,13 +861,16 @@ inline constexpr simd_vector<T,N> operator/(simd_vector<T,N> const& a,simd_vecto
 			}
 			else if constexpr(std::floating_point<T>&&::fast_io::details::cpu_flags::avx512f_supported)
 			{
+#if !defined(__clang__)
 				if constexpr(sizeof(T)==sizeof(float)/2)
 				{
 					__m512h amm = __builtin_bit_cast(__m512h,a);
 					__m512h bmm = __builtin_bit_cast(__m512h,b);
 					return __builtin_bit_cast(vec_type,_mm512_div_ph(amm,bmm));
 				}
-				else if constexpr(sizeof(T)==sizeof(float))
+				else
+#endif
+				if constexpr(sizeof(T)==sizeof(float))
 				{
 					__m512 amm = __builtin_bit_cast(__m512,a);
 					__m512 bmm = __builtin_bit_cast(__m512,b);
@@ -843,7 +886,7 @@ inline constexpr simd_vector<T,N> operator/(simd_vector<T,N> const& a,simd_vecto
 		}
 	}
 #endif
-	return ::fast_io::details::generic_simd_create_op_impl(a,b,[](T va,T vb)
+	return ::fast_io::details::generic_simd_create_op_impl(a,b,[](T va,T vb) noexcept -> T
 	{
 		return va/vb;
 	});
@@ -889,7 +932,7 @@ inline constexpr simd_vector<T,N> operator&(simd_vector<T,N> const& a,simd_vecto
 		}
 	}
 #endif
-	return ::fast_io::details::generic_simd_create_op_impl(a,b,[](T va,T vb)
+	return ::fast_io::details::generic_simd_create_op_impl(a,b,[](T va,T vb) noexcept -> T
 	{
 		return va&vb;
 	});
@@ -935,7 +978,7 @@ inline constexpr simd_vector<T,N> operator|(simd_vector<T,N> const& a,simd_vecto
 		}
 	}
 #endif
-	return ::fast_io::details::generic_simd_create_op_impl(a,b,[](T va,T vb)
+	return ::fast_io::details::generic_simd_create_op_impl(a,b,[](T va,T vb) noexcept -> T
 	{
 		return va|vb;
 	});
@@ -981,7 +1024,7 @@ inline constexpr simd_vector<T,N> operator^(simd_vector<T,N> const& a,simd_vecto
 		}
 	}
 #endif
-	return ::fast_io::details::generic_simd_create_op_impl(a,b,[](T va,T vb)
+	return ::fast_io::details::generic_simd_create_op_impl(a,b,[](T va,T vb) noexcept -> T
 	{
 		return va^vb;
 	});
@@ -990,7 +1033,7 @@ inline constexpr simd_vector<T,N> operator^(simd_vector<T,N> const& a,simd_vecto
 template<typename T,std::size_t N>
 inline constexpr simd_vector<T,N> operator<<(simd_vector<T,N> const& a,simd_vector<T,N> const& b) noexcept
 {
-	return ::fast_io::details::generic_simd_create_op_impl(a,b,[](T va,T vb)
+	return ::fast_io::details::generic_simd_create_op_impl(a,b,[](T va,T vb) noexcept -> T
 	{
 		return va<<vb;
 	});
@@ -999,7 +1042,7 @@ inline constexpr simd_vector<T,N> operator<<(simd_vector<T,N> const& a,simd_vect
 template<typename T,std::size_t N>
 inline constexpr simd_vector<T,N> operator>>(simd_vector<T,N> const& a,simd_vector<T,N> const& b) noexcept
 {
-	return ::fast_io::details::generic_simd_create_op_impl(a,b,[](T va,T vb)
+	return ::fast_io::details::generic_simd_create_op_impl(a,b,[](T va,T vb) noexcept -> T
 	{
 		return va>>vb;
 	});
@@ -1092,7 +1135,7 @@ inline constexpr simd_vector<T,N> operator<(simd_vector<T,N> const& a,simd_vecto
 						if constexpr(sizeof(T)==1)
 						{
 							constexpr auto mn{INT_LEAST8_MIN};
-							mask=_mm_set1_epi8(INT_LEAST8_MIN);
+							mask=_mm_set1_epi8(mn);
 						}
 						else if constexpr(sizeof(T)==2)
 						{
@@ -1195,7 +1238,7 @@ inline constexpr simd_vector<T,N> operator<(simd_vector<T,N> const& a,simd_vecto
 						if constexpr(sizeof(T)==1)
 						{
 							constexpr auto mn{INT_LEAST8_MIN};
-							mask=_mm256_set1_epi8(INT_LEAST8_MIN);
+							mask=_mm256_set1_epi8(mn);
 						}
 						else if constexpr(sizeof(T)==2)
 						{
@@ -1218,17 +1261,17 @@ inline constexpr simd_vector<T,N> operator<(simd_vector<T,N> const& a,simd_vecto
 					if constexpr(sizeof(T)==1)
 					{
 						alow = _mm_cmplt_epi8(alow,blow);
-						ahigh = _mm_cmplt_epi8(ahigh,blow);
+						ahigh = _mm_cmplt_epi8(ahigh,bhigh);
 					}
 					else if constexpr(sizeof(T)==2)
 					{
 						alow = _mm_cmplt_epi16(alow,blow);
-						ahigh = _mm_cmplt_epi16(ahigh,blow);
+						ahigh = _mm_cmplt_epi16(ahigh,bhigh);
 					}
 					else if constexpr(sizeof(T)==4)
 					{
 						alow = _mm_cmplt_epi32(alow,blow);
-						ahigh = _mm_cmplt_epi32(ahigh,blow);
+						ahigh = _mm_cmplt_epi32(ahigh,bhigh);
 					}
 					__m256i res = _mm256_castsi128_si256(alow);
 					res = _mm256_insertf128_si256(res,ahigh,1);
@@ -1314,7 +1357,7 @@ inline constexpr simd_vector<T,N> operator<(simd_vector<T,N> const& a,simd_vecto
 		}
 	}
 #endif
-	return ::fast_io::details::generic_simd_comparision_common_impl(a,b,[](T va,T vb) noexcept
+	return ::fast_io::details::generic_simd_comparision_common_impl(a,b,[](T va,T vb) noexcept -> bool
 	{
 		return va<vb;
 	});
@@ -1389,7 +1432,7 @@ inline constexpr simd_vector<T,N> operator>(simd_vector<T,N> const& a,simd_vecto
 						if constexpr(sizeof(T)==1)
 						{
 							constexpr auto mn{INT_LEAST8_MIN};
-							mask=_mm_set1_epi8(INT_LEAST8_MIN);
+							mask=_mm_set1_epi8(mn);
 						}
 						else if constexpr(sizeof(T)==2)
 						{
@@ -1492,7 +1535,7 @@ inline constexpr simd_vector<T,N> operator>(simd_vector<T,N> const& a,simd_vecto
 						if constexpr(sizeof(T)==1)
 						{
 							constexpr auto mn{INT_LEAST8_MIN};
-							mask=_mm256_set1_epi8(INT_LEAST8_MIN);
+							mask=_mm256_set1_epi8(mn);
 						}
 						else if constexpr(sizeof(T)==2)
 						{
@@ -1515,17 +1558,17 @@ inline constexpr simd_vector<T,N> operator>(simd_vector<T,N> const& a,simd_vecto
 					if constexpr(sizeof(T)==1)
 					{
 						alow = _mm_cmpgt_epi8(alow,blow);
-						ahigh = _mm_cmpgt_epi8(ahigh,blow);
+						ahigh = _mm_cmpgt_epi8(ahigh,bhigh);
 					}
 					else if constexpr(sizeof(T)==2)
 					{
 						alow = _mm_cmpgt_epi16(alow,blow);
-						ahigh = _mm_cmpgt_epi16(ahigh,blow);
+						ahigh = _mm_cmpgt_epi16(ahigh,bhigh);
 					}
 					else if constexpr(sizeof(T)==4)
 					{
 						alow = _mm_cmpgt_epi32(alow,blow);
-						ahigh = _mm_cmpgt_epi32(ahigh,blow);
+						ahigh = _mm_cmpgt_epi32(ahigh,bhigh);
 					}
 					__m256i res = _mm256_castsi128_si256(alow);
 					res = _mm256_insertf128_si256(res,ahigh,1);
@@ -1611,7 +1654,7 @@ inline constexpr simd_vector<T,N> operator>(simd_vector<T,N> const& a,simd_vecto
 		}
 	}
 #endif
-	return ::fast_io::details::generic_simd_comparision_common_impl(a,b,[](T va,T vb) noexcept
+	return ::fast_io::details::generic_simd_comparision_common_impl(a,b,[](T va,T vb) noexcept -> bool
 	{
 		return va>vb;
 	});
@@ -1825,7 +1868,7 @@ inline constexpr simd_vector<T,N> operator<=(simd_vector<T,N> const& a,simd_vect
 		}
 	}
 #endif
-	return ::fast_io::details::generic_simd_comparision_common_impl(a,b,[](T va,T vb) noexcept
+	return ::fast_io::details::generic_simd_comparision_common_impl(a,b,[](T va,T vb) noexcept -> bool
 	{
 		return va<=vb;
 	});
@@ -2043,7 +2086,7 @@ inline constexpr simd_vector<T,N> operator>=(simd_vector<T,N> const& a,simd_vect
 		}
 	}
 #endif
-	return ::fast_io::details::generic_simd_comparision_common_impl(a,b,[](T va,T vb) noexcept
+	return ::fast_io::details::generic_simd_comparision_common_impl(a,b,[](T va,T vb) noexcept -> bool
 	{
 		return va>=vb;
 	});
@@ -2125,7 +2168,7 @@ inline constexpr simd_vector<T,N> operator==(simd_vector<T,N> const& a,simd_vect
 		}
 	}
 #endif
-	return ::fast_io::details::generic_simd_comparision_common_impl(a,b,[](T va,T vb) noexcept
+	return ::fast_io::details::generic_simd_comparision_common_impl(a,b,[](T va,T vb) noexcept -> bool
 	{
 		return va==vb;
 	});
@@ -2218,7 +2261,7 @@ inline constexpr simd_vector<T,N> operator!=(simd_vector<T,N> const& a,simd_vect
 		}
 	}
 #endif
-		return ::fast_io::details::generic_simd_comparision_common_impl(a,b,[](T va,T vb) noexcept
+		return ::fast_io::details::generic_simd_comparision_common_impl(a,b,[](T va,T vb) noexcept -> bool
 		{
 			return va!=vb;
 		});

--- a/include/fast_io_core_impl/simd/is_all_zeros.h
+++ b/include/fast_io_core_impl/simd/is_all_zeros.h
@@ -72,15 +72,11 @@ bool is_all_zeros_impl(::fast_io::intrinsics::simd_vector<T,n> const& vec) noexc
 {
 #if __cpp_if_consteval >= 202106L || __cpp_lib_is_constant_evaluated >= 201811L
 #if __cpp_if_consteval >= 202106L
-	if consteval
+	if !consteval
 #elif __cpp_lib_is_constant_evaluated >= 201811L
-	if (std::is_constant_evaluated())
+	if (!std::is_constant_evaluated())
 #endif
 	{
-		return is_all_zeros_recursive_impl<0>(vec);
-	}
-#endif
-
 	if constexpr(sizeof(::fast_io::intrinsics::simd_vector<T,n>)==16)
 	{
 #if defined(__has_builtin) && __has_cpp_attribute(__gnu__::__vector_size__)
@@ -157,6 +153,8 @@ bool is_all_zeros_impl(::fast_io::intrinsics::simd_vector<T,n> const& vec) noexc
 		return _mm512_test_epi8_mask(a,a);
 #endif
 	}
+	}
+#endif
 	constexpr std::size_t N{sizeof(::fast_io::intrinsics::simd_vector<T,n>)/sizeof(std::uint_least64_t)};
 	return is_all_zeros_recursive_impl<0>(static_cast<::fast_io::intrinsics::simd_vector<std::uint_least64_t,N>>(vec));
 }

--- a/include/fast_io_core_impl/simd/is_all_zeros.h
+++ b/include/fast_io_core_impl/simd/is_all_zeros.h
@@ -45,9 +45,6 @@ can_simd_vector_run_with_cpu_instruction<64>?64:
 template<unsigned pos,typename T>
 inline constexpr bool is_all_zeros_recursive_impl(T const& v2) noexcept
 {
-	constexpr std::uint_least64_t mx{std::numeric_limits<std::uint_least64_t>::max()};
-	constexpr unsigned digits{std::numeric_limits<std::uint_least64_t>::digits};
-	constexpr unsigned digitspos{digits*pos};
 	constexpr std::size_t N{sizeof(T)/sizeof(std::uint_least64_t)};
 	static_assert(N!=0);
 	std::uint_least64_t element{v2[pos]};
@@ -83,7 +80,6 @@ bool is_all_zeros_impl(::fast_io::intrinsics::simd_vector<T,n> const& vec) noexc
 		return is_all_zeros_recursive_impl<0>(vec);
 	}
 #endif
-	constexpr std::size_t szofvec{sizeof(::fast_io::intrinsics::simd_vector<T,n>)};
 
 	if constexpr(sizeof(::fast_io::intrinsics::simd_vector<T,n>)==16)
 	{

--- a/include/fast_io_core_impl/simd/mask_countr.h
+++ b/include/fast_io_core_impl/simd/mask_countr.h
@@ -122,7 +122,6 @@ unsigned vector_mask_countr_common_intrinsics_impl(::fast_io::intrinsics::simd_v
 		return vector_mask_countr_common_no_intrinsics_impl<ctzero>(vec);
 	}
 #endif
-	constexpr std::size_t szofvec{sizeof(::fast_io::intrinsics::simd_vector<T,n>)};
 	unsigned d{};
 	if constexpr(sizeof(::fast_io::intrinsics::simd_vector<T,n>)==16)
 	{

--- a/include/fast_io_core_impl/simd_find.h
+++ b/include/fast_io_core_impl/simd_find.h
@@ -155,7 +155,8 @@ ASCII: space (0x20, ' '), EBCDIC:64
 			simd_vector_type horizontaltabs{
 				std::bit_cast<simd_vector_type>(characters_array_impl<horizontaltab,char_type,N>)};
 #else
-		simd_vector_type verticaltabs,ebcdic_specific_nls,linefeeds,horizontaltabs;
+		simd_vector_type ebcdic_specific_nls,linefeeds,horizontaltabs;
+
 		ebcdic_specific_nls.load(characters_array_impl<ebcdic_specific_nl,char_type,N>.data());
 		linefeeds.load(characters_array_impl<linefeed,char_type,N>.data());
 		horizontaltabs.load(characters_array_impl<horizontaltab,char_type,N>.data());
@@ -217,9 +218,9 @@ ASCII: space (0x20, ' '), EBCDIC:64
 			decision_simd_vector_type horizontaltabs{
 				std::bit_cast<decision_simd_vector_type>(characters_array_impl<horizontaltab,char_type,N,use_signed_vector_type>)};
 #else
-
 		decision_simd_vector_type fives;
 		fives.load(characters_array_impl<five,char_type,N,use_signed_vector_type>.data());
+
 		decision_simd_vector_type horizontaltabs;
 		horizontaltabs.load(characters_array_impl<horizontaltab,char_type,N,use_signed_vector_type>.data());
 #endif
@@ -228,9 +229,10 @@ ASCII: space (0x20, ' '), EBCDIC:64
 		{
 #if (__cpp_lib_bit_cast >= 201806L) && !defined(__clang__)
 			constexpr
-				decision_simd_vector_type verticaltabs{
-					std::bit_cast<decision_simd_vector_type>(characters_array_impl<verticaltab,char_type,N,use_signed_vector_type>)};
+				simd_vector_type verticaltabs{
+					std::bit_cast<simd_vector_type>(characters_array_impl<verticaltab,char_type,N>)};
 #else
+
 			simd_vector_type verticaltabs;
 			verticaltabs.load(characters_array_impl<verticaltab,char_type,N>.data());
 #endif
@@ -267,12 +269,9 @@ inline constexpr char unsigned const* find_characters_musl(char unsigned const* 
 	constexpr char unsigned ucharmx{std::numeric_limits<char unsigned>::max()};
 	constexpr std::size_t ones{std::numeric_limits<std::size_t>::max()/ucharmx};
 	constexpr std::size_t highs{ones*(ucharmx/2+1)};
-	constexpr std::size_t highsmask{ones*(ucharmx/2)};
-	constexpr unsigned udiff{static_cast<unsigned>(diff)};
-
 	if(first!=last&&*first!=ch)
 	{
-	for(std::size_t const constantk{ones*ch};last-first>diff;first+=diff)
+	for(std::size_t const constantk{ones*ch};diff<=static_cast<std::size_t>(last-first);first+=diff)
 	{
 
 		std::size_t x;

--- a/include/fast_io_core_impl/simd_find.h
+++ b/include/fast_io_core_impl/simd_find.h
@@ -41,7 +41,6 @@ inline constexpr char_type const* find_simd_common_condition_impl(char_type cons
 	constexpr unsigned N{vec_size/sizeof(char_type)};
 	using simd_vector_type = ::fast_io::intrinsics::simd_vector<char_type,N>;
 	simd_vector_type simdvec;
-	std::size_t diff{static_cast<std::size_t>(last-first)};
 	for(;N<=static_cast<std::size_t>(last-first);first+=N)
 	{
 		simdvec.load(first);
@@ -64,7 +63,6 @@ inline constexpr char_type const* find_simd_common_all_impl(char_type const* fir
 		constexpr simd_vector_type mask_vecs{create_simd_vector_with_all_masks<simd_vector_type>()};
 		return find_simd_common_condition_impl<vec_size>(first,last,[&](simd_vector_type const& simdvec) noexcept -> bool
 		{
-			simd_vector_type chunk=func(simdvec);
 			return !is_all_zeros(func(simdvec)!=mask_vecs);
 		});
 	}
@@ -151,18 +149,14 @@ ASCII: space (0x20, ' '), EBCDIC:64
 			simd_vector_type ebcdic_specific_nls{
 				std::bit_cast<simd_vector_type>(characters_array_impl<ebcdic_specific_nl,char_type,N>)};
 		constexpr
-			simd_vector_type spaces{
-				std::bit_cast<simd_vector_type>(characters_array_impl<spacech,char_type,N>)};
-		constexpr
 			simd_vector_type linefeeds{
 				std::bit_cast<simd_vector_type>(characters_array_impl<linefeed,char_type,N>)};
 		constexpr
 			simd_vector_type horizontaltabs{
 				std::bit_cast<simd_vector_type>(characters_array_impl<horizontaltab,char_type,N>)};
 #else
-		simd_vector_type verticaltabs,ebcdic_specific_nls,spaces,linefeeds,horizontaltabs;
+		simd_vector_type verticaltabs,ebcdic_specific_nls,linefeeds,horizontaltabs;
 		ebcdic_specific_nls.load(characters_array_impl<ebcdic_specific_nl,char_type,N>.data());
-		spaces.load(characters_array_impl<spacech,char_type,N>.data());
 		linefeeds.load(characters_array_impl<linefeed,char_type,N>.data());
 		horizontaltabs.load(characters_array_impl<horizontaltab,char_type,N>.data());
 #endif

--- a/include/fast_io_unit/string_impl/ostring_ref.h
+++ b/include/fast_io_unit/string_impl/ostring_ref.h
@@ -42,7 +42,7 @@ template<std::integral char_type,typename size_type>
 struct empty_string_set_ptr
 {
 	std::size_t realsize{};
-	inline constexpr std::size_t operator()(char_type const*,size_type n) noexcept
+	inline constexpr std::size_t operator()(char_type const*,size_type) noexcept
 	{
 		return realsize;
 	}


### PR DESCRIPTION
[Fix all compiler warnings for gcc, clang and msvc](https://github.com/cppfastio/fast_io/commit/ded6ce2a1419c5f14a0e1ba2bf71ea5dc8855b95)