### PR TITLE
Using SEH to correctly implement msvc.h

### DIFF
--- a/include/fast_io_legacy_impl/filebuf/rtti_hack/msvc.h
+++ b/include/fast_io_legacy_impl/filebuf/rtti_hack/msvc.h
@@ -15,7 +15,7 @@ extern
 #if defined(_DLL) && !defined(__WINE__)
 	__declspec(dllimport)
 #endif
-	void *__cdecl msvc__RTtypeid(void *)
+	void *__cdecl msvc__RTtypeid(void *) noexcept
 #if (defined(__GNUC__) || defined(__clang__))
 #if SIZE_MAX <= UINT_LEAST32_MAX && (defined(__x86__) || defined(_M_IX86) || defined(__i386__))
 #if defined(__GNUC__)
@@ -35,19 +35,15 @@ namespace rtti_hack
 {
 inline char const *abi_type_info_name_or_nullptr(void *mythis) noexcept
 {
-#if (defined(_MSC_VER) && _HAS_EXCEPTIONS != 0) || (!defined(_MSC_VER) && defined(__cpp_exceptions))
-	try
+	__try
 	{
-#endif
 		return ::__std_type_info_name(reinterpret_cast<::__std_type_info_data *>(reinterpret_cast<char *>(::fast_io::msvc::msvc__RTtypeid(mythis)) + sizeof(void *)),
 									  __builtin_addressof(::__type_info_root_node));
-#if (defined(_MSC_VER) && _HAS_EXCEPTIONS != 0) || (!defined(_MSC_VER) && defined(__cpp_exceptions))
 	}
-	catch (...)
+	__except(1)
 	{
 		return nullptr;
 	}
-#endif
 }
 } // namespace rtti_hack
 } // namespace fast_io


### PR DESCRIPTION
The problem is that if the type does not match, wine(maybe windows too) throws SEH, this needs to handle