### PR TITLE
remove os_env in examples

### DIFF
--- a/examples/0005.sha/crc32.cc
+++ b/examples/0005.sha/crc32.cc
@@ -11,6 +11,10 @@ int main(int argc,char** argv)
 	using namespace fast_io::mnp;
 	if(argc!=2)
 	{
+		if(argc==0)
+		{
+			return 1;
+		}
 		perr("Usage: ",os_c_str(*argv)," <file>\n");
 		return 1;
 	}

--- a/examples/0005.sha/cryptopp_md5.cc
+++ b/examples/0005.sha/cryptopp_md5.cc
@@ -14,6 +14,10 @@ int main(int argc,char** argv)
 	using namespace fast_io::mnp;
 	if(argc!=2)
 	{
+		if(argc==0)
+		{
+			return 1;
+		}
 		perr("Usage: ",os_c_str(*argv)," <file>\n");
 		return 1;
 	}

--- a/examples/0005.sha/cryptopp_sha256.cc
+++ b/examples/0005.sha/cryptopp_sha256.cc
@@ -12,6 +12,10 @@ int main(int argc,char** argv)
 	using namespace fast_io::mnp;
 	if(argc!=2)
 	{
+		if(argc==0)
+		{
+			return 1;
+		}
 		perr("Usage: ",os_c_str(*argv)," <file>\n");
 		return 1;
 	}

--- a/examples/0005.sha/cryptopp_sha512.cc
+++ b/examples/0005.sha/cryptopp_sha512.cc
@@ -12,6 +12,10 @@ int main(int argc,char** argv)
 	using namespace fast_io::mnp;
 	if(argc!=2)
 	{
+		if(argc==0)
+		{
+			return 1;
+		}
 		perr("Usage: ",os_c_str(*argv)," <file>\n");
 		return 1;
 	}

--- a/examples/0005.sha/md5.cc
+++ b/examples/0005.sha/md5.cc
@@ -11,6 +11,10 @@ int main(int argc,char** argv)
 	using namespace fast_io::mnp;
 	if(argc!=2)
 	{
+		if(argc==0)
+		{
+			return 1;
+		}
 		perr("Usage: ",os_c_str(*argv)," <file>\n");
 		return 1;
 	}

--- a/examples/0005.sha/ossl_md5.cc
+++ b/examples/0005.sha/ossl_md5.cc
@@ -12,6 +12,10 @@ int main(int argc,char** argv)
 	using namespace fast_io::mnp;
 	if(argc!=2)
 	{
+		if(argc==0)
+		{
+			return 1;
+		}
 		perr("Usage: ",os_c_str(*argv)," <file>\n");
 		return 1;
 	}

--- a/examples/0005.sha/ossl_sha1.cc
+++ b/examples/0005.sha/ossl_sha1.cc
@@ -12,6 +12,10 @@ int main(int argc,char** argv)
 	using namespace fast_io::mnp;
 	if(argc!=2)
 	{
+		if(argc==0)
+		{
+			return 1;
+		}
 		perr("Usage: ",os_c_str(*argv)," <file>\n");
 		return 1;
 	}

--- a/examples/0005.sha/ossl_sha256.cc
+++ b/examples/0005.sha/ossl_sha256.cc
@@ -11,6 +11,10 @@ int main(int argc,char** argv)
 	using namespace fast_io::mnp;
 	if(argc!=2)
 	{
+		if(argc==0)
+		{
+			return 1;
+		}
 		perr("Usage: ",os_c_str(*argv)," <file>\n");
 		return 1;
 	}

--- a/examples/0005.sha/ossl_sha512.cc
+++ b/examples/0005.sha/ossl_sha512.cc
@@ -11,6 +11,10 @@ int main(int argc,char** argv)
 	using namespace fast_io::mnp;
 	if(argc!=2)
 	{
+		if(argc==0)
+		{
+			return 1;
+		}
 		perr("Usage: ",os_c_str(*argv)," <file>\n");
 		return 1;
 	}

--- a/examples/0005.sha/sha1.cc
+++ b/examples/0005.sha/sha1.cc
@@ -13,6 +13,10 @@ int main(int argc,char** argv)
 	using namespace fast_io::mnp;
 	if(argc!=2)
 	{
+		if(argc==0)
+		{
+			return 1;
+		}
 		perr("Usage: ",os_c_str(*argv)," <file>\n");
 		return 1;
 	}

--- a/examples/0005.sha/sha256.cc
+++ b/examples/0005.sha/sha256.cc
@@ -12,6 +12,10 @@ int main(int argc,char** argv)
 	using namespace fast_io::mnp;
 	if(argc!=2)
 	{
+		if(argc==0)
+		{
+			return 1;
+		}
 		perr("Usage: ",os_c_str(*argv)," <file>\n");
 		return 1;
 	}

--- a/examples/0005.sha/sha512.cc
+++ b/examples/0005.sha/sha512.cc
@@ -11,6 +11,10 @@ int main(int argc,char** argv)
 	using namespace fast_io::mnp;
 	if(argc!=2)
 	{
+		if(argc==0)
+		{
+			return 1;
+		}
 		perr("Usage: ",os_c_str(*argv)," <file>\n");
 		return 1;
 	}

--- a/examples/0009.filesystem/binary_to_text.cc
+++ b/examples/0009.filesystem/binary_to_text.cc
@@ -7,7 +7,7 @@ try
 {
 	if(argc<3)
 	{
-		perr("Usage: ",fast_io::mnp::os_env(argc,argv,0)," <source directory> <dest directory>\n");
+		perr("Usage: ",fast_io::mnp::os_c_str(argv[0])," <source directory> <dest directory>\n");
 		return 1;
 	}
 	fast_io::dir_file df(::fast_io::mnp::os_c_str(argv[1]));

--- a/examples/0009.filesystem/binary_to_text.cc
+++ b/examples/0009.filesystem/binary_to_text.cc
@@ -7,7 +7,11 @@ try
 {
 	if(argc<3)
 	{
-		perr("Usage: ",fast_io::mnp::os_c_str(argv[0])," <source directory> <dest directory>\n");
+		if(argc==0)
+		{
+			return 1;
+		}
+		perr("Usage: ",fast_io::mnp::os_c_str(*argv)," <source directory> <dest directory>\n");
 		return 1;
 	}
 	fast_io::dir_file df(::fast_io::mnp::os_c_str(argv[1]));

--- a/examples/0009.filesystem/gcc_symlink_install.cc
+++ b/examples/0009.filesystem/gcc_symlink_install.cc
@@ -10,7 +10,11 @@ int main(int argc,char const** argv)
 {
 	if(argc<2)
 	{
-		perr("Usage: ",::fast_io::mnp::os_c_str(argv[0])," <dir path>\n");
+		if(argc==0)
+		{
+			return 1;
+		}
+		perr("Usage: ",::fast_io::mnp::os_c_str(*argv)," <dir path>\n");
 		return 1;
 	}
 	std::vector<std::u8string> names;

--- a/examples/0009.filesystem/gcc_symlink_install.cc
+++ b/examples/0009.filesystem/gcc_symlink_install.cc
@@ -10,7 +10,7 @@ int main(int argc,char const** argv)
 {
 	if(argc<2)
 	{
-		perr("Usage: ",::fast_io::mnp::os_env(argc,argv,0)," <dir path>\n");
+		perr("Usage: ",::fast_io::mnp::os_c_str(argv[0])," <dir path>\n");
 		return 1;
 	}
 	std::vector<std::u8string> names;


### PR DESCRIPTION
Several examples don't follow ["remove os_env" PR](https://github.com/cppfastio/fast_io/pull/417).
