### PR TITLE
Implement floating point binary serialization based on wasm standard

### DIFF
--- a/examples/0030.binary_serialization/lec559_lebe.cc
+++ b/examples/0030.binary_serialization/lec559_lebe.cc
@@ -1,0 +1,49 @@
+#include <string>
+#include <limits>
+#include <source_location>
+#include <fast_io.h>
+#include <stdfloat>
+
+template<typename T>
+inline void test(::std::string& buffer,T u1)
+{
+	T u2;
+	using namespace fast_io::mnp;
+	print(fast_io::obuffer_view{ buffer }, iec559_le_put(u1));
+	scan(fast_io::ibuffer_view{ buffer }, iec559_le_get(u2));
+	println(std::source_location::current(), "\tu1 == u2: ", boolalpha(u1 == u2));
+}
+
+int main()
+{
+	std::string buffer(10000, '\0');
+
+#if __STDCPP_BFLOAT_T__
+	test(buffer,124.4264bf);
+#endif
+
+#if __STDCPP_FLOAT8_T__
+	test(buffer,124.4264f8);
+#endif
+
+#if __STDCPP_FLOAT16_T__
+	test(buffer,124.4264f16);
+#endif
+
+#if __STDCPP_FLOAT32_T__
+	test(buffer,124.4264325f32);
+#endif
+
+#if __STDCPP_FLOAT64_T__
+	test(buffer,124.4264325f64);
+#endif
+
+#if __STDCPP_FLOAT128_T__
+	test(buffer,142112424.4264325f128);
+#endif
+
+	test(buffer,1245.35f);
+
+	test(buffer,12421421.35);
+}
+

--- a/include/fast_io_freestanding_impl/serializations/lebe.h
+++ b/include/fast_io_freestanding_impl/serializations/lebe.h
@@ -1,11 +1,67 @@
 ﻿#pragma once
+
 namespace fast_io::details
 {
 
-template<std::size_t sz>
-inline constexpr bool supported_lebe_size{sz==8||sz==16||sz==32||sz==64};
+template<::std::size_t sz>
+inline constexpr bool supported_lebe_size{sz==8||sz==16||sz==32||sz==64||sz==128};
+
+#ifdef __SIZEOF_INT128__
+using pesudo_int128type = __uint128_t;
+#else
+struct pesudo_int128type
+{
+	::std::uint_least64_t uarr[2];
+};
+#endif
+
+template<typename T>
+inline constexpr ::std::size_t cal_size_lebe_floatsize() noexcept
+{
+	using nocvref = ::std::remove_cvref_t<T>;
+	if constexpr(::std::same_as<nocvref,float>)
+	{
+		return 32;
+	}
+	else if constexpr(::std::same_as<nocvref,double>)
+	{
+		return 64;
+	}
+	else if constexpr(::std::same_as<nocvref,long double>)
+	{
+		return 128;
+	}
+	else if constexpr(::std::same_as<nocvref,::std::uint_least8_t>)
+	{
+		return 8;
+	}
+	else if constexpr(::std::same_as<nocvref,::std::uint_least16_t>)
+	{
+		return 16;
+	}
+	else if constexpr(::std::same_as<nocvref,::std::uint_least32_t>)
+	{
+		return 32;
+	}
+	else if constexpr(::std::same_as<nocvref,::std::uint_least64_t>)
+	{
+		return 64;
+	}
+	else if constexpr(::std::same_as<nocvref,pesudo_int128type>)
+	{
+		return 128;
+	}
+	else
+	{
+		return 0;
+	}
+}
+
+template<typename floattype>
+inline constexpr ::std::size_t size_lebe_float_size{::fast_io::details::cal_size_lebe_floatsize<floattype>()};
 
 }
+
 namespace fast_io::manipulators
 {
 
@@ -79,10 +135,11 @@ inline constexpr auto lebe_put(int_type t) noexcept((::std::numeric_limits<::fas
 			throw_parse_code(::fast_io::parse_code::invalid);
 	}
 	using proxy_type =
+		::std::conditional_t<(sz==128),::fast_io::details::pesudo_int128type,
 		::std::conditional_t<(sz==64),::std::uint_least64_t,
 		::std::conditional_t<(sz==32),::std::uint_least32_t,
 		::std::conditional_t<(sz==16),::std::uint_least16_t,
-		::std::conditional_t<(sz==8),::std::uint_least8_t,void>>>>;
+		::std::conditional_t<(sz==8),::std::uint_least8_t,void>>>>>;
 	return basic_lebe_get_put<en,basic_lebe_put_integral<sz,proxy_type>>{{static_cast<proxy_type>(static_cast<uint_type>(u))}};
 }
 
@@ -100,6 +157,109 @@ inline constexpr auto be_put(int_type t) noexcept(noexcept(lebe_put<::std::endia
 	return lebe_put<::std::endian::big,sz>(t);
 }
 
+template<::std::endian en,::std::floating_point T>
+inline constexpr auto iec559_lebe_put(T t)
+{
+	constexpr
+		bool isiec559{::std::numeric_limits<T>::is_iec559};
+	using nocvref = ::std::remove_cvref_t<T>;
+
+	if constexpr(::std::same_as<nocvref,float>)
+	{
+		if constexpr(isiec559)
+		{
+			return ::fast_io::manipulators::lebe_put<en,32>(::std::bit_cast<::std::uint_least32_t>(static_cast<float>(t)));
+		}
+		else
+		{
+#if __STDCPP_FLOAT32_T__
+			return ::fast_io::manipulators::lebe_put<en,32>(::std::bit_cast<::std::uint_least32_t>(static_cast<_Float32>(t)));
+#else
+static_assert(isiec559,"float is not iec60559");
+#endif
+		}
+	}
+	else if constexpr(::std::same_as<nocvref,double>)
+	{
+		if constexpr(isiec559)
+		{
+			return ::fast_io::manipulators::lebe_put<en,64>(::std::bit_cast<::std::uint_least64_t>(static_cast<double>(t)));
+		}
+		else
+		{
+#if __STDCPP_FLOAT64_T__
+			return ::fast_io::manipulators::lebe_put<en,64>(::std::bit_cast<::std::uint_least64_t>(static_cast<_Float64>(t)));
+#else
+static_assert(isiec559,"double is not iec60559");
+#endif
+		}
+	}
+	else if constexpr(::std::same_as<nocvref,long double>)
+	{
+#if __STDCPP_FLOAT128_T__
+		return ::fast_io::manipulators::lebe_put<en,128>(::std::bit_cast<::fast_io::details::pesudo_int128type>(static_cast<_Float128>(t)));
+#else
+static_assert(sizeof(double)!=sizeof(long)&&isiec559,"long double is not iec60559 or sizeof(double) == sizeof(long double)");
+#endif
+	}
+	else if constexpr(sizeof(T)==sizeof(::std::uint_least8_t))
+	{
+		return ::fast_io::manipulators::lebe_put<en,8>(::std::bit_cast<::std::uint_least8_t>(static_cast<nocvref>(t)));
+	}
+	else if constexpr(sizeof(T)==sizeof(::std::uint_least16_t))
+	{
+		return ::fast_io::manipulators::lebe_put<en,16>(::std::bit_cast<::std::uint_least16_t>(static_cast<nocvref>(t)));
+	}
+	else if constexpr(sizeof(T)==sizeof(::std::uint_least32_t))
+	{
+		return ::fast_io::manipulators::lebe_put<en,32>(::std::bit_cast<::std::uint_least32_t>(static_cast<nocvref>(t)));
+	}
+	else if constexpr(sizeof(T)==sizeof(::std::uint_least64_t))
+	{
+		return ::fast_io::manipulators::lebe_put<en,64>(::std::bit_cast<::std::uint_least64_t>(static_cast<nocvref>(t)));
+	}
+	else if constexpr(sizeof(T)==sizeof(::fast_io::details::pesudo_int128type))
+	{
+		return ::fast_io::manipulators::lebe_put<en,128>(::std::bit_cast<::fast_io::details::pesudo_int128type>(static_cast<nocvref>(t)));
+	}
+}
+
+/*
+WASM standard uses this format.
+*/
+template<::std::floating_point T>
+inline constexpr auto iec559_le_put(T t)
+{
+	return ::fast_io::manipulators::iec559_lebe_put<::std::endian::little>(t);
+}
+
+template<::std::floating_point T>
+inline constexpr auto iec559_be_put(T t)
+{
+	return ::fast_io::manipulators::iec559_lebe_put<::std::endian::big>(t);
+}
+
+template<::std::endian en,::std::floating_point T>
+requires (!::std::is_const_v<T>)
+inline constexpr auto iec559_lebe_get(T& t) noexcept
+{
+	using nocvreft = ::std::remove_cvref_t<T>;
+	return ::fast_io::manipulators::basic_lebe_get_put<en,
+		::fast_io::manipulators::basic_lebe_get_integral<::fast_io::details::cal_size_lebe_floatsize<nocvreft>(),T>>{{__builtin_addressof(t)}};
+}
+
+template<::std::floating_point T>
+inline constexpr auto iec559_le_get(T& t)
+{
+	return ::fast_io::manipulators::iec559_lebe_get<::std::endian::little>(t);
+}
+
+template<::std::floating_point T>
+inline constexpr auto iec559_be_get(T& t)
+{
+	return ::fast_io::manipulators::iec559_lebe_get<::std::endian::big>(t);
+}
+
 }
 
 namespace fast_io
@@ -108,7 +268,7 @@ namespace fast_io
 namespace details
 {
 
-template<::std::endian endn,::fast_io::details::my_unsigned_integral int_type,::std::integral char_type>
+template<::std::endian endn,typename int_type,::std::integral char_type>
 inline
 #if __cpp_lib_bit_cast >= 201806L && (__cpp_if_consteval >= 202106L ||__cpp_lib_is_constant_evaluated >= 201811L)
 constexpr
@@ -142,7 +302,17 @@ auto scan_precise_reserve_define_integer_common_impl(char_type const* iter) noex
 	}
 	if constexpr(::std::endian::native!=endn)
 	{
-		t=::fast_io::byte_swap(t);
+		if constexpr(::fast_io::details::my_unsigned_integral<int_type>)
+		{
+			t=::fast_io::byte_swap(t);
+		}
+		else
+		{
+			::std::uint_least64_t low{t.low};
+			::std::uint_least64_t high{t.high};
+			t.low=::fast_io::byte_swap(high);
+			t.high=::fast_io::byte_swap(low);
+		}
 	}
 	return t;
 }
@@ -150,12 +320,13 @@ auto scan_precise_reserve_define_integer_common_impl(char_type const* iter) noex
 template<::std::endian endn,std::size_t n,::fast_io::details::my_integral int_type,::std::integral char_type>
 inline constexpr auto scan_precise_reserve_define_integer_impl(char_type const* iter,int_type& t) noexcept
 {
-	static_assert(n<=64);
+	static_assert(n<=128);
 	using proxy_type =
+		::std::conditional_t<(n==128),::fast_io::details::pesudo_int128type,
 		::std::conditional_t<(n==64),::std::uint_least64_t,
 		::std::conditional_t<(n==32),::std::uint_least32_t,
 		::std::conditional_t<(n==16),::std::uint_least16_t,
-		::std::conditional_t<(n==8),::std::uint_least8_t,void>>>>;
+		::std::conditional_t<(n==8),::std::uint_least8_t,void>>>>>;
 	proxy_type const temp{scan_precise_reserve_define_integer_common_impl<endn,proxy_type>(iter)};
 	using my_unsigned_type = ::fast_io::details::my_make_unsigned_t<int_type>;
 	constexpr std::size_t digits{::std::numeric_limits<my_unsigned_type>::digits};
@@ -175,18 +346,104 @@ inline constexpr auto scan_precise_reserve_define_integer_impl(char_type const* 
 	}
 }
 
-template<::std::endian endn,::fast_io::details::my_unsigned_integral uint_type,::std::integral char_type>
+template<::std::endian endn,::std::floating_point flttypef,::std::integral char_type>
+inline constexpr auto scan_precise_reserve_define_lebe_float_get_impl(char_type const* iter,flttypef& t) noexcept
+{
+	using flttype =
+		::std::remove_cvref_t<flttypef>;
+	constexpr
+		::std::size_t n{::fast_io::details::size_lebe_float_size<flttype>};
+	using proxy_type =
+		::std::conditional_t<(n==128),::fast_io::details::pesudo_int128type,
+		::std::conditional_t<(n==64),::std::uint_least64_t,
+		::std::conditional_t<(n==32),::std::uint_least32_t,
+		::std::conditional_t<(n==16),::std::uint_least16_t,
+		::std::conditional_t<(n==8),::std::uint_least8_t,void>>>>>;
+	proxy_type const temp{scan_precise_reserve_define_integer_common_impl<endn,proxy_type>(iter)};
+
+	constexpr
+		bool isiec559{::std::numeric_limits<flttype>::is_iec559};
+	if constexpr(::std::same_as<flttype,float>)
+	{
+		if constexpr(isiec559)
+		{
+			t=static_cast<flttypef>(std::bit_cast<float>(temp));
+		}
+		else
+		{
+#if __STDCPP_FLOAT32_T__
+			t=static_cast<flttypef>(std::bit_cast<_Float32>(temp));
+#else
+static_assert(isiec559,"float is not iec60559");
+#endif
+		}
+	}
+	else if constexpr(::std::same_as<flttype,double>)
+	{
+		if constexpr(isiec559)
+		{
+			t=static_cast<flttypef>(std::bit_cast<double>(temp));
+		}
+		else
+		{
+#if __STDCPP_FLOAT32_T__
+			t=static_cast<flttypef>(std::bit_cast<_Float64>(temp));
+#else
+static_assert(isiec559,"float is not iec60559");
+#endif
+		}
+	}
+	else if constexpr(::std::same_as<flttype,double>)
+	{
+		if constexpr(isiec559)
+		{
+			t=static_cast<flttypef>(std::bit_cast<double>(temp));
+		}
+		else
+		{
+#if __STDCPP_FLOAT64_T__
+			t=static_cast<flttypef>(std::bit_cast<_Float64>(temp));
+#else
+static_assert(isiec559,"double is not iec60559");
+#endif
+		}
+	}
+	else if constexpr(::std::same_as<flttype,long double>)
+	{
+#if __STDCPP_FLOAT128_T__
+			t=static_cast<flttypef>(std::bit_cast<_Float128>(temp));
+#else
+static_assert(sizeof(double)!=sizeof(long)&&isiec559,"long double is not iec60559 or sizeof(double) == sizeof(long double)");
+#endif
+	}
+	else
+	{
+		t=static_cast<flttypef>(std::bit_cast<flttype>(temp));
+	}
+}
+
+template<::std::endian endn,typename uint_type,::std::integral char_type>
 inline
 #if __cpp_lib_bit_cast >= 201806L && (__cpp_if_consteval >= 202106L ||__cpp_lib_is_constant_evaluated >= 201811L)
 constexpr
 #endif
-char_type* print_reserve_define_integer_common_impl(char_type* iter,uint_type u) noexcept
+char_type* print_reserve_define_integer_lebe_common_impl(char_type* iter,uint_type u) noexcept
 {
 	constexpr std::size_t n{sizeof(uint_type)/sizeof(char_type)};
 	static_assert(n!=0);
 	if constexpr(::std::endian::native!=endn)
 	{
-		u=::fast_io::byte_swap(u);
+		if constexpr(::fast_io::details::my_unsigned_integral<uint_type>)
+		{
+			u=::fast_io::byte_swap(u);
+		}
+		else
+		{
+			::std::uint_least64_t low{u.low};
+			::std::uint_least64_t high{u.high};
+			u.low=::fast_io::byte_swap(high);
+			u.high=::fast_io::byte_swap(low);
+		}
 	}
 #if __cpp_lib_bit_cast >= 201806L && (__cpp_if_consteval >= 202106L ||__cpp_lib_is_constant_evaluated >= 201811L)
 #if __cpp_if_consteval >= 202106L
@@ -215,8 +472,10 @@ char_type* print_reserve_define_integer_common_impl(char_type* iter,uint_type u)
 
 }
 
-template<::std::integral char_type,::std::endian end,::std::size_t sz,::fast_io::details::my_integral int_type>
-requires (((sz%(::std::numeric_limits<::std::make_unsigned_t<char_type>>::digits))==0)&&!::std::is_const_v<int_type>)
+template<::std::integral char_type,::std::endian end,::std::size_t sz,typename int_type>
+requires (((sz%(::std::numeric_limits<::std::make_unsigned_t<char_type>>::digits))==0)&&!::std::is_const_v<int_type>
+	&&(::fast_io::details::my_integral<int_type>||
+	(::std::floating_point<int_type>&&(::fast_io::details::size_lebe_float_size<int_type>)==sz)))
 inline constexpr std::size_t scan_precise_reserve_size(io_reserve_type_t<char_type,
 	::fast_io::manipulators::basic_lebe_get_put<end,::fast_io::manipulators::basic_lebe_get_integral<sz,int_type>>>) noexcept
 {
@@ -224,18 +483,28 @@ inline constexpr std::size_t scan_precise_reserve_size(io_reserve_type_t<char_ty
 	return cache;
 }
 
-template<::std::endian en,::std::size_t sz,::std::integral char_type,::fast_io::details::my_integral int_type>
-requires (((sz%(::std::numeric_limits<::std::make_unsigned_t<char_type>>::digits))==0)&&!::std::is_const_v<int_type>)
+template<::std::endian en,::std::size_t sz,::std::integral char_type,typename int_type>
+requires (((sz%(::std::numeric_limits<::std::make_unsigned_t<char_type>>::digits))==0)&&!::std::is_const_v<int_type>
+	&&(::fast_io::details::my_integral<int_type>||
+	(::std::floating_point<int_type>&&(::fast_io::details::size_lebe_float_size<int_type>)==sz)))
 inline constexpr auto scan_precise_reserve_define(io_reserve_type_t<char_type,
 	::fast_io::manipulators::basic_lebe_get_put<en,::fast_io::manipulators::basic_lebe_get_integral<sz,int_type>>>,
 	char_type const* iter,
 	::fast_io::manipulators::basic_lebe_get_put<en,::fast_io::manipulators::basic_lebe_get_integral<sz,int_type>> t) noexcept
 {
-	return ::fast_io::details::scan_precise_reserve_define_integer_impl<en,sz>(iter,*t.reference.pointer);
+	if constexpr(::std::floating_point<int_type>)
+	{
+		return ::fast_io::details::scan_precise_reserve_define_lebe_float_get_impl<en,sz>(iter,*t.reference.pointer);
+	}
+	else
+	{
+		return ::fast_io::details::scan_precise_reserve_define_integer_impl<en,sz>(iter,*t.reference.pointer);
+	}
 }
 
-template<::std::integral char_type,::std::endian end,::std::size_t sz,::fast_io::details::my_unsigned_integral int_type>
-requires (((sz%(::std::numeric_limits<::std::make_unsigned_t<char_type>>::digits))==0))
+template<::std::integral char_type,::std::endian end,::std::size_t sz,typename int_type>
+requires (((sz%(::std::numeric_limits<::std::make_unsigned_t<char_type>>::digits))==0)&&
+	(::fast_io::details::my_unsigned_integral<int_type>||::std::same_as<int_type,::fast_io::details::pesudo_int128type>))
 inline constexpr std::size_t print_reserve_size(io_reserve_type_t<char_type,
 	::fast_io::manipulators::basic_lebe_get_put<end,::fast_io::manipulators::basic_lebe_put_integral<sz,int_type>>>) noexcept
 {
@@ -243,13 +512,14 @@ inline constexpr std::size_t print_reserve_size(io_reserve_type_t<char_type,
 	return cache;
 }
 
-template<::std::integral char_type,::std::endian end,::std::size_t sz,::fast_io::details::my_unsigned_integral int_type>
-requires (((sz%(::std::numeric_limits<::std::make_unsigned_t<char_type>>::digits))==0))
+template<::std::integral char_type,::std::endian end,::std::size_t sz,typename int_type>
+requires (((sz%(::std::numeric_limits<::std::make_unsigned_t<char_type>>::digits))==0)&&
+	(::fast_io::details::my_unsigned_integral<int_type>||::std::same_as<int_type,::fast_io::details::pesudo_int128type>))
 inline constexpr auto print_reserve_define(io_reserve_type_t<char_type,
 	::fast_io::manipulators::basic_lebe_get_put<end,::fast_io::manipulators::basic_lebe_put_integral<sz,int_type>>>,char_type* iter,
 	::fast_io::manipulators::basic_lebe_get_put<end,::fast_io::manipulators::basic_lebe_put_integral<sz,int_type>> v) noexcept
 {
-	return ::fast_io::details::print_reserve_define_integer_common_impl<end>(iter,v.reference.value);
+	return ::fast_io::details::print_reserve_define_integer_lebe_common_impl<end>(iter,v.reference.value);
 }
 
 }

--- a/include/fast_io_freestanding_impl/serializations/lebe.h
+++ b/include/fast_io_freestanding_impl/serializations/lebe.h
@@ -31,23 +31,23 @@ inline constexpr ::std::size_t cal_size_lebe_floatsize() noexcept
 	{
 		return 128;
 	}
-	else if constexpr(::std::same_as<nocvref,::std::uint_least8_t>)
+	else if constexpr(sizeof(nocvref)==sizeof(::std::uint_least8_t))
 	{
 		return 8;
 	}
-	else if constexpr(::std::same_as<nocvref,::std::uint_least16_t>)
+	else if constexpr(sizeof(nocvref)==sizeof(::std::uint_least16_t))
 	{
 		return 16;
 	}
-	else if constexpr(::std::same_as<nocvref,::std::uint_least32_t>)
+	else if constexpr(sizeof(nocvref)==sizeof(::std::uint_least32_t))
 	{
 		return 32;
 	}
-	else if constexpr(::std::same_as<nocvref,::std::uint_least64_t>)
+	else if constexpr(sizeof(nocvref)==sizeof(::std::uint_least64_t))
 	{
 		return 64;
 	}
-	else if constexpr(::std::same_as<nocvref,pesudo_int128type>)
+	else if constexpr(sizeof(nocvref)==sizeof(pesudo_int128type))
 	{
 		return 128;
 	}
@@ -197,7 +197,8 @@ static_assert(isiec559,"double is not iec60559");
 	else if constexpr(::std::same_as<nocvref,long double>)
 	{
 #if __STDCPP_FLOAT128_T__
-		return ::fast_io::manipulators::lebe_put<en,128>(::std::bit_cast<::fast_io::details::pesudo_int128type>(static_cast<_Float128>(t)));
+		using proxy_type = ::fast_io::details::pesudo_int128type;
+		return ::fast_io::manipulators::basic_lebe_get_put<en,basic_lebe_put_integral<128,proxy_type>>{{::std::bit_cast<::fast_io::details::pesudo_int128type>(static_cast<_Float128>(t))}};
 #else
 static_assert(sizeof(double)!=sizeof(long)&&isiec559,"long double is not iec60559 or sizeof(double) == sizeof(long double)");
 #endif
@@ -220,7 +221,8 @@ static_assert(sizeof(double)!=sizeof(long)&&isiec559,"long double is not iec6055
 	}
 	else if constexpr(sizeof(T)==sizeof(::fast_io::details::pesudo_int128type))
 	{
-		return ::fast_io::manipulators::lebe_put<en,128>(::std::bit_cast<::fast_io::details::pesudo_int128type>(static_cast<nocvref>(t)));
+		using proxy_type = ::fast_io::details::pesudo_int128type;
+		return ::fast_io::manipulators::basic_lebe_get_put<en,basic_lebe_put_integral<128,proxy_type>>{{::std::bit_cast<::fast_io::details::pesudo_int128type>(static_cast<nocvref>(t))}};
 	}
 }
 
@@ -360,7 +362,6 @@ inline constexpr auto scan_precise_reserve_define_lebe_float_get_impl(char_type 
 		::std::conditional_t<(n==16),::std::uint_least16_t,
 		::std::conditional_t<(n==8),::std::uint_least8_t,void>>>>>;
 	proxy_type const temp{scan_precise_reserve_define_integer_common_impl<endn,proxy_type>(iter)};
-
 	constexpr
 		bool isiec559{::std::numeric_limits<flttype>::is_iec559};
 	if constexpr(::std::same_as<flttype,float>)
@@ -494,7 +495,7 @@ inline constexpr auto scan_precise_reserve_define(io_reserve_type_t<char_type,
 {
 	if constexpr(::std::floating_point<int_type>)
 	{
-		return ::fast_io::details::scan_precise_reserve_define_lebe_float_get_impl<en,sz>(iter,*t.reference.pointer);
+		return ::fast_io::details::scan_precise_reserve_define_lebe_float_get_impl<en>(iter,*t.reference.pointer);
 	}
 	else
 	{

--- a/include/fast_io_hosted/timeutil/posix_timezone.h
+++ b/include/fast_io_hosted/timeutil/posix_timezone.h
@@ -51,10 +51,11 @@ inline posix_timezone_name posix_localtimezone_impl() noexcept
 	{
 		return {};
 	}
+	using unsignedtype = ::std::make_unsigned_t<decltype(st.st_size)>;
 	if constexpr(sizeof(decltype(st.st_size))>sizeof(std::size_t))
 	{
 		constexpr std::size_t mx{::std::numeric_limits<std::size_t>::max()};
-		if(st.st_size>mx)
+		if(mx<static_cast<unsignedtype>(st.st_size))
 		{
 			return {};
 		}
@@ -63,7 +64,7 @@ inline posix_timezone_name posix_localtimezone_impl() noexcept
 	char8_t* bufptr{::fast_io::typed_generic_allocator_adapter<::fast_io::generic_allocator_adapter<::fast_io::c_malloc_allocator>,char8_t>::allocate(real_size)};
 	posix_timezone_name nm;
 	nm.ptr=bufptr;
-	nm.n=st.st_size;
+	nm.n=static_cast<std::size_t>(static_cast<unsignedtype>(st.st_size));
 	std::ptrdiff_t symret{::fast_io::posix::libc_readlink(u8"/etc/localtime",bufptr,real_size)};
 	if(ret==-1||static_cast<std::size_t>(symret)!=real_size||real_size<=localtimezoneinfo_string_len)
 	{


### PR DESCRIPTION
https://github.com/sunfishcode/wasm-reference-manual/blob/master/WebAssembly.md#primitive-encoding-types

Wasm standard says floating point should be serialized by using type punning to ints integer type.