### PR TITLE
Add an example for filebuf_file_ostream

### DIFF
--- a/examples/0007.legacy/filebuf_file_ostream.cc
+++ b/examples/0007.legacy/filebuf_file_ostream.cc
@@ -1,0 +1,12 @@
+﻿#include<fast_io_legacy.h>
+
+int main()
+{
+	fast_io::filebuf_file fbf(u8"filebuf_file_ostream.txt",fast_io::open_mode::out);
+/*
+filebuf_file will construct a std::filebuf directly through syscalls.
+*/
+	std::ostream fout(fbf.fb); //make std::ostream's streambuf binds to our filebuf_file
+	print(fbf,"Hello World from fast_io::filebuf_file\n");
+	fout<<"Hello World from std::ostream\n";
+}


### PR DESCRIPTION
This example is a simple solution when code only needs ostream instead of ofstream. No need move etc