### PR TITLE
arm neon should only enable for gcc and clang. MSVC support for arm h…

### DIFF
--- a/include/fast_io_core_impl/simd/cpu_flags.h
+++ b/include/fast_io_core_impl/simd/cpu_flags.h
@@ -79,7 +79,7 @@ true
 
 inline constexpr bool armneon_supported
 {
-#if defined(__ARM_NEON)
+#if defined(__ARM_NEON) && __has_cpp_attribute(__gnu__::__vector_size__)
 true
 #endif
 };


### PR DESCRIPTION
…as not yet done