### PR TITLE
Add safety checks by default to containers

### DIFF
--- a/examples/0014.random/ranuint64.cc
+++ b/examples/0014.random/ranuint64.cc
@@ -1,0 +1,13 @@
+#include<random>
+#include<fast_io.h>
+
+int main()
+{
+	::fast_io::ibuf_white_hole_engine iwhe;
+	::std::uniform_int_distribution<::std::uint_least64_t> udis(0,UINT_LEAST64_MAX);
+	for(::std::size_t i{};i!=10;++i)
+	{
+		::fast_io::io::println(::fast_io::mnp::addrvw(udis(iwhe)));
+	}
+}
+

--- a/include/fast_io_dsal/impl/list.h
+++ b/include/fast_io_dsal/impl/list.h
@@ -704,19 +704,117 @@ public:
 	constexpr void pop_back() noexcept
 	{
 		auto node = static_cast<::fast_io::containers::details::list_node_common *>(imp.prev);
+		if (node == __builtin_addressof(imp))
+		{
+			::fast_io::fast_terminate();
+		}
+#if 0
+		auto prev = static_cast<::fast_io::containers::details::list_node_common *>(node->prev);
+		imp.prev = prev;
+		prev->next = __builtin_addressof(imp);
+		this->destroy_node(node);
+#else
+		this->pop_back_unchecked();
+#endif
+	}
+
+	constexpr void pop_front() noexcept
+	{
+		auto node = static_cast<::fast_io::containers::details::list_node_common *>(imp.next);
+		if (node == __builtin_addressof(imp))
+		{
+			::fast_io::fast_terminate();
+		}
+#if 0
+		auto next = static_cast<::fast_io::containers::details::list_node_common *>(node->next);
+		imp.next = next;
+		next->prev = __builtin_addressof(imp);
+		this->destroy_node(node);
+#else
+		this->pop_front_unchecked();
+#endif
+	}
+
+	constexpr void pop_back_unchecked() noexcept
+	{
+		auto node = static_cast<::fast_io::containers::details::list_node_common *>(imp.prev);
 		auto prev = static_cast<::fast_io::containers::details::list_node_common *>(node->prev);
 		imp.prev = prev;
 		prev->next = __builtin_addressof(imp);
 		this->destroy_node(node);
 	}
 
-	constexpr void pop_front() noexcept
+	constexpr void pop_front_unchecked() noexcept
 	{
 		auto node = static_cast<::fast_io::containers::details::list_node_common *>(imp.next);
 		auto next = static_cast<::fast_io::containers::details::list_node_common *>(node->next);
 		imp.next = next;
 		next->prev = __builtin_addressof(imp);
 		this->destroy_node(node);
+	}
+
+	[[nodiscard]] constexpr const_reference front() const noexcept
+	{
+		auto nodeptr{imp.next};
+		auto node = static_cast<::fast_io::containers::details::list_node_common *>(nodeptr);
+		if (node == __builtin_addressof(imp)) [[unlikely]]
+		{
+			::fast_io::fast_terminate();
+		}
+		return static_cast<::fast_io::containers::details::list_node<T> *>(nodeptr)->element;
+	}
+	[[nodiscard]] constexpr reference front() noexcept
+	{
+		auto nodeptr{imp.next};
+		auto node = static_cast<::fast_io::containers::details::list_node_common *>(nodeptr);
+		if (node == __builtin_addressof(imp)) [[unlikely]]
+		{
+			::fast_io::fast_terminate();
+		}
+		return static_cast<::fast_io::containers::details::list_node<T> *>(nodeptr)->element;
+	}
+
+	[[nodiscard]] constexpr const_reference back() const noexcept
+	{
+		auto nodeptr{imp.prev};
+		auto node = static_cast<::fast_io::containers::details::list_node_common *>(nodeptr);
+		if (node == __builtin_addressof(imp)) [[unlikely]]
+		{
+			::fast_io::fast_terminate();
+		}
+		return static_cast<::fast_io::containers::details::list_node<T> *>(nodeptr)->element;
+	}
+	[[nodiscard]] constexpr reference back() noexcept
+	{
+		auto nodeptr{imp.prev};
+		auto node = static_cast<::fast_io::containers::details::list_node_common *>(nodeptr);
+		if (node == __builtin_addressof(imp)) [[unlikely]]
+		{
+			::fast_io::fast_terminate();
+		}
+		return static_cast<::fast_io::containers::details::list_node<T> *>(nodeptr)->element;
+	}
+
+	[[nodiscard]] constexpr const_reference front_unchecked() const noexcept
+	{
+		auto nodeptr{imp.next};
+		return static_cast<::fast_io::containers::details::list_node<T> *>(nodeptr)->element;
+	}
+	[[nodiscard]] constexpr reference front_unchecked() noexcept
+	{
+		auto nodeptr{imp.next};
+		return static_cast<::fast_io::containers::details::list_node<T> *>(nodeptr)->element;
+	}
+
+	[[nodiscard]] constexpr const_reference back_unchecked() const noexcept
+	{
+		auto nodeptr{imp.prev};
+		return static_cast<::fast_io::containers::details::list_node<T> *>(nodeptr)->element;
+	}
+	[[nodiscard]] constexpr reference back_unchecked() noexcept
+	{
+		auto nodeptr{imp.prev};
+		return static_cast<::fast_io::containers::details::list_node<T> *>(nodeptr)->element;
 	}
 
 	constexpr void erase(const_iterator iter) noexcept

--- a/include/fast_io_dsal/impl/vector.h
+++ b/include/fast_io_dsal/impl/vector.h
@@ -1534,30 +1534,89 @@ public:
 		return allochdl.get();
 	}
 
-	[[nodiscard]] constexpr const_reference operator[](size_type pos) const noexcept
+	[[nodiscard]] constexpr const_reference index_unchecked(size_type pos) const noexcept
 	{
 		return imp.begin_ptr[pos];
+	}
+	[[nodiscard]] constexpr reference index_unchecked(size_type pos) noexcept
+	{
+		return imp.begin_ptr[pos];
+	}
+
+	[[nodiscard]] constexpr const_reference operator[](size_type pos) const noexcept
+	{
+		auto begin_ptr{imp.begin_ptr}, curr_ptr{imp.curr_ptr};
+		if (static_cast<::std::size_t>(curr_ptr - begin_ptr) <= pos) [[unlikely]]
+		{
+			::fast_io::fast_terminate();
+		}
+		return begin_ptr[pos];
 	}
 	[[nodiscard]] constexpr reference operator[](size_type pos) noexcept
 	{
-		return imp.begin_ptr[pos];
+		auto begin_ptr{imp.begin_ptr}, curr_ptr{imp.curr_ptr};
+		if (static_cast<::std::size_t>(curr_ptr - begin_ptr) <= pos) [[unlikely]]
+		{
+			::fast_io::fast_terminate();
+		}
+		return begin_ptr[pos];
 	}
+
 	[[nodiscard]] constexpr const_reference front() const noexcept
 	{
-		return *imp.begin_ptr;
+		auto begin_ptr{imp.begin_ptr}, curr_ptr{imp.curr_ptr};
+		if (begin_ptr == curr_ptr) [[unlikely]]
+		{
+			::fast_io::fast_terminate();
+		}
+		return *begin_ptr;
 	}
 	[[nodiscard]] constexpr reference front() noexcept
 	{
-		return *imp.begin_ptr;
+		auto begin_ptr{imp.begin_ptr}, curr_ptr{imp.curr_ptr};
+		if (begin_ptr == curr_ptr) [[unlikely]]
+		{
+			::fast_io::fast_terminate();
+		}
+		return *begin_ptr;
 	}
+
 	[[nodiscard]] constexpr const_reference back() const noexcept
 	{
-		return imp.curr_ptr[-1];
+		auto begin_ptr{imp.begin_ptr}, curr_ptr{imp.curr_ptr};
+		if (begin_ptr == curr_ptr) [[unlikely]]
+		{
+			::fast_io::fast_terminate();
+		}
+		return curr_ptr[-1];
 	}
 	[[nodiscard]] constexpr reference back() noexcept
 	{
+		auto begin_ptr{imp.begin_ptr}, curr_ptr{imp.curr_ptr};
+		if (begin_ptr == curr_ptr) [[unlikely]]
+		{
+			::fast_io::fast_terminate();
+		}
+		return curr_ptr[-1];
+	}
+
+	[[nodiscard]] constexpr const_reference front_unchecked() const noexcept
+	{
+		return *imp.begin_ptr;
+	}
+	[[nodiscard]] constexpr reference front_unchecked() noexcept
+	{
+		return *imp.begin_ptr;
+	}
+	[[nodiscard]] constexpr const_reference back_unchecked() const noexcept
+	{
 		return imp.curr_ptr[-1];
 	}
+	[[nodiscard]] constexpr reference back_unchecked() noexcept
+	{
+		return imp.curr_ptr[-1];
+	}
+
 	[[nodiscard]] constexpr pointer data() noexcept
 	{
 		return imp.begin_ptr;
@@ -1927,6 +1986,15 @@ public:
 	}
 
 	constexpr void pop_back() noexcept
+	{
+		if (imp.curr_ptr == imp.begin_ptr) [[unlikely]]
+		{
+			::fast_io::fast_terminate();
+		}
+		(--imp.curr_ptr)->~value_type();
+	}
+
+	constexpr void pop_back_unchecked() noexcept
 	{
 		(--imp.curr_ptr)->~value_type();
 	}

--- a/include/fast_io_hosted/filesystem/nt.h
+++ b/include/fast_io_hosted/filesystem/nt.h
@@ -245,7 +245,7 @@ inline bool is_dot(nt_directory_entry ent) noexcept
 	::std::size_t const native_d_namlen{ent.entry->native_d_namlen};
 	char16_t const *native_d_name_ptr{ent.entry->native_d_name};
 	return ((native_d_namlen == 1 && *native_d_name_ptr == u'.') ||
-			(native_d_namlen == 2 && *native_d_name_ptr == u'.' && native_d_name_ptr[1] == u'.'))
+			(native_d_namlen == 2 && *native_d_name_ptr == u'.' && native_d_name_ptr[1] == u'.'));
 }
 
 template <nt_family family>


### PR DESCRIPTION
We can do better than C++ standard library for everything, including memory safety. They must be extremely efficient checking (aka fail fast with __builtin_trap() or std::abort(), no any message output diagnostic)

We can provide both versions of the api.
For example:
Checked -> Unchecked
vec[pos] -> vec.index_unchecked(pos)
vec.front() -> vec.front_unchecked()
vec.back() -> vec.back_unchecked()
vec.pop_back() -> vec.pop_back_unchecked()
vec.push_back() -> vec.push_back_unchecked() which already exists