### PR TITLE
fix memory leak in vector

### DIFF
--- a/tests/0026.container/trivialclass.cc
+++ b/tests/0026.container/trivialclass.cc
@@ -1,0 +1,21 @@
+#include<string>
+#include<fast_io_dsal/vector.h>
+
+struct metaindex
+{
+	::std::size_t modulepos{SIZE_MAX},moduleroutinepos{SIZE_MAX};
+};
+
+struct edge_info
+{
+	metaindex modpos;
+	::std::size_t counts{};
+};
+
+int main()
+{
+	::fast_io::vector<::fast_io::vector<int>> vec;
+//	vec.push_back(foo{});
+//	println(vec.size());
+	vec.emplace_back(30);
+}


### PR DESCRIPTION
vector<vector<int>> causes sanitizers to complain about memory leak

The problem is that is_trivially_relocatable does not cover the case for trivially_relocatable. That needs a fix