### PR TITLE
Using c_malloc instead of win32_heapalloc when asan is available.

### DIFF
--- a/include/fast_io_core_impl/allocation/asan_util.h
+++ b/include/fast_io_core_impl/allocation/asan_util.h
@@ -1,0 +1,65 @@
+#pragma once
+
+/*
+Referenced from
+https://github.com/google/sanitizers/wiki/AddressSanitizerManualPoisoning
+*/
+
+namespace fast_io::asan
+{
+
+enum class asan_status
+{
+	none,
+	activate,
+#if defined(__SANITIZE_ADDRESS__)
+	current = activate
+#elif defined(__has_feature)
+#if __has_feature(address_sanitizer)
+	current = activate
+#else
+	current = none
+#endif
+#else
+	current = none
+#endif
+};
+
+#if 0
+#if defined(_MSC_VER) && !defined(__clang__)
+__declspec(dllimport)
+#elif (__has_cpp_attribute(__gnu__::__dllimport__) && !defined(__WINE__))
+[[__gnu__::__dllimport__]]
+#endif
+#if (__has_cpp_attribute(__gnu__::__cdecl__) && !defined(__WINE__))
+[[__gnu__::__cdecl__]]
+#endif
+extern void
+#if (!__has_cpp_attribute(__gnu__::__cdecl__) && !defined(__WINE__)) && defined(_MSC_VER)
+	__cdecl
+#endif
+	__asan_poison_memory_region(void const volatile *, ::std::size_t) noexcept
+#if defined(__clang__) || defined(__GNUC__)
+	__asm__("__asan_poison_memory_region")
+#endif
+		;
+
+#if defined(_MSC_VER) && !defined(__clang__)
+__declspec(dllimport)
+#elif (__has_cpp_attribute(__gnu__::__dllimport__) && !defined(__WINE__))
+[[__gnu__::__dllimport__]]
+#endif
+#if (__has_cpp_attribute(__gnu__::__cdecl__) && !defined(__WINE__))
+[[__gnu__::__cdecl__]]
+#endif
+extern void
+#if (!__has_cpp_attribute(__gnu__::__cdecl__) && !defined(__WINE__)) && defined(_MSC_VER)
+	__cdecl
+#endif
+	__asan_unpoison_memory_region(void const volatile *, ::std::size_t) noexcept
+#if defined(__clang__) || defined(__GNUC__)
+	__asm__("__asan_unpoison_memory_region")
+#endif
+		;
+#endif
+} // namespace fast_io::asan

--- a/include/fast_io_core_impl/allocation/impl.h
+++ b/include/fast_io_core_impl/allocation/impl.h
@@ -1,6 +1,7 @@
 ﻿#pragma once
 
 #include "common.h"
+#include "asan_util.h"
 #if (defined(_WIN32) || defined(__CYGWIN__)) && !defined(__WINE__)
 #include "win32_heapalloc.h"
 #include "nt_rtlheapalloc.h"
@@ -45,7 +46,7 @@ using native_global_allocator = generic_allocator_adapter<
 #if defined(_DEBUG) && defined(_MSC_VER)
 	wincrt_malloc_dbg_allocator
 #else
-	win32_heapalloc_allocator
+	::std::conditional_t<::fast_io::asan::asan_status::current == ::fast_io::asan::asan_status::none, win32_heapalloc_allocator, c_malloc_allocator>
 #endif
 #else
 #if defined(_DEBUG) && defined(_MSC_VER)


### PR DESCRIPTION
This allows asan to detect heap corruption