### PR TITLE
only allow void* to used for print_alias. Not allowing function point…

### DIFF
--- a/include/fast_io_core_impl/integers/impl.h
+++ b/include/fast_io_core_impl/integers/impl.h
@@ -1423,7 +1423,7 @@ inline constexpr char_type* print_reserve_nullptr_alphabet_impl(char_type* iter)
 }
 
 template<typename scalar_type>
-requires (details::my_integral<scalar_type>||(std::is_pointer_v<std::remove_cvref_t<scalar_type>>&&!std::is_function_v<std::remove_pointer_t<scalar_type>>)||::std::contiguous_iterator<scalar_type>||::fast_io::details::my_floating_point<scalar_type>||std::same_as<std::nullptr_t,std::remove_cvref_t<scalar_type>>)
+requires (details::my_integral<scalar_type>||(::std::same_as<::std::remove_pointer_t<scalar_type>,void>)||::std::contiguous_iterator<scalar_type>||::fast_io::details::my_floating_point<scalar_type>||std::same_as<std::nullptr_t,std::remove_cvref_t<scalar_type>>)
 #if __has_cpp_attribute(__gnu__::__always_inline__)
 [[__gnu__::__always_inline__]]
 #elif __has_cpp_attribute(msvc::forceinline)


### PR DESCRIPTION
…ers, users must use addrvw manipulator for function pointer