### PR TITLE
No longer allow printing pointers directly. Users should always use p…

### DIFF
--- a/examples/0007.legacy/construct_fp_from_syscall.cc
+++ b/examples/0007.legacy/construct_fp_from_syscall.cc
@@ -50,16 +50,16 @@ This potentially contains format string vuln.
 #else
 	"Unknown C++ standard library\n"
 #endif
-	"FILE*:",static_cast<fast_io::c_io_observer>(cf).fp,"\n"
+	"FILE*:",::fast_io::mnp::handlevw(static_cast<fast_io::c_io_observer>(cf).fp),"\n"
 	"fd:",static_cast<fast_io::posix_io_observer>(cf).fd
 #if (defined(_WIN32)&&!defined(__WINE__)) || defined(__CYGWIN__)
 	,"\n"
-	"win32 HANDLE:",static_cast<fast_io::win32_io_observer>(cf).handle
+	"win32 HANDLE:",::fast_io::mnp::handlevw(static_cast<fast_io::win32_io_observer>(cf).handle)
 #ifndef _WIN32_WINDOWS
 //NT kernel
 	,"\n"
-	"zw HANDLE:",static_cast<fast_io::zw_io_observer>(cf).handle,"\n"
-	"nt HANDLE:",static_cast<fast_io::nt_io_observer>(cf).handle
+	"zw HANDLE:",::fast_io::mnp::handlevw(static_cast<fast_io::zw_io_observer>(cf).handle),"\n"
+	"nt HANDLE:",::fast_io::mnp::handlevw(static_cast<fast_io::nt_io_observer>(cf).handle)
 #endif
 #endif
 );

--- a/examples/0007.legacy/construct_fstream_from_syscall.cc
+++ b/examples/0007.legacy/construct_fstream_from_syscall.cc
@@ -62,17 +62,17 @@ This is an example to explain how fast_io's files work with each other, and how 
 #else
 	"Unknown C++ standard library\n"
 #endif
-	"fstream.rdbuf():",fiob.fb,"\n"
-	"FILE*:",static_cast<fast_io::c_io_observer>(fiob).fp,"\n"
+	"fstream.rdbuf():",::fast_io::mnp::handlevw(fiob.fb),"\n"
+	"FILE*:",::fast_io::mnp::handlevw(static_cast<fast_io::c_io_observer>(fiob).fp),"\n"
 	"fd:",static_cast<fast_io::posix_io_observer>(fiob).fd
 #if (defined(_WIN32) && !defined(__WINE__)) || defined(__CYGWIN__)
 	,"\n"
-	"win32 HANDLE:",static_cast<fast_io::win32_io_observer>(fiob).handle
+	"win32 HANDLE:",::fast_io::mnp::handlevw(static_cast<fast_io::win32_io_observer>(fiob).handle)
 #ifndef _WIN32_WINDOWS
 //NT kernel
 	,"\n"
-	"zw HANDLE:",static_cast<fast_io::zw_io_observer>(fiob).handle,"\n"
-	"nt HANDLE:",static_cast<fast_io::nt_io_observer>(fiob).handle
+	"zw HANDLE:",::fast_io::mnp::handlevw(static_cast<fast_io::zw_io_observer>(fiob).handle),"\n"
+	"nt HANDLE:",::fast_io::mnp::handlevw(static_cast<fast_io::nt_io_observer>(fiob).handle)
 #endif
 #endif
 );

--- a/examples/0007.legacy/construct_fstream_from_syscall_l10n.cc
+++ b/examples/0007.legacy/construct_fstream_from_syscall_l10n.cc
@@ -69,17 +69,17 @@ This is an example to explain how fast_io's files work with each other, and how 
 #else
 	"Unknown C++ standard library\n"
 #endif
-	"fstream.rdbuf():",fiob.fb,"\n"
-	"FILE*:",static_cast<fast_io::c_io_observer>(fiob).fp,"\n"
+	"fstream.rdbuf():",::fast_io::mnp::handlevw(fiob.fb),"\n"
+	"FILE*:",::fast_io::mnp::handlevw(static_cast<fast_io::c_io_observer>(fiob).fp),"\n"
 	"fd:",static_cast<fast_io::posix_io_observer>(fiob).fd
 #if (defined(_WIN32) && !defined(__WINE__)) || defined(__CYGWIN__)
 	,"\n"
-	"win32 HANDLE:",static_cast<fast_io::win32_io_observer>(fiob).handle
+	"win32 HANDLE:",::fast_io::mnp::handlevw(static_cast<fast_io::win32_io_observer>(fiob).handle)
 #ifndef _WIN32_WINDOWS
 //NT kernel
 	,"\n"
-	"zw HANDLE:",static_cast<fast_io::zw_io_observer>(fiob).handle,"\n"
-	"nt HANDLE:",static_cast<fast_io::nt_io_observer>(fiob).handle
+	"zw HANDLE:",::fast_io::mnp::handlevw(static_cast<fast_io::zw_io_observer>(fiob).handle),"\n"
+	"nt HANDLE:",::fast_io::mnp::handlevw(static_cast<fast_io::nt_io_observer>(fiob).handle)
 #endif
 #endif
 );

--- a/include/fast_io_core_impl/alias.h
+++ b/include/fast_io_core_impl/alias.h
@@ -3,10 +3,25 @@
 namespace fast_io
 {
 
+namespace details
+{
+
+struct cannot_output_type
+{
+inline explicit constexpr cannot_output_type() noexcept = default;
+};
+
+}
+
 template<typename T>
 inline constexpr decltype(auto) io_print_alias(T&& t) noexcept
 {
-	if constexpr(alias_printable<std::remove_cvref_t<T>>)
+	using no_cvref_t=std::remove_cvref_t<T>;
+	if constexpr(::std::is_function_v<no_cvref_t>)
+	{
+		return ::fast_io::details::cannot_output_type{};
+	}
+	else if constexpr(alias_printable<no_cvref_t>)
 		return print_alias_define(io_alias,::std::forward<T>(t));
 	else
 		return ::std::forward<T>(t);
@@ -16,7 +31,11 @@ template<std::integral char_type,typename T>
 inline constexpr auto io_print_forward(T&& t) noexcept
 {
 	using no_cvref_t=std::remove_cvref_t<T>;
-	if constexpr(status_io_print_forwardable<char_type,T>)
+	if constexpr(::std::is_function_v<no_cvref_t>)
+	{
+		return ::fast_io::details::cannot_output_type{};
+	}
+	else if constexpr(status_io_print_forwardable<char_type,T>)
 		return status_io_print_forward(io_alias_type<char_type>,::std::forward<T>(t));
 	else if constexpr(std::is_trivially_copyable_v<no_cvref_t>&&sizeof(no_cvref_t)<=sizeof(std::size_t)*2)
 		return static_cast<no_cvref_t>(t);
@@ -37,7 +56,11 @@ template<typename T>
 inline constexpr auto io_scan_alias(T&& t) noexcept
 {
 	using no_ref_t = std::remove_reference_t<T>;
-	if constexpr(alias_scannable<no_ref_t>)
+	if constexpr(::std::is_function_v<no_ref_t>)
+	{
+		return ::fast_io::details::cannot_output_type{};
+	}
+	else if constexpr(alias_scannable<no_ref_t>)
 		return scan_alias_define(io_alias,::std::forward<T>(t));
 	else if constexpr(manipulator<no_ref_t>)
 		return t;

--- a/include/fast_io_core_impl/integers/impl.h
+++ b/include/fast_io_core_impl/integers/impl.h
@@ -6,6 +6,21 @@
 namespace fast_io
 {
 
+namespace details
+{
+struct method_ptr_dummyclass
+{
+	void amethod() noexcept
+	{}
+};
+
+inline constexpr ::std::size_t method_ptr_size{sizeof(&method_ptr_dummyclass::amethod)};
+
+inline constexpr ::std::size_t method_ptr_hold_size{::fast_io::details::method_ptr_size%sizeof(::std::size_t)==0?
+	::fast_io::details::method_ptr_size/sizeof(::std::size_t):
+	::fast_io::details::method_ptr_size/sizeof(::std::size_t)+1};
+}
+
 namespace manipulators
 {
 
@@ -74,6 +89,13 @@ struct scalar_manip_t
 #endif
 #endif
 	T reference;
+};
+
+struct member_function_pointer_holder_t
+{
+	using manip_tag = manip_tag_t;
+	::fast_io::freestanding::array<::std::size_t,
+	::fast_io::details::method_ptr_hold_size> reference;
 };
 
 }
@@ -244,6 +266,10 @@ inline constexpr auto scalar_flags_int_cache(scalar_type t) noexcept
 		{
 			return ::fast_io::manipulators::scalar_manip_t<cache,uintptr_full_alias_type>{static_cast<uintptr_full_alias_type>(::std::bit_cast<std::uintptr_t>(t))};
 		}
+		else if constexpr(::std::same_as<::fast_io::manipulators::member_function_pointer_holder_t,scalar_type_nocvref>)
+		{
+			return ::fast_io::manipulators::scalar_manip_t<cache,::fast_io::manipulators::member_function_pointer_holder_t>{t};
+		}
 		else
 		{
 			return ::fast_io::manipulators::scalar_manip_t<cache,uintptr_full_alias_type>{static_cast<uintptr_full_alias_type>(::std::bit_cast<std::uintptr_t>(::std::to_address(t)))};
@@ -271,6 +297,10 @@ inline constexpr auto scalar_flags_int_cache(scalar_type t) noexcept
 			using alias_type = integer_alias_type<scalar_type_nocvref>;
 			return ::fast_io::manipulators::scalar_manip_t<cache,alias_type>{static_cast<alias_type>(t)};
 		}
+		else if constexpr(::std::same_as<::fast_io::manipulators::member_function_pointer_holder_t,scalar_type_nocvref>)
+		{
+			return ::fast_io::manipulators::scalar_manip_t<cache,::fast_io::manipulators::member_function_pointer_holder_t>{t};
+		}
 		else if constexpr(std::is_pointer_v<scalar_type_nocvref>)
 		{
 			return ::fast_io::manipulators::scalar_manip_t<cache,uintptr_alias_type>{static_cast<uintptr_alias_type>(::std::bit_cast<std::uintptr_t>(t))};
@@ -285,9 +315,7 @@ inline constexpr auto scalar_flags_int_cache(scalar_type t) noexcept
 template<typename scalar_type>
 concept scalar_integrals = 
 ::fast_io::details::my_integral<scalar_type>||
-std::is_pointer_v<std::remove_cvref_t<scalar_type>>||
 std::same_as<std::nullptr_t,std::remove_cvref_t<scalar_type>>||
-::std::contiguous_iterator<scalar_type>||
 std::same_as<std::byte,std::remove_cvref_t<scalar_type>>||
 std::same_as<bool,std::remove_cvref_t<scalar_type>>;
 
@@ -428,18 +456,56 @@ inline constexpr auto uhexfull(scalar_type t) noexcept
 	return ::fast_io::details::scalar_flags_int_cache<::fast_io::details::base_mani_flags_cache<16,false,shbase,true>>(t);
 }
 
-template<typename scalar_type>
+template<bool uppercase=false,typename scalar_type>
 requires (::fast_io::details::scalar_integrals<scalar_type>)
 inline constexpr auto addrvw(scalar_type t) noexcept
-{	
+{
 	if constexpr(::fast_io::details::my_signed_integral<scalar_type>)
 	{
-		return ::fast_io::details::scalar_flags_int_cache<::fast_io::details::base_mani_flags_cache<16,false,true,true,false>>(static_cast<::fast_io::details::my_make_unsigned_t<std::remove_cvref_t<scalar_type>>>(t));
+		return ::fast_io::details::scalar_flags_int_cache<::fast_io::details::base_mani_flags_cache<16,uppercase,true,true,false>>(static_cast<::fast_io::details::my_make_unsigned_t<std::remove_cvref_t<scalar_type>>>(t));
 	}
 	else
 	{
-		return ::fast_io::details::scalar_flags_int_cache<::fast_io::details::base_mani_flags_cache<16,false,true,true,false>>(t);
+		return ::fast_io::details::scalar_flags_int_cache<::fast_io::details::base_mani_flags_cache<16,uppercase,true,true,false>>(t);
 	}
+}
+
+template<bool uppercase=false,typename scalar_type>
+requires ((::std::is_pointer_v<scalar_type>||::std::contiguous_iterator<scalar_type>)&&
+		(!::std::is_function_v<std::remove_cvref_t<scalar_type>>))
+inline constexpr auto pointervw(scalar_type t) noexcept
+{
+	return ::fast_io::details::scalar_flags_int_cache<::fast_io::details::base_mani_flags_cache<16,uppercase,true,true,false>>(t);
+}
+
+template<bool uppercase=false,typename scalar_type>
+requires (::std::is_function_v<scalar_type>)
+inline constexpr auto funcvw(scalar_type *t) noexcept
+{
+	return ::fast_io::details::scalar_flags_int_cache<::fast_io::details::base_mani_flags_cache<16,uppercase,true,true,false>>(::std::bit_cast<std::uintptr_t>(t));
+}
+
+template<bool uppercase=false,typename scalar_type>
+requires (::std::is_member_function_pointer_v<scalar_type>&&
+(sizeof(scalar_type)%sizeof(::std::size_t)==0))
+inline constexpr auto methodvw(scalar_type t) noexcept
+{
+	if constexpr(sizeof(scalar_type)==sizeof(::std::size_t))
+	{
+		return ::fast_io::details::scalar_flags_int_cache<::fast_io::details::base_mani_flags_cache<16,uppercase,true,true,false>>(::std::bit_cast<::std::size_t>(t));
+	}
+	else
+	{
+		return ::fast_io::details::scalar_flags_int_cache<::fast_io::details::base_mani_flags_cache<16,uppercase,true,true,false>>(::std::bit_cast<::fast_io::manipulators::member_function_pointer_holder_t>(t));
+	}
+}
+
+template<bool uppercase=false,typename scalar_type>
+requires ((::std::is_pointer_v<scalar_type>&&!::std::is_function_v<std::remove_cvref_t<scalar_type>>)||
+	::std::integral<scalar_type>)
+inline constexpr auto handlevw(scalar_type t) noexcept
+{
+	return ::fast_io::details::scalar_flags_int_cache<::fast_io::details::base_mani_flags_cache<16,uppercase,true,true,false>>(t);
 }
 
 template<typename scalar_type>
@@ -1420,10 +1486,48 @@ inline constexpr char_type* print_reserve_nullptr_alphabet_impl(char_type* iter)
 	}
 }
 
+
+template<std::size_t base,
+	bool showbase=false,
+	bool uppercase_showbase=false,
+	bool showpos=false,
+	bool uppercase=false,
+	bool full=false,
+	::std::integral char_type>
+inline constexpr char_type* print_reserve_method_impl(char_type* iter,::fast_io::manipulators::member_function_pointer_holder_t mfph)
+{
+	if constexpr(base<=10&&uppercase)
+	{
+		return print_reserve_method_impl<base,showbase,uppercase_showbase,showpos,false,full>(iter,mfph);//prevent duplications
+	}
+	else if constexpr(::fast_io::details::method_ptr_hold_size==0)
+		return iter;
+	else
+	{
+		iter=details::print_reserve_integral_define<base,showbase,uppercase_showbase,showpos,uppercase,full>(iter,mfph.reference.front());
+		using myssizet = ::std::make_signed_t<::std::size_t>;
+		if constexpr(true)
+		{
+			::std::size_t backptr{mfph.reference.back()};
+			return details::print_reserve_integral_define<base,showbase,uppercase_showbase,true,uppercase,false>(iter,static_cast<myssizet>(backptr));
+		}
+		else
+		{
+
+			::std::size_t last{::fast_io::details::method_ptr_hold_size};
+			for(::std::size_t i{1};i!=last;++i)
+			{
+				iter=details::print_reserve_integral_define<base,showbase,uppercase_showbase,true,uppercase,false>(iter,static_cast<myssizet>(mfph.reference[i]));
+			}
+			return iter;
+		}
+	}
+}
+
 }
 
 template<typename scalar_type>
-requires (details::my_integral<scalar_type>||(std::is_pointer_v<std::remove_cvref_t<scalar_type>>)||::std::contiguous_iterator<scalar_type>||::fast_io::details::my_floating_point<scalar_type>||std::same_as<std::nullptr_t,std::remove_cvref_t<scalar_type>>)
+requires (details::my_integral<scalar_type>||::fast_io::details::my_floating_point<scalar_type>||std::same_as<std::nullptr_t,std::remove_cvref_t<scalar_type>>)
 #if __has_cpp_attribute(__gnu__::__always_inline__)
 [[__gnu__::__always_inline__]]
 #elif __has_cpp_attribute(msvc::forceinline)
@@ -1441,23 +1545,9 @@ inline constexpr auto print_alias_define(io_alias_t,scalar_type t) noexcept
 		using float_alias_type = ::fast_io::details::float_alias_type<scalar_type>;
 		return manipulators::scalar_manip_t<manipulators::floating_point_default_scalar_flags,float_alias_type>{static_cast<float_alias_type>(t)};
 	}
-	else if constexpr(std::same_as<std::nullptr_t,std::remove_cvref_t<scalar_type>>)
-	{
-		return manipulators::scalar_manip_t<manipulators::scalar_flags{.alphabet=true},std::nullptr_t>{};
-	}
-	else if constexpr(std::is_pointer_v<std::remove_cvref_t<scalar_type>>)
-	{
-		using int_alias_type = ::fast_io::details::integer_alias_type<std::uintptr_t>;
-		return manipulators::scalar_manip_t<manipulators::address_default_scalar_flags,int_alias_type>{
-			static_cast<int_alias_type>(::std::bit_cast<std::uintptr_t>(t))
-		};
-	}
 	else
 	{
-		using int_alias_type = ::fast_io::details::integer_alias_type<std::uintptr_t>;
-		return manipulators::scalar_manip_t<manipulators::address_default_scalar_flags,int_alias_type>{
-			static_cast<int_alias_type>(::std::bit_cast<int_alias_type>(::std::to_address(t)))
-		};
+		return manipulators::scalar_manip_t<manipulators::scalar_flags{.alphabet=true},std::nullptr_t>{};
 	}
 }
 
@@ -1484,8 +1574,9 @@ inline constexpr char_type* print_reserve_define(io_reserve_type_t<char_type,T>,
 		return details::print_reserve_integral_define<10,false,false,false,false,false>(iter,t);
 }
 
-template<std::integral char_type,manipulators::scalar_flags flags,typename T>
-requires (details::my_integral<T>||std::same_as<std::remove_cv_t<T>,std::byte>||std::same_as<std::remove_cvref_t<T>,std::nullptr_t>)
+template<std::integral char_type,::fast_io::manipulators::scalar_flags flags,typename T>
+requires (details::my_integral<T>||std::same_as<::std::remove_cv_t<T>,std::byte>||std::same_as<std::remove_cvref_t<T>,std::nullptr_t>||
+::std::same_as<::std::remove_cv_t<T>,::fast_io::manipulators::member_function_pointer_holder_t>)
 inline constexpr std::size_t print_reserve_size(io_reserve_type_t<char_type,manipulators::scalar_manip_t<flags,T>>) noexcept
 {
 	if constexpr(flags.alphabet)
@@ -1496,16 +1587,23 @@ inline constexpr std::size_t print_reserve_size(io_reserve_type_t<char_type,mani
 		else
 			return 7; // u8"nullptr"
 	}
-	else if constexpr(std::same_as<std::remove_cvref_t<T>,std::nullptr_t>)
+	else if constexpr(::std::same_as<::std::remove_cv_t<T>,::fast_io::manipulators::member_function_pointer_holder_t>)
+	{
+		constexpr
+			::std::size_t method_size{(details::print_integer_reserved_size_cache<flags.base,flags.showbase,flags.showpos,::std::size_t>+1)*::fast_io::details::method_ptr_hold_size-1};
+		return method_size;
+	}
+	else if constexpr(::std::same_as<std::remove_cvref_t<T>,std::nullptr_t>)
 		return details::nullptr_print_optimization_call_size_cache<char_type,flags.base,flags.showbase,flags.uppercase_showbase,flags.showpos,flags.uppercase,flags.full>;
-	else if constexpr(std::same_as<std::remove_cv_t<T>,std::byte>)
+	else if constexpr(::std::same_as<std::remove_cv_t<T>,::std::byte>)
 		return details::print_integer_reserved_size_cache<flags.base,flags.showbase,flags.showpos,char8_t>;
 	else
 		return details::print_integer_reserved_size_cache<flags.base,flags.showbase,flags.showpos,T>;
 }
 
 template<::std::integral char_type,manipulators::scalar_flags flags,typename T>
-requires (details::my_integral<T>||std::same_as<std::remove_cv_t<T>,std::byte>||std::same_as<std::remove_cvref_t<T>,std::nullptr_t>)
+requires (details::my_integral<T>||std::same_as<std::remove_cv_t<T>,std::byte>||std::same_as<std::remove_cvref_t<T>,std::nullptr_t>||
+::std::same_as<::std::remove_cv_t<T>,::fast_io::manipulators::member_function_pointer_holder_t>)
 #if __has_cpp_attribute(__gnu__::__always_inline__)
 [[__gnu__::__always_inline__]]//always inline to reduce inline depth in GCC and LLVM clang
 #endif
@@ -1518,6 +1616,10 @@ constexpr char_type* print_reserve_define(io_reserve_type_t<char_type,::fast_io:
 			return details::print_reserve_boolalpha_impl<flags.uppercase>(iter,t.reference);
 		else
 			return details::print_reserve_nullptr_alphabet_impl<flags.uppercase>(iter);
+	}
+	else if constexpr(::std::same_as<::std::remove_cv_t<T>,::fast_io::manipulators::member_function_pointer_holder_t>)
+	{
+		return ::fast_io::details::print_reserve_method_impl<flags.base,flags.showbase,flags.uppercase_showbase,flags.showpos,flags.uppercase,flags.full>(iter,t.reference);
 	}
 	else if constexpr(std::same_as<std::remove_cv_t<T>,std::nullptr_t>)
 	{

--- a/include/fast_io_core_impl/integers/pointer.h
+++ b/include/fast_io_core_impl/integers/pointer.h
@@ -137,22 +137,44 @@ inline constexpr basic_io_scatter_t<char_type> print_scatter_define(io_reserve_t
 	return iosc;
 }
 
-template<std::integral char_type,std::size_t n>
-inline constexpr auto print_alias_define(io_alias_t,char_type (&s)[n]) noexcept
+namespace details
 {
-	constexpr bool not_char_literal{::std::is_const_v<char_type>};
-	if constexpr(not_char_literal)
+
+template<::std::integral char_type,::std::size_t n>
+inline consteval ::std::integral_constant<char_type,n> compute_char_literal_array_type(char_type (&s)[n]) noexcept
+{
+	return {};
+}
+
+}
+
+template<typename T>
+requires (::std::is_array_v<::std::remove_reference_t<T>>&&
+	::std::integral<::std::remove_extent_t<::std::remove_cvref_t<T>>>&&
+	requires(T const& s)
 	{
-		constexpr std::size_t nm1{n-1};
-		if constexpr(n==2)
-			return manipulators::chvw_t<std::remove_const_t<char_type>>{*s};
-		else
-			return basic_io_scatter_t<std::remove_const_t<char_type>>{s,nm1};
+		::fast_io::details::compute_char_literal_array_type(s);
+	})
+inline constexpr auto print_alias_define(io_alias_t,T const& s) noexcept
+{
+	using constanttype = decltype(::fast_io::details::compute_char_literal_array_type(s));
+	using char_type = typename constanttype::value_type;
+	using no_const_char_type = ::std::remove_const_t<char_type>;
+
+	constexpr bool not_char_literal{::std::is_const_v<char_type>};
+	constexpr
+		::std::size_t n{constanttype::value};
+	constexpr std::size_t nm1{n-1};
+static_assert(n!=0);
+static_assert(not_char_literal,"The type is an array but not char array literal. Reject.");
+
+	if constexpr(n==2)
+	{
+		return manipulators::chvw_t<no_const_char_type>{*s};
 	}
 	else
 	{
-static_assert(not_char_literal,"The type is an array but not char array literal. Reject.");
-		return;
+		return basic_io_scatter_t<no_const_char_type>{s,nm1};
 	}
 }
 


### PR DESCRIPTION
…ointervw to print out pointers or iterators

To print out handle types handlevw manipulator is also available.

For function pointer, user must use funcvw manipulator. For member function poiner, user must use methodvw manipulator.