### PR TITLE
remove

### DIFF
--- a/include/fast_io_core_impl/freestanding/relocatable.h
+++ b/include/fast_io_core_impl/freestanding/relocatable.h
@@ -6,11 +6,7 @@ namespace fast_io::freestanding
 template<typename T>
 struct is_trivially_relocatable
 {
-	inline static constexpr bool value =
-#if defined(__clang__) && defined(__has_extension) && __has_cpp_attribute(clang::trivial_abi)
-	__is_trivially_relocatable(T) ||
-#endif
-	::std::is_trivially_copyable_v<T>;
+	inline static constexpr bool value = ::std::is_trivially_copyable_v<T>;
 };
 
 template<typename T>


### PR DESCRIPTION
#if defined(__clang__) && defined(__has_extension) && __has_cpp_attribute(clang::trivial_abi)
	__is_trivially_relocatable(T) ||
#endif
	::std::is_trivially_copyable_v<T>;

Since tons of stupid people are using old legacy clang right now. Removed