### PR TITLE
Mutiple changes

### DIFF
--- a/benchmark/0011.containers/list/0000.algos/fast_io.cc
+++ b/benchmark/0011.containers/list/0000.algos/fast_io.cc
@@ -1,4 +1,4 @@
-#include <fast_io_dsal/list.h>
+﻿#include <fast_io_dsal/list.h>
 #include <fast_io_dsal/vector.h>
 #include <fast_io.h>
 #include <fast_io_driver/timer.h>

--- a/benchmark/0011.containers/list/0000.algos/std.cc
+++ b/benchmark/0011.containers/list/0000.algos/std.cc
@@ -1,4 +1,4 @@
-#include <list>
+﻿#include <list>
 #include <fast_io_dsal/vector.h>
 #include <fast_io.h>
 #include <fast_io_driver/timer.h>

--- a/benchmark/0018.get_fd/cout.cc
+++ b/benchmark/0018.get_fd/cout.cc
@@ -1,4 +1,4 @@
-#include <fast_io_legacy.h>
+﻿#include <fast_io_legacy.h>
 #include <fast_io_driver/timer.h>
 #include <iostream>
 

--- a/benchmark/0018.get_fd/coutfp.cc
+++ b/benchmark/0018.get_fd/coutfp.cc
@@ -1,4 +1,4 @@
-#include <fast_io_legacy.h>
+﻿#include <fast_io_legacy.h>
 #include <fast_io_driver/timer.h>
 #include <iostream>
 

--- a/examples/0001.helloworld/examples.cc
+++ b/examples/0001.helloworld/examples.cc
@@ -1,4 +1,4 @@
-#include <string>
+﻿#include <string>
 #include <fast_io.h>
 #include <fast_io_device.h>
 #include <fast_io_dsal/string.h>

--- a/examples/0009.filesystem/add_utf8_bom_to_all_cplusplus_files.cc
+++ b/examples/0009.filesystem/add_utf8_bom_to_all_cplusplus_files.cc
@@ -34,7 +34,7 @@ int main(int argc, char **argv)
 			continue;
 		}
 		fast_io::obuf_file obf(drt(ent), fast_io::open_mode::out);
-		write(obf, utf8bom.cbegin(), utf8bom.cend());
+		::fast_io::operations::write_all_range(obf, utf8bom);
 		print(obf, loader);
 	}
 }

--- a/examples/0009.filesystem/list_files.cc
+++ b/examples/0009.filesystem/list_files.cc
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Usage:
  *     ./list_files [directory]
  */

--- a/examples/0014.random/ranuint64.cc
+++ b/examples/0014.random/ranuint64.cc
@@ -1,4 +1,4 @@
-#include<random>
+﻿#include<random>
 #include<fast_io.h>
 
 int main()

--- a/examples/0033.get_fd/cout.cc
+++ b/examples/0033.get_fd/cout.cc
@@ -1,4 +1,4 @@
-#include <fast_io_legacy.h>
+﻿#include <fast_io_legacy.h>
 #include <fast_io_driver/timer.h>
 #include <iostream>
 

--- a/examples/0033.get_fd/coutfp.cc
+++ b/examples/0033.get_fd/coutfp.cc
@@ -1,4 +1,4 @@
-#include <fast_io_legacy.h>
+﻿#include <fast_io_legacy.h>
 #include <fast_io_driver/timer.h>
 #include <iostream>
 

--- a/include/fast_io_core_impl/allocation/asan_util.h
+++ b/include/fast_io_core_impl/allocation/asan_util.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 /*
 Referenced from

--- a/include/fast_io_core_impl/allocation/common.h
+++ b/include/fast_io_core_impl/allocation/common.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 namespace fast_io
 {

--- a/include/fast_io_core_impl/allocation/wincrt_malloc_dbg.h
+++ b/include/fast_io_core_impl/allocation/wincrt_malloc_dbg.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #if defined(_MSC_VER) && !defined(__clang__)
 #pragma warning(push)

--- a/include/fast_io_core_impl/concepts/decorator.h
+++ b/include/fast_io_core_impl/concepts/decorator.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 namespace fast_io
 {

--- a/include/fast_io_core_impl/enums/mmap_flags.h
+++ b/include/fast_io_core_impl/enums/mmap_flags.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 namespace fast_io
 {

--- a/include/fast_io_core_impl/freestanding/noexcept_call.h
+++ b/include/fast_io_core_impl/freestanding/noexcept_call.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 namespace fast_io
 {

--- a/include/fast_io_core_impl/freestanding/ranges.h
+++ b/include/fast_io_core_impl/freestanding/ranges.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 namespace fast_io::freestanding
 {

--- a/include/fast_io_core_impl/intrinsics/msvc/common.h
+++ b/include/fast_io_core_impl/intrinsics/msvc/common.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 namespace fast_io::intrinsics::msvc
 {

--- a/include/fast_io_core_impl/intrinsics/msvc/impl.h
+++ b/include/fast_io_core_impl/intrinsics/msvc/impl.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #if defined(_MSC_VER) && !defined(__clang__)
 #include "x86.h"

--- a/include/fast_io_core_impl/intrinsics/msvc/x86.h
+++ b/include/fast_io_core_impl/intrinsics/msvc/x86.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 namespace fast_io::intrinsics::msvc::x86
 {

--- a/include/fast_io_core_impl/io_lockable.h
+++ b/include/fast_io_core_impl/io_lockable.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 namespace fast_io
 {

--- a/include/fast_io_core_impl/operations/print_freestanding.h
+++ b/include/fast_io_core_impl/operations/print_freestanding.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 namespace fast_io
 {

--- a/include/fast_io_core_impl/operations/transcodeimpl/defines.h
+++ b/include/fast_io_core_impl/operations/transcodeimpl/defines.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 namespace fast_io
 {

--- a/include/fast_io_core_impl/operations/transcodeimpl/impl.h
+++ b/include/fast_io_core_impl/operations/transcodeimpl/impl.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "defines.h"
 #include "ops.h"

--- a/include/fast_io_core_impl/operations/transcodeimpl/ops.h
+++ b/include/fast_io_core_impl/operations/transcodeimpl/ops.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 namespace fast_io
 {

--- a/include/fast_io_core_impl/operations/transcodeimpl/transcoder.h
+++ b/include/fast_io_core_impl/operations/transcodeimpl/transcoder.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 namespace fast_io
 {

--- a/include/fast_io_crypto/platforms/win32/msvc_linker_32.h
+++ b/include/fast_io_crypto/platforms/win32/msvc_linker_32.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 // clang-format off
 #pragma comment(linker,"/alternatename:__imp_?BCryptOpenAlgorithmProvider@win32@fast_io@@YAIPAPAXPB_S1I@Z=__imp_BCryptOpenAlgorithmProvider")

--- a/include/fast_io_crypto/platforms/win32/msvc_linker_32.h
+++ b/include/fast_io_crypto/platforms/win32/msvc_linker_32.h
@@ -1,15 +1,11 @@
-﻿#pragma once
+#pragma once
 
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?BCryptOpenAlgorithmProvider@win32@fast_io@@YAIPAPAXPB_S1I@Z=__imp_BCryptOpenAlgorithmProvider")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?BCryptCloseAlgorithmProvider@win32@fast_io@@YAIPAXI@Z=__imp_BCryptCloseAlgorithmProvider")
-#pragma comment(linker, \
-				"/alternatename:__imp_?BCryptGetProperty@win32@fast_io@@YAIPAXPB_S0IPAII@Z=__imp_BCryptGetProperty")
-#pragma comment(linker, \
-				"/alternatename:__imp_?BCryptCreateHash@win32@fast_io@@YAIPAXPAPAX0I0II@Z=__imp_BCryptCreateHash")
-#pragma comment(linker, "/alternatename:__imp_?BCryptHashData@win32@fast_io@@YAIPAXPBXII@Z=__imp_BCryptHashData")
-#pragma comment(linker, "/alternatename:__imp_?BCryptFinishHash@win32@fast_io@@YAIPAX0II@Z=__imp_BCryptFinishHash")
-#pragma comment(linker, "/alternatename:__imp_?BCryptDestroyHash@win32@fast_io@@YAIPAX@Z=__imp_BCryptDestroyHash")
+// clang-format off
+#pragma comment(linker,"/alternatename:__imp_?BCryptOpenAlgorithmProvider@win32@fast_io@@YAIPAPAXPB_S1I@Z=__imp_BCryptOpenAlgorithmProvider")
+#pragma comment(linker,"/alternatename:__imp_?BCryptCloseAlgorithmProvider@win32@fast_io@@YAIPAXI@Z=__imp_BCryptCloseAlgorithmProvider")
+#pragma comment(linker,"/alternatename:__imp_?BCryptGetProperty@win32@fast_io@@YAIPAXPB_S0IPAII@Z=__imp_BCryptGetProperty")
+#pragma comment(linker,"/alternatename:__imp_?BCryptCreateHash@win32@fast_io@@YAIPAXPAPAX0I0II@Z=__imp_BCryptCreateHash")
+#pragma comment(linker,"/alternatename:__imp_?BCryptHashData@win32@fast_io@@YAIPAXPBXII@Z=__imp_BCryptHashData")
+#pragma comment(linker,"/alternatename:__imp_?BCryptFinishHash@win32@fast_io@@YAIPAX0II@Z=__imp_BCryptFinishHash")
+#pragma comment(linker,"/alternatename:__imp_?BCryptDestroyHash@win32@fast_io@@YAIPAX@Z=__imp_BCryptDestroyHash")
+// clang-format on

--- a/include/fast_io_crypto/platforms/win32/msvc_linker_32_i686.h
+++ b/include/fast_io_crypto/platforms/win32/msvc_linker_32_i686.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 // clang-format off
 #pragma comment(linker,"/alternatename:__imp_?BCryptOpenAlgorithmProvider@win32@fast_io@@YGIPAPAXPB_S1I@Z=__imp__BCryptOpenAlgorithmProvider@16")

--- a/include/fast_io_crypto/platforms/win32/msvc_linker_32_i686.h
+++ b/include/fast_io_crypto/platforms/win32/msvc_linker_32_i686.h
@@ -1,15 +1,11 @@
-﻿#pragma once
+#pragma once
 
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?BCryptOpenAlgorithmProvider@win32@fast_io@@YGIPAPAXPB_S1I@Z=__imp__BCryptOpenAlgorithmProvider@16")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?BCryptCloseAlgorithmProvider@win32@fast_io@@YGIPAXI@Z=__imp__BCryptCloseAlgorithmProvider@8")
-#pragma comment( \
-	linker, "/alternatename:__imp_?BCryptGetProperty@win32@fast_io@@YGIPAXPB_S0IPAII@Z=__imp__BCryptGetProperty@24")
-#pragma comment(linker, \
-				"/alternatename:__imp_?BCryptCreateHash@win32@fast_io@@YGIPAXPAPAX0I0II@Z=__imp__BCryptCreateHash@28")
-#pragma comment(linker, "/alternatename:__imp_?BCryptHashData@win32@fast_io@@YGIPAXPBXII@Z=__imp__BCryptHashData@16")
-#pragma comment(linker, "/alternatename:__imp_?BCryptFinishHash@win32@fast_io@@YGIPAX0II@Z=__imp__BCryptFinishHash@16")
-#pragma comment(linker, "/alternatename:__imp_?BCryptDestroyHash@win32@fast_io@@YGIPAX@Z=__imp__BCryptDestroyHash@4")
+// clang-format off
+#pragma comment(linker,"/alternatename:__imp_?BCryptOpenAlgorithmProvider@win32@fast_io@@YGIPAPAXPB_S1I@Z=__imp__BCryptOpenAlgorithmProvider@16")
+#pragma comment(linker,"/alternatename:__imp_?BCryptCloseAlgorithmProvider@win32@fast_io@@YGIPAXI@Z=__imp__BCryptCloseAlgorithmProvider@8")
+#pragma comment(linker,"/alternatename:__imp_?BCryptGetProperty@win32@fast_io@@YGIPAXPB_S0IPAII@Z=__imp__BCryptGetProperty@24")
+#pragma comment(linker,"/alternatename:__imp_?BCryptCreateHash@win32@fast_io@@YGIPAXPAPAX0I0II@Z=__imp__BCryptCreateHash@28")
+#pragma comment(linker,"/alternatename:__imp_?BCryptHashData@win32@fast_io@@YGIPAXPBXII@Z=__imp__BCryptHashData@16")
+#pragma comment(linker,"/alternatename:__imp_?BCryptFinishHash@win32@fast_io@@YGIPAX0II@Z=__imp__BCryptFinishHash@16")
+#pragma comment(linker,"/alternatename:__imp_?BCryptDestroyHash@win32@fast_io@@YGIPAX@Z=__imp__BCryptDestroyHash@4")
+// clang-format on

--- a/include/fast_io_crypto/platforms/win32/msvc_linker_64.h
+++ b/include/fast_io_crypto/platforms/win32/msvc_linker_64.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 // clang-format off
 #pragma comment(linker,"/alternatename:__imp_?BCryptOpenAlgorithmProvider@win32@fast_io@@YAIPEAPEAXPEB_S1I@Z=__imp_BCryptOpenAlgorithmProvider")

--- a/include/fast_io_crypto/platforms/win32/msvc_linker_64.h
+++ b/include/fast_io_crypto/platforms/win32/msvc_linker_64.h
@@ -1,15 +1,11 @@
-﻿#pragma once
+#pragma once
 
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?BCryptOpenAlgorithmProvider@win32@fast_io@@YAIPEAPEAXPEB_S1I@Z=__imp_BCryptOpenAlgorithmProvider")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?BCryptCloseAlgorithmProvider@win32@fast_io@@YAIPEAXI@Z=__imp_BCryptCloseAlgorithmProvider")
-#pragma comment( \
-	linker, "/alternatename:__imp_?BCryptGetProperty@win32@fast_io@@YAIPEAXPEB_S0IPEAII@Z=__imp_BCryptGetProperty")
-#pragma comment(linker, \
-				"/alternatename:__imp_?BCryptCreateHash@win32@fast_io@@YAIPEAXPEAPEAX0I0II@Z=__imp_BCryptCreateHash")
-#pragma comment(linker, "/alternatename:__imp_?BCryptHashData@win32@fast_io@@YAIPEAXPEBXII@Z=__imp_BCryptHashData")
-#pragma comment(linker, "/alternatename:__imp_?BCryptFinishHash@win32@fast_io@@YAIPEAX0II@Z=__imp_BCryptFinishHash")
-#pragma comment(linker, "/alternatename:__imp_?BCryptDestroyHash@win32@fast_io@@YAIPEAX@Z=__imp_BCryptDestroyHash")
+// clang-format off
+#pragma comment(linker,"/alternatename:__imp_?BCryptOpenAlgorithmProvider@win32@fast_io@@YAIPEAPEAXPEB_S1I@Z=__imp_BCryptOpenAlgorithmProvider")
+#pragma comment(linker,"/alternatename:__imp_?BCryptCloseAlgorithmProvider@win32@fast_io@@YAIPEAXI@Z=__imp_BCryptCloseAlgorithmProvider")
+#pragma comment(linker,"/alternatename:__imp_?BCryptGetProperty@win32@fast_io@@YAIPEAXPEB_S0IPEAII@Z=__imp_BCryptGetProperty")
+#pragma comment(linker,"/alternatename:__imp_?BCryptCreateHash@win32@fast_io@@YAIPEAXPEAPEAX0I0II@Z=__imp_BCryptCreateHash")
+#pragma comment(linker,"/alternatename:__imp_?BCryptHashData@win32@fast_io@@YAIPEAXPEBXII@Z=__imp_BCryptHashData")
+#pragma comment(linker,"/alternatename:__imp_?BCryptFinishHash@win32@fast_io@@YAIPEAX0II@Z=__imp_BCryptFinishHash")
+#pragma comment(linker,"/alternatename:__imp_?BCryptDestroyHash@win32@fast_io@@YAIPEAX@Z=__imp_BCryptDestroyHash")
+// clang-format on

--- a/include/fast_io_dsal/array.h
+++ b/include/fast_io_dsal/array.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 #undef min
 #undef max
 

--- a/include/fast_io_dsal/impl/array.h
+++ b/include/fast_io_dsal/impl/array.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 namespace fast_io::containers
 {

--- a/include/fast_io_dsal/impl/common.h
+++ b/include/fast_io_dsal/impl/common.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 namespace fast_io
 {

--- a/include/fast_io_dsal/impl/deque.h
+++ b/include/fast_io_dsal/impl/deque.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 namespace fast_io
 {

--- a/include/fast_io_dsal/impl/forward_list.h
+++ b/include/fast_io_dsal/impl/forward_list.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 namespace fast_io
 {

--- a/include/fast_io_dsal/impl/freestanding.h
+++ b/include/fast_io_dsal/impl/freestanding.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 namespace fast_io::freestanding
 {

--- a/include/fast_io_dsal/impl/index_span.h
+++ b/include/fast_io_dsal/impl/index_span.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 namespace fast_io::containers
 {

--- a/include/fast_io_dsal/impl/list.h
+++ b/include/fast_io_dsal/impl/list.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 namespace fast_io
 {

--- a/include/fast_io_dsal/impl/priority_queue.h
+++ b/include/fast_io_dsal/impl/priority_queue.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 namespace fast_io::containers
 {

--- a/include/fast_io_dsal/impl/queue.h
+++ b/include/fast_io_dsal/impl/queue.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 namespace fast_io
 {

--- a/include/fast_io_dsal/impl/span.h
+++ b/include/fast_io_dsal/impl/span.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 namespace fast_io::containers
 {

--- a/include/fast_io_dsal/impl/stack.h
+++ b/include/fast_io_dsal/impl/stack.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 namespace fast_io
 {

--- a/include/fast_io_dsal/impl/string.h
+++ b/include/fast_io_dsal/impl/string.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 namespace fast_io::containers
 {

--- a/include/fast_io_dsal/index_span.h
+++ b/include/fast_io_dsal/index_span.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 #undef min
 #undef max
 

--- a/include/fast_io_dsal/priority_queue.h
+++ b/include/fast_io_dsal/priority_queue.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 #include "vector.h"
 #include "impl/priority_queue.h"
 

--- a/include/fast_io_dsal/queue.h
+++ b/include/fast_io_dsal/queue.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 #include "deque.h"
 #include "impl/queue.h"
 

--- a/include/fast_io_dsal/span.h
+++ b/include/fast_io_dsal/span.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 #undef min
 #undef max
 

--- a/include/fast_io_dsal/stack.h
+++ b/include/fast_io_dsal/stack.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 #include "deque.h"
 #include "impl/stack.h"
 

--- a/include/fast_io_dsal/string.h
+++ b/include/fast_io_dsal/string.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 #undef min
 #undef max
 

--- a/include/fast_io_freestanding_impl/transcoders/transcoder_file.h
+++ b/include/fast_io_freestanding_impl/transcoders/transcoder_file.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 namespace fast_io
 {

--- a/include/fast_io_hosted/file_loaders/file_size.h
+++ b/include/fast_io_hosted/file_loaders/file_size.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #if defined(__has_builtin)
 #if !__has_builtin(__builtin_malloc) || !__has_builtin(__builtin_free)

--- a/include/fast_io_hosted/filesystem/dos.h
+++ b/include/fast_io_hosted/filesystem/dos.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include <libc/fd_props.h>
 #include <dirent.h>

--- a/include/fast_io_hosted/filesystem/dos_at.h
+++ b/include/fast_io_hosted/filesystem/dos_at.h
@@ -1,1 +1,1 @@
-#pragma once
+﻿#pragma once

--- a/include/fast_io_hosted/filesystem/win9x.h
+++ b/include/fast_io_hosted/filesystem/win9x.h
@@ -1,1 +1,1 @@
-#pragma once
+﻿#pragma once

--- a/include/fast_io_hosted/filesystem/win9x_at.h
+++ b/include/fast_io_hosted/filesystem/win9x_at.h
@@ -1,1 +1,1 @@
-#pragma once
+﻿#pragma once

--- a/include/fast_io_hosted/mmap/allocation_options.h
+++ b/include/fast_io_hosted/mmap/allocation_options.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 namespace fast_io
 {

--- a/include/fast_io_hosted/mmap/impl.h
+++ b/include/fast_io_hosted/mmap/impl.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #if defined(_WIN32) || defined(__CYGWIN__) || defined(__WINE__)
 #include "nt_options.h"

--- a/include/fast_io_hosted/mmap/nt.h
+++ b/include/fast_io_hosted/mmap/nt.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 namespace fast_io
 {

--- a/include/fast_io_hosted/mmap/nt_options.h
+++ b/include/fast_io_hosted/mmap/nt_options.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 namespace fast_io
 {

--- a/include/fast_io_hosted/mmap/posix.h
+++ b/include/fast_io_hosted/mmap/posix.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 namespace fast_io
 {

--- a/include/fast_io_hosted/mmap/posix_options.h
+++ b/include/fast_io_hosted/mmap/posix_options.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 namespace fast_io
 {

--- a/include/fast_io_hosted/mmap/win32.h
+++ b/include/fast_io_hosted/mmap/win32.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 namespace fast_io
 {

--- a/include/fast_io_hosted/mmap/win32_options.h
+++ b/include/fast_io_hosted/mmap/win32_options.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 namespace fast_io
 {

--- a/include/fast_io_hosted/platforms/win32/apis.h
+++ b/include/fast_io_hosted/platforms/win32/apis.h
@@ -2108,7 +2108,7 @@ extern int
 #if (!__has_cpp_attribute(__gnu__::__stdcall__) && !defined(__WINE__)) && defined(_MSC_VER)
 	__stdcall
 #endif
-	sendto(::std::size_t, const char *, int, int, const void *, int) noexcept
+	sendto(::std::size_t, char const *, int, int, void const *, int) noexcept
 #if defined(__clang__) || defined(__GNUC__)
 #if SIZE_MAX <= UINT_LEAST32_MAX && (defined(__x86__) || defined(_M_IX86) || defined(__i386__))
 #if !defined(__clang__)

--- a/include/fast_io_hosted/platforms/win32/msvc_linker_32.h
+++ b/include/fast_io_hosted/platforms/win32/msvc_linker_32.h
@@ -1,378 +1,194 @@
-﻿#pragma once
+#pragma once
 
-#pragma comment(linker, "/alternatename:__imp_?GetLastError@win32@fast_io@@YAIXZ=__imp_GetLastError")
-#pragma comment(linker, "/alternatename:__imp_?LoadLibraryA@win32@fast_io@@YAPAXPBD@Z=__imp_LoadLibraryA")
-#pragma comment(linker, "/alternatename:__imp_?LoadLibraryW@win32@fast_io@@YAPAXPB_S@Z=__imp_LoadLibraryW")
-#pragma comment(linker, "/alternatename:__imp_?LoadLibraryExA@win32@fast_io@@YAPAXPBDPAXI@Z=__imp_LoadLibraryExA")
-#pragma comment(linker, "/alternatename:__imp_?LoadLibraryExW@win32@fast_io@@YAPAXPB_SPAXI@Z=__imp_LoadLibraryExW")
-#pragma comment(linker, "/alternatename:__imp_?FormatMessageA@win32@fast_io@@YAIIPBDIIPADIPAX@Z=__imp_FormatMessageA")
-#pragma comment(linker, "/alternatename:__imp_?FormatMessageW@win32@fast_io@@YAIIPB_SIIPA_SIPAX@Z=__imp_FormatMessageW")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?CreateFileMappingA@win32@fast_io@@YAPAXPAXPAUsecurity_attributes@12@IIIPBD@Z=__imp_CreateFileMappingA")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?CreateFileMappingW@win32@fast_io@@YAPAXPAXPAUsecurity_attributes@12@IIIPB_S@Z=__imp_CreateFileMappingW")
-#pragma comment(linker, "/alternatename:__imp_?MapViewOfFile@win32@fast_io@@YAPAXPAXIIII@Z=__imp_MapViewOfFile")
-#pragma comment(linker, "/alternatename:__imp_?SetEndOfFile@win32@fast_io@@YAHPAX@Z=__imp_SetEndOfFile")
-#pragma comment(linker, "/alternatename:__imp_?UnmapViewOfFile@win32@fast_io@@YAHPBX@Z=__imp_UnmapViewOfFile")
-#pragma comment(linker, \
-				"/alternatename:__imp_?WriteFile@win32@fast_io@@YAHPAXPBXIPAIPAUoverlapped@12@@Z=__imp_WriteFile")
-#pragma comment(linker, "/alternatename:__imp_?ReadFile@win32@fast_io@@YAHPAXPBXIPAIPAUoverlapped@12@@Z=__imp_ReadFile")
-#pragma comment(linker, "/alternatename:__imp_?SetFilePointer@win32@fast_io@@YAIPAXHPAHI@Z=__imp_SetFilePointer")
-#pragma comment(linker, "/alternatename:__imp_?SetFilePointerEx@win32@fast_io@@YAHPAX_JPA_JI@Z=__imp_SetFilePointerEx")
-#pragma comment(linker, "/alternatename:__imp_?DuplicateHandle@win32@fast_io@@YAHPAX00PAPAXIHI@Z=__imp_DuplicateHandle")
-#pragma comment(linker, "/alternatename:__imp_?GetStdHandle@win32@fast_io@@YAPAXI@Z=__imp_GetStdHandle")
-#pragma comment( \
-	linker, "/alternatename:__imp_?CreatePipe@win32@fast_io@@YAHPAPAX0PAUsecurity_attributes@12@I@Z=__imp_CreatePipe")
-#pragma comment(linker, "/alternatename:__imp_?FreeLibrary@win32@fast_io@@YAHPAX@Z=__imp_FreeLibrary")
-#pragma comment(linker, "/alternatename:__imp_?GetProcAddress@win32@fast_io@@YAP6AHX_EPAXPBD@Z=__imp_GetProcAddress")
-#pragma comment(linker, "/alternatename:__imp_?GetModuleHandleA@win32@fast_io@@YAPAXPBD@Z=__imp_GetModuleHandleA")
-#pragma comment(linker, "/alternatename:__imp_?GetModuleHandleW@win32@fast_io@@YAPAXPB_S@Z=__imp_GetModuleHandleW")
-#pragma comment(linker, "/alternatename:__imp_?WaitForSingleObject@win32@fast_io@@YAIPAXI@Z=__imp_WaitForSingleObject")
-#pragma comment(linker, "/alternatename:__imp_?CancelIo@win32@fast_io@@YAIPAX@Z=__imp_CancelIo")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?GetFileInformationByHandle@win32@fast_io@@YAHPIAXPIAUby_handle_file_information@12@@Z=__imp_GetFileInformationByHandle")
-#pragma comment( \
-	linker, "/alternatename:__imp_?GetUserDefaultLocaleName@win32@fast_io@@YAHPA_SH@Z=__imp_GetUserDefaultLocaleName")
-#pragma comment(linker, "/alternatename:__imp_?GetUserDefaultLCID@win32@fast_io@@YAIXZ=__imp_GetUserDefaultLCID")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?GetSystemTimePreciseAsFileTime@win32@fast_io@@YAXPAUfiletime@12@@Z=__imp_GetSystemTimePreciseAsFileTime")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?GetSystemTimeAsFileTime@win32@fast_io@@YAXPAUfiletime@12@@Z=__imp_GetSystemTimeAsFileTime")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?QueryUnbiasedInterruptTime@win32@fast_io@@YAHPA_K@Z=__imp_QueryUnbiasedInterruptTime")
-#pragma comment( \
-	linker, "/alternatename:__imp_?QueryPerformanceCounter@win32@fast_io@@YAHPA_J@Z=__imp_QueryPerformanceCounter")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?QueryPerformanceFrequency@win32@fast_io@@YAHPA_J@Z=__imp_QueryPerformanceFrequency")
-#pragma comment( \
-	linker, "/alternatename:__imp_?GetProcessTimes@win32@fast_io@@YAHPAXPAUfiletime@12@111@Z=__imp_GetProcessTimes")
-#pragma comment(linker, \
-				"/alternatename:__imp_?GetThreadTimes@win32@fast_io@@YAHPAXPAUfiletime@12@111@Z=__imp_GetThreadTimes")
-#pragma comment(linker, \
-				"/alternatename:__imp_?GetHandleInformation@win32@fast_io@@YAHPAXPAI@Z=__imp_GetHandleInformation")
-#pragma comment(linker, \
-				"/alternatename:__imp_?SetHandleInformation@win32@fast_io@@YAHPAXII@Z=__imp_SetHandleInformation")
-#pragma comment(linker, "/alternatename:__imp_?GetTempPathA@win32@fast_io@@YAIIPAD@Z=__imp_GetTempPathA")
-#pragma comment(linker, "/alternatename:__imp_?GetTempPathW@win32@fast_io@@YAIIPA_S@Z=__imp_GetTempPathW")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?CreateFileA@win32@fast_io@@YAPAXPBDIIPAUsecurity_attributes@12@IIPAX@Z=__imp_CreateFileA")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?CreateFileW@win32@fast_io@@YAPAXPB_SIIPAUsecurity_attributes@12@IIPAX@Z=__imp_CreateFileW")
-#pragma comment( \
-	linker, "/alternatename:__imp_?CreateIoCompletionPort@win32@fast_io@@YAPAXPAX0II@Z=__imp_CreateIoCompletionPort")
-#pragma comment(linker, "/alternatename:__imp_?SystemFunction036@win32@fast_io@@YAHPAXI@Z=__imp_SystemFunction036")
-#pragma comment(linker, "/alternatename:__imp_?CloseHandle@win32@fast_io@@YAHPAX@Z=__imp_CloseHandle")
-#pragma comment(linker, \
-				"/alternatename:__imp_?LockFileEx@win32@fast_io@@YAHPAXIIIIPAUoverlapped@12@@Z=__imp_LockFileEx")
-#pragma comment(linker, \
-				"/alternatename:__imp_?UnlockFileEx@win32@fast_io@@YAHPAXIIIPAUoverlapped@12@@Z=__imp_UnlockFileEx")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?DeviceIoControl@win32@fast_io@@YAHPAXI0I0I0PAUoverlapped@12@@Z=__imp_DeviceIoControl")
-#pragma comment(linker, "/alternatename:__imp_?GetFileType@win32@fast_io@@YAIPAX@Z=__imp_GetFileType")
-#pragma comment(linker, "/alternatename:__imp_?GetACP@win32@fast_io@@YAIXZ=__imp_GetACP")
-#pragma comment( \
-	linker, "/alternatename:__imp_?GetEnvironmentVariableA@win32@fast_io@@YAIPBDPADI@Z=__imp_GetEnvironmentVariableA")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?GetEnvironmentVariableW@win32@fast_io@@YAIPB_SPA_SI@Z=__imp_GetEnvironmentVariableW")
-#pragma comment(linker, "/alternatename:__imp_?MessageBoxA@win32@fast_io@@YAIPAXPBD1I@Z=__imp_MessageBoxA")
-#pragma comment(linker, "/alternatename:__imp_?MessageBoxW@win32@fast_io@@YAIPAXPB_S1I@Z=__imp_MessageBoxW")
-#pragma comment(linker, "/alternatename:__imp_?GetConsoleMode@win32@fast_io@@YAHPAXPAI@Z=__imp_GetConsoleMode")
-#pragma comment(linker, "/alternatename:__imp_?SetConsoleMode@win32@fast_io@@YAHPAXI@Z=__imp_SetConsoleMode")
-#pragma comment(linker, "/alternatename:__imp_?ReadConsoleA@win32@fast_io@@YAHPAX0IPAI0@Z=__imp_ReadConsoleA")
-#pragma comment(linker, "/alternatename:__imp_?ReadConsoleW@win32@fast_io@@YAHPAX0IPAI0@Z=__imp_ReadConsoleW")
-#pragma comment(linker, "/alternatename:__imp_?WriteConsoleA@win32@fast_io@@YAHPAXPBXIPAI0@Z=__imp_WriteConsoleA")
-#pragma comment(linker, "/alternatename:__imp_?WriteConsoleW@win32@fast_io@@YAHPAXPBXIPAI0@Z=__imp_WriteConsoleW")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?GetConsoleScreenBufferInfo@win32@fast_io@@YAHPAXPAUconsole_screen_buffer_info@12@@Z=__imp_GetConsoleScreenBufferInfo")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?ScrollConsoleScreenBufferA@win32@fast_io@@YAHPAXPBUsmall_rect@12@1Ucoord@12@PBUchar_info@12@@Z=__imp_ScrollConsoleScreenBufferA")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?ScrollConsoleScreenBufferW@win32@fast_io@@YAHPAXPBUsmall_rect@12@1Ucoord@12@PBUchar_info@12@@Z=__imp_ScrollConsoleScreenBufferW")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?SetConsoleCursorPosition@win32@fast_io@@YAHPAXUcoord@12@@Z=__imp_SetConsoleCursorPosition")
-#pragma comment( \
-	linker, "/alternatename:__imp_?InitializeCriticalSection@win32@fast_io@@YAXPAX@Z=__imp_InitializeCriticalSection")
-#pragma comment(linker, "/alternatename:__imp_?EnterCriticalSection@win32@fast_io@@YAXPAX@Z=__imp_EnterCriticalSection")
-#pragma comment(linker, \
-				"/alternatename:__imp_?TryEnterCriticalSection@win32@fast_io@@YAHPAX@Z=__imp_TryEnterCriticalSection")
-#pragma comment(linker, "/alternatename:__imp_?LeaveCriticalSection@win32@fast_io@@YAXPAX@Z=__imp_LeaveCriticalSection")
-#pragma comment(linker, \
-				"/alternatename:__imp_?DeleteCriticalSection@win32@fast_io@@YAXPAX@Z=__imp_DeleteCriticalSection")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?WSADuplicateSocketA@win32@fast_io@@YAHPAXIPAUwsaprotocol_infoa@12@@Z=__imp_WSADuplicateSocketA")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?WSADuplicateSocketW@win32@fast_io@@YAXPAXIPAUwsaprotocol_infow@12@@Z=__imp_WSADuplicateSocketW")
-#pragma comment(linker, "/alternatename:__imp_?WSACleanup@win32@fast_io@@YAHXZ=__imp_WSACleanup")
-#pragma comment(linker, "/alternatename:__imp_?WSAStartup@win32@fast_io@@YAHIPAUwsadata@12@@Z=__imp_WSAStartup")
-#pragma comment(linker, "/alternatename:__imp_?WSAGetLastError@win32@fast_io@@YAHXZ=__imp_WSAGetLastError")
-#pragma comment(linker, "/alternatename:__imp_?closesocket@win32@fast_io@@YAHI@Z=__imp_closesocket")
-#pragma comment(linker, \
-				"/alternatename:__imp_?WSASocketW@win32@fast_io@@YAIHHHPAUwsaprotocol_infow@12@II@Z=__imp_WSASocketW")
-#pragma comment(linker, \
-				"/alternatename:__imp_?WSASocketA@win32@fast_io@@YAIHHHPAUwsaprotocol_infoa@12@II@Z=__imp_WSASocketA")
-#pragma comment(linker, "/alternatename:__imp_?bind@win32@fast_io@@YAHIPBXH@Z=__imp_bind")
-#pragma comment(linker, "/alternatename:__imp_?listen@win32@fast_io@@YAHIH@Z=__imp_listen")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?WSAAccept@win32@fast_io@@YAIIPBXPAHP6AXPAUwsabuf@12@2PAUqualityofservice@12@322PAII@_EI@Z=__imp_WSAAccept")
-#pragma comment(linker, "/alternatename:__imp_?ioctlsocket@win32@fast_io@@YAHIJPAI@Z=__imp_ioctlsocket")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?WSASend@win32@fast_io@@YAHIPAUwsabuf@12@IPAIIPAUoverlapped@12@P6AXII2I@_E@Z=__imp_WSASend")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?WSASendMsg@win32@fast_io@@YAHIPAUwsamsg@12@IPAIPAUoverlapped@12@P6AXII2I@_E@Z=__imp_WSASendMsg")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?WSASendTo@win32@fast_io@@YAHIPAUwsabuf@12@IPAIIPBXHPAUoverlapped@12@P6AXII3I@_E@Z=__imp_WSASendTo")
-#pragma comment(linker, "/alternatename:__imp_?recv@win32@fast_io@@YAHIPADHH@Z=__imp_recv")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?WSARecv@win32@fast_io@@YAHIPAUwsabuf@12@IPAI1PAUoverlapped@12@P6AXII2I@_E@Z=__imp_WSARecv")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?WSARecvFrom@win32@fast_io@@YAHIPAUwsabuf@12@IPAI1PAXPAHPAUoverlapped@12@P6AXII4I@_E@Z=__imp_WSARecvFrom")
-#pragma comment(linker, "/alternatename:__imp_?connect@win32@fast_io@@YAHIPBXH@Z=__imp_connect")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?WSAConnect@win32@fast_io@@YAHIPBXHPAUwsabuf@12@1PAUqualityofservice@12@2@Z=__imp_WSAConnect")
-#pragma comment(linker, "/alternatename:__imp_?recvfrom@win32@fast_io@@YAHIPADHHPAXPAH@Z=__imp_recvfrom")
-#pragma comment(linker, "/alternatename:__imp_?sendto@win32@fast_io@@YAHIPBDHHPBXH@Z=__imp_sendto")
-#pragma comment(linker, "/alternatename:__imp_?shutdown@win32@fast_io@@YAHIPBXH@Z=__imp_shutdown")
-#pragma comment(linker, "/alternatename:__imp_?GetCurrentProcessId@win32@fast_io@@YAIXZ=__imp_GetCurrentProcessId")
-#pragma comment(linker, "/alternatename:__imp_?FlushFileBuffers@win32@fast_io@@YAHPAX@Z=__imp_FlushFileBuffers")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?GetQueuedCompletionStatus@win32@fast_io@@YAHPAXPAI1PAUoverlapped@12@I@Z=__imp_GetQueuedCompletionStatus")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?freeaddrinfo@win32@fast_io@@YAXPAU?$win32_family_addrinfo@$0A@@12@@Z=__imp_freeaddrinfo")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?FreeAddrInfoW@win32@fast_io@@YAXPAU?$win32_family_addrinfo@$00@12@@Z=__imp_FreeAddrInfoW")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?getaddrinfo@win32@fast_io@@YAHPBD0PBU?$win32_family_addrinfo@$0A@@12@PAPAU312@@Z=__imp_getaddrinfo")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?GetAddrInfoW@win32@fast_io@@YAHPB_S0PBU?$win32_family_addrinfo@$00@12@PAPAU312@@Z=__imp_GetAddrInfoW")
-#pragma comment( \
-	linker, "/alternatename:__imp_?CryptAcquireContextA@win32@fast_io@@YAHPAIPB_Q1II@Z=__imp_CryptAcquireContextA")
-#pragma comment( \
-	linker, "/alternatename:__imp_?CryptAcquireContextW@win32@fast_io@@YAHPAIPB_S1II@Z=__imp_CryptAcquireContextW")
-#pragma comment(linker, "/alternatename:__imp_?CryptReleaseContext@win32@fast_io@@YAHII@Z=__imp_CryptReleaseContext")
-#pragma comment(linker, "/alternatename:__imp_?CryptGenRandom@win32@fast_io@@YAHIIPAE@Z=__imp_CryptGenRandom")
-#pragma comment(linker, "/alternatename:__imp_?RegOpenKeyA@win32@fast_io@@YAHIPB_QPAI@Z=__imp_RegOpenKeyA")
-#pragma comment(linker, "/alternatename:__imp_?RegOpenKeyW@win32@fast_io@@YAHIPB_SPAI@Z=__imp_RegOpenKeyW")
-#pragma comment(linker, \
-				"/alternatename:__imp_?RegQueryValueExA@win32@fast_io@@YAHIPB_QPAI1PAX1@Z=__imp_RegQueryValueExA")
-#pragma comment(linker, \
-				"/alternatename:__imp_?RegQueryValueExW@win32@fast_io@@YAHIPB_SPAI1PAX1@Z=__imp_RegQueryValueExW")
-#pragma comment(linker, "/alternatename:__imp_?RegCloseKey@win32@fast_io@@YAHI@Z=__imp_RegCloseKey")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?GetTimeZoneInformation@win32@fast_io@@YAIPAUtime_zone_information@12@@Z=__imp_GetTimeZoneInformation")
-#pragma comment( \
-	linker, "/alternatename:__imp_?rtl_nt_status_to_dos_error@nt@win32@fast_io@@YAII@Z=__imp_RtlNtStatusToDosError")
-#pragma comment(linker, "/alternatename:__imp_?NtClose@nt@win32@fast_io@@YAIPAX@Z=__imp_NtClose")
-#pragma comment(linker, "/alternatename:__imp_?ZwClose@nt@win32@fast_io@@YAIPAX@Z=__imp_ZwClose")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?NtCreateFile@nt@win32@fast_io@@YAIPAPAXIPAUobject_attributes@123@PAUio_status_block@123@PA_JIIIIPAXI@Z=__imp_NtCreateFile")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?ZwCreateFile@nt@win32@fast_io@@YAIPAPAXIPAUobject_attributes@123@PAUio_status_block@123@PA_JIIIIPAXI@Z=__imp_ZwCreateFile")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?NtCreateSection@nt@win32@fast_io@@YAIPIAPAXIPIAUobject_attributes@123@PA_KIIPIAX@Z=__imp_NtCreateSection")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?ZwCreateSection@nt@win32@fast_io@@YAIPIAPAXIPIAUobject_attributes@123@PA_KIIPIAX@Z=__imp_ZwCreateSection")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?NtQueryInformationProcess@nt@win32@fast_io@@YAIPIAXW4process_information_class@123@PAXIPAI@Z=__imp_NtQueryInformationProcess")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?ZwQueryInformationProcess@nt@win32@fast_io@@YAIPIAXW4process_information_class@123@PAXIPAI@Z=__imp_ZwQueryInformationProcess")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?NtWriteFile@nt@win32@fast_io@@YAIPAX0P6AX0PAUio_status_block@123@I@_E01PBXIPA_JPAI@Z=__imp_NtWriteFile")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?ZwWriteFile@nt@win32@fast_io@@YAIPAX0P6AX0PAUio_status_block@123@I@_E01PBXIPA_JPAI@Z=__imp_ZwWriteFile")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?NtReadFile@nt@win32@fast_io@@YAIPAX0P6AX0PAUio_status_block@123@I@_E01PBXIPA_JPAI@Z=__imp_NtReadFile")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?ZwReadFile@nt@win32@fast_io@@YAIPAX0P6AX0PAUio_status_block@123@I@_E01PBXIPA_JPAI@Z=__imp_ZwReadFile")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?NtQueryDirectoryFile@nt@win32@fast_io@@YAIPAX0P6AX0PAUio_status_block@123@I@_E010IW4file_information_class@123@HPAUunicode_string@123@H@Z=__imp_NtQueryDirectoryFile")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?ZwQueryDirectoryFile@nt@win32@fast_io@@YAIPAX0P6AX0PAUio_status_block@123@I@_E010IW4file_information_class@123@HPAUunicode_string@123@H@Z=__imp_ZwQueryDirectoryFile")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?NtQuerySection@nt@win32@fast_io@@YAIPAXW4section_information_class@123@0IPAI@Z=__imp_NtQuerySection")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?ZwQuerySection@nt@win32@fast_io@@YAIPAXW4section_information_class@123@0IPAI@Z=__imp_ZwQuerySection")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?NtQueryInformationFile@nt@win32@fast_io@@YAIPIAXPIAUio_status_block@123@0IW4file_information_class@123@@Z=__imp_NtQueryInformationFile")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?ZwQueryInformationFile@nt@win32@fast_io@@YAIPIAXPIAUio_status_block@123@0IW4file_information_class@123@@Z=__imp_ZwQueryInformationFile")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?NtSetInformationFile@nt@win32@fast_io@@YAIPIAXPIAUio_status_block@123@0IW4file_information_class@123@@Z=__imp_NtSetInformationFile")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?ZwSetInformationFile@nt@win32@fast_io@@YAIPIAXPIAUio_status_block@123@0IW4file_information_class@123@@Z=__imp_ZwSetInformationFile")
-#pragma comment( \
-	linker, "/alternatename:__imp_?NtDuplicateObject@nt@win32@fast_io@@YAIPAX00PAPAXIII@Z=__imp_NtDuplicateObject")
-#pragma comment( \
-	linker, "/alternatename:__imp_?ZwDuplicateObject@nt@win32@fast_io@@YAIPAX00PAPAXIII@Z=__imp_ZwDuplicateObject")
-#pragma comment( \
-	linker, "/alternatename:__imp_?NtWaitForSingleObject@nt@win32@fast_io@@YAIPAXHPA_K@Z=__imp_NtWaitForSingleObject")
-#pragma comment( \
-	linker, "/alternatename:__imp_?ZwWaitForSingleObject@nt@win32@fast_io@@YAIPAXHPA_K@Z=__imp_ZwWaitForSingleObject")
-#pragma comment(linker, "/alternatename:__imp_?NtSetSystemTime@nt@win32@fast_io@@YAIPA_K0@Z=__imp_NtSetSystemTime")
-#pragma comment(linker, "/alternatename:__imp_?ZwSetSystemTime@nt@win32@fast_io@@YAIPA_K0@Z=__imp_ZwSetSystemTime")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?NtCreateProcess@nt@win32@fast_io@@YAIPAPAXIPAUobject_attributes@123@PAXI222@Z=__imp_NtCreateProcess")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?ZwCreateProcess@nt@win32@fast_io@@YAIPAPAXIPAUobject_attributes@123@PAXI222@Z=__imp_ZwCreateProcess")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?rtl_dos_path_name_to_nt_path_name_u@nt@win32@fast_io@@YAEPB_SPAUunicode_string@123@PAPB_SPAUrtl_relative_name_u@123@@Z=__imp_RtlDosPathNameToNtPathName_U")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?rtl_dos_path_name_to_nt_path_name_u_with_status@nt@win32@fast_io@@YAIPB_SPAUunicode_string@123@PAPB_SPAUrtl_relative_name_u@123@@Z=__imp_RtlDosPathNameToNtPathName_U_WithStatus")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?rtl_free_unicode_string@nt@win32@fast_io@@YAXPAUunicode_string@123@@Z=__imp_RtlFreeUnicodeString")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?RtlInitializeCriticalSection@nt@win32@fast_io@@YAXPAX@Z=__imp_RtlInitializeCriticalSection")
-#pragma comment( \
-	linker, "/alternatename:__imp_?RtlEnterCriticalSection@nt@win32@fast_io@@YAXPAX@Z=__imp_RtlEnterCriticalSection")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?RtlTryEnterCriticalSection@nt@win32@fast_io@@YAHPAX@Z=__imp_RtlTryEnterCriticalSection")
-#pragma comment( \
-	linker, "/alternatename:__imp_?RtlLeaveCriticalSection@nt@win32@fast_io@@YAXPAX@Z=__imp_RtlLeaveCriticalSection")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?RtlDeleteCriticalSection@nt@win32@fast_io@@YAXPAX@Z=__imp_RtlDeleteCriticalSection")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?RtlCreateUserThread@nt@win32@fast_io@@YAIPAX0HIII00PAPAXPAUclient_id@123@@Z=__imp_RtlCreateUserThread")
-#pragma comment(linker, "/alternatename:__imp_?NtResumeThread@nt@win32@fast_io@@YAIPAXPAI@Z=__imp_NtResumeThread")
-#pragma comment(linker, "/alternatename:__imp_?ZwResumeThread@nt@win32@fast_io@@YAIPAXPAI@Z=__imp_ZwResumeThread")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?NtLockFile@nt@win32@fast_io@@YAIPAX0P6AX0PAUio_status_block@123@I@_E01PA_J3IEE@Z=__imp_NtLockFile")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?ZwLockFile@nt@win32@fast_io@@YAIPAX0P6AX0PAUio_status_block@123@I@_E01PA_J3IEE@Z=__imp_ZwLockFile")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?NtUnlockFile@nt@win32@fast_io@@YAIPAXPAUio_status_block@123@PA_J2I@Z=__imp_NtUnlockFile")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?ZwUnlockFile@nt@win32@fast_io@@YAIPAXPAUio_status_block@123@PA_J2I@Z=__imp_ZwUnlockFile")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?NtFlushBuffersFile@nt@win32@fast_io@@YAIPAXPAUio_status_block@123@@Z=__imp_NtFlushBuffersFile")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?ZwFlushBuffersFile@nt@win32@fast_io@@YAIPAXPAUio_status_block@123@@Z=__imp_ZwFlushBuffersFile")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?NtFlushBuffersFileEx@nt@win32@fast_io@@YAIPAXI0IPAUio_status_block@123@@Z=__imp_NtFlushBuffersFileEx")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?ZwFlushBuffersFileEx@nt@win32@fast_io@@YAIPAXI0IPAUio_status_block@123@@Z=__imp_ZwFlushBuffersFileEx")
-#pragma comment(linker, "/alternatename:__imp_?DbgPrint@nt@win32@fast_io@@YAIPBDZZ=__imp_DbgPrint")
-#pragma comment(linker, "/alternatename:__imp_?DbgPrintEx@nt@win32@fast_io@@YAIIIPBDZZ=__imp_DbgPrintEx")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?RtlCreateProcessParameters@nt@win32@fast_io@@YAIPAPAUrtl_user_process_parameters@123@PAUunicode_string@123@111PAX1111@Z=__imp_RtlCreateProcessParameters")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?RtlCreateProcessParametersEx@nt@win32@fast_io@@YAIPAPAUrtl_user_process_parameters@123@PAUunicode_string@123@111PAX1111I@Z=__imp_RtlCreateProcessParametersEx")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?RtlDestroyProcessParameters@nt@win32@fast_io@@YAIPAUrtl_user_process_parameters@123@@Z=__imp_RtlDestroyProcessParameters")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?NtCreateUserProcess@nt@win32@fast_io@@YAIPAX0IIPAUobject_attributes@123@1IIPAUrtl_user_process_parameters@123@PAUps_create_info@123@PAUps_attribute_list@123@@Z=__imp_NtCreateUserProcess")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?ZwCreateUserProcess@nt@win32@fast_io@@YAIPAX0IIPAUobject_attributes@123@1IIPAUrtl_user_process_parameters@123@PAUps_create_info@123@PAUps_attribute_list@123@@Z=__imp_ZwCreateUserProcess")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?RtlCreateUserProcess@nt@win32@fast_io@@YAIPAUunicode_string@123@IPAUrtl_user_process_parameters@123@PAUsecurity_descriptor@123@2PAXE33PAUrtl_user_process_information@123@@Z=__imp_RtlCreateUserProcess")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?NtMapViewOfSection@nt@win32@fast_io@@YAIPAX0PAPAXIIPBTlarge_integer@123@PAIW4section_inherit@123@II@Z=__imp_NtMapViewOfSection")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?ZwMapViewOfSection@nt@win32@fast_io@@YAIPAX0PAPAXIIPBTlarge_integer@123@PAIW4section_inherit@123@II@Z=__imp_ZwMapViewOfSection")
-#pragma comment(linker, \
-				"/alternatename:__imp_?NtUnmapViewOfSection@nt@win32@fast_io@@YAIPAX0@Z=__imp_NtUnmapViewOfSection")
-#pragma comment(linker, \
-				"/alternatename:__imp_?ZwUnmapViewOfSection@nt@win32@fast_io@@YAIPAX0@Z=__imp_ZwUnmapViewOfSection")
-#pragma comment(linker, "/alternatename:__imp_?SetConsoleCP@win32@fast_io@@YAHI@Z=__imp_SetConsoleCP")
-#pragma comment(linker, "/alternatename:__imp_?SetConsoleOutputCP@win32@fast_io@@YAHI@Z=__imp_SetConsoleOutputCP")
-#pragma comment(linker, "/alternatename:__imp_?GetConsoleCP@win32@fast_io@@YAIXZ=__imp_GetConsoleCP")
-#pragma comment(linker, "/alternatename:__imp_?GetConsoleOutputCP@win32@fast_io@@YAIXZ=__imp_GetConsoleOutputCP")
-#pragma comment( \
-	linker, "/alternatename:__imp_?NtReadVirtualMemory@nt@win32@fast_io@@YAIPAX00IPAI@Z=__imp_NtReadVirtualMemory")
-#pragma comment( \
-	linker, "/alternatename:__imp_?ZwReadVirtualMemory@nt@win32@fast_io@@YAIPAX00IPAI@Z=__imp_ZwReadVirtualMemory")
-#pragma comment( \
-	linker, "/alternatename:__imp_?NtWriteVirtualMemory@nt@win32@fast_io@@YAIPAX00IPAI@Z=__imp_NtWriteVirtualMemory")
-#pragma comment( \
-	linker, "/alternatename:__imp_?ZwWriteVirtualMemory@nt@win32@fast_io@@YAIPAX00IPAI@Z=__imp_ZwWriteVirtualMemory")
-#pragma comment(linker, "/alternatename:__imp_?RtlAcquirePebLock@nt@win32@fast_io@@YAIXZ=__imp_RtlAcquirePebLock")
-#pragma comment(linker, "/alternatename:__imp_?RtlReleasePebLock@nt@win32@fast_io@@YAIXZ=__imp_RtlReleasePebLock")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?NtAllocateVirtualMemory@nt@win32@fast_io@@YAIPAXPAPAXIPAIII@Z=__imp_NtAllocateVirtualMemory")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?ZwAllocateVirtualMemory@nt@win32@fast_io@@YAIPAXPAPAXIPAIII@Z=__imp_ZwAllocateVirtualMemory")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?NtQueryObject@nt@win32@fast_io@@YAIPAXW4object_information_class@123@0IPAI@Z=__imp_NtQueryObject")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?ZwQueryObject@nt@win32@fast_io@@YAIPAXW4object_information_class@123@0IPAI@Z=__imp_ZwQueryObject")
-
-#if defined(_DLL)
+// clang-format off
+#pragma comment(linker,"/alternatename:__imp_?GetLastError@win32@fast_io@@YAIXZ=__imp_GetLastError")
+#pragma comment(linker,"/alternatename:__imp_?LoadLibraryA@win32@fast_io@@YAPAXPBD@Z=__imp_LoadLibraryA")
+#pragma comment(linker,"/alternatename:__imp_?LoadLibraryW@win32@fast_io@@YAPAXPB_S@Z=__imp_LoadLibraryW")
+#pragma comment(linker,"/alternatename:__imp_?LoadLibraryExA@win32@fast_io@@YAPAXPBDPAXI@Z=__imp_LoadLibraryExA")
+#pragma comment(linker,"/alternatename:__imp_?LoadLibraryExW@win32@fast_io@@YAPAXPB_SPAXI@Z=__imp_LoadLibraryExW")
+#pragma comment(linker,"/alternatename:__imp_?FormatMessageA@win32@fast_io@@YAIIPBDIIPADIPAX@Z=__imp_FormatMessageA")
+#pragma comment(linker,"/alternatename:__imp_?FormatMessageW@win32@fast_io@@YAIIPB_SIIPA_SIPAX@Z=__imp_FormatMessageW")
+#pragma comment(linker,"/alternatename:__imp_?CreateFileMappingA@win32@fast_io@@YAPAXPAXPAUsecurity_attributes@12@IIIPBD@Z=__imp_CreateFileMappingA")
+#pragma comment(linker,"/alternatename:__imp_?CreateFileMappingW@win32@fast_io@@YAPAXPAXPAUsecurity_attributes@12@IIIPB_S@Z=__imp_CreateFileMappingW")
+#pragma comment(linker,"/alternatename:__imp_?MapViewOfFile@win32@fast_io@@YAPAXPAXIIII@Z=__imp_MapViewOfFile")
+#pragma comment(linker,"/alternatename:__imp_?SetEndOfFile@win32@fast_io@@YAHPAX@Z=__imp_SetEndOfFile")
+#pragma comment(linker,"/alternatename:__imp_?UnmapViewOfFile@win32@fast_io@@YAHPBX@Z=__imp_UnmapViewOfFile")
+#pragma comment(linker,"/alternatename:__imp_?WriteFile@win32@fast_io@@YAHPAXPBXIPAIPAUoverlapped@12@@Z=__imp_WriteFile")
+#pragma comment(linker,"/alternatename:__imp_?ReadFile@win32@fast_io@@YAHPAXPBXIPAIPAUoverlapped@12@@Z=__imp_ReadFile")
+#pragma comment(linker,"/alternatename:__imp_?SetFilePointer@win32@fast_io@@YAIPAXHPAHI@Z=__imp_SetFilePointer")
+#pragma comment(linker,"/alternatename:__imp_?SetFilePointerEx@win32@fast_io@@YAHPAX_JPA_JI@Z=__imp_SetFilePointerEx")
+#pragma comment(linker,"/alternatename:__imp_?DuplicateHandle@win32@fast_io@@YAHPAX00PAPAXIHI@Z=__imp_DuplicateHandle")
+#pragma comment(linker,"/alternatename:__imp_?GetStdHandle@win32@fast_io@@YAPAXI@Z=__imp_GetStdHandle")
+#pragma comment(linker,"/alternatename:__imp_?CreatePipe@win32@fast_io@@YAHPAPAX0PAUsecurity_attributes@12@I@Z=__imp_CreatePipe")
+#pragma comment(linker,"/alternatename:__imp_?FreeLibrary@win32@fast_io@@YAHPAX@Z=__imp_FreeLibrary")
+#pragma comment(linker,"/alternatename:__imp_?GetProcAddress@win32@fast_io@@YAP6AHX_EPAXPBD@Z=__imp_GetProcAddress")
+#pragma comment(linker,"/alternatename:__imp_?GetModuleHandleA@win32@fast_io@@YAPAXPBD@Z=__imp_GetModuleHandleA")
+#pragma comment(linker,"/alternatename:__imp_?GetModuleHandleW@win32@fast_io@@YAPAXPB_S@Z=__imp_GetModuleHandleW")
+#pragma comment(linker,"/alternatename:__imp_?WaitForSingleObject@win32@fast_io@@YAIPAXI@Z=__imp_WaitForSingleObject")
+#pragma comment(linker,"/alternatename:__imp_?CancelIo@win32@fast_io@@YAIPAX@Z=__imp_CancelIo")
+#pragma comment(linker,"/alternatename:__imp_?GetFileInformationByHandle@win32@fast_io@@YAHPIAXPIAUby_handle_file_information@12@@Z=__imp_GetFileInformationByHandle")
+#pragma comment(linker,"/alternatename:__imp_?GetUserDefaultLocaleName@win32@fast_io@@YAHPA_SH@Z=__imp_GetUserDefaultLocaleName")
+#pragma comment(linker,"/alternatename:__imp_?GetUserDefaultLCID@win32@fast_io@@YAIXZ=__imp_GetUserDefaultLCID")
+#pragma comment(linker,"/alternatename:__imp_?GetSystemTimePreciseAsFileTime@win32@fast_io@@YAXPAUfiletime@12@@Z=__imp_GetSystemTimePreciseAsFileTime")
+#pragma comment(linker,"/alternatename:__imp_?GetSystemTimeAsFileTime@win32@fast_io@@YAXPAUfiletime@12@@Z=__imp_GetSystemTimeAsFileTime")
+#pragma comment(linker,"/alternatename:__imp_?QueryUnbiasedInterruptTime@win32@fast_io@@YAHPA_K@Z=__imp_QueryUnbiasedInterruptTime")
+#pragma comment(linker,"/alternatename:__imp_?QueryPerformanceCounter@win32@fast_io@@YAHPA_J@Z=__imp_QueryPerformanceCounter")
+#pragma comment(linker,"/alternatename:__imp_?QueryPerformanceFrequency@win32@fast_io@@YAHPA_J@Z=__imp_QueryPerformanceFrequency")
+#pragma comment(linker,"/alternatename:__imp_?GetProcessTimes@win32@fast_io@@YAHPAXPAUfiletime@12@111@Z=__imp_GetProcessTimes")
+#pragma comment(linker,"/alternatename:__imp_?GetThreadTimes@win32@fast_io@@YAHPAXPAUfiletime@12@111@Z=__imp_GetThreadTimes")
+#pragma comment(linker,"/alternatename:__imp_?GetHandleInformation@win32@fast_io@@YAHPAXPAI@Z=__imp_GetHandleInformation")
+#pragma comment(linker,"/alternatename:__imp_?SetHandleInformation@win32@fast_io@@YAHPAXII@Z=__imp_SetHandleInformation")
+#pragma comment(linker,"/alternatename:__imp_?GetTempPathA@win32@fast_io@@YAIIPAD@Z=__imp_GetTempPathA")
+#pragma comment(linker,"/alternatename:__imp_?GetTempPathW@win32@fast_io@@YAIIPA_S@Z=__imp_GetTempPathW")
+#pragma comment(linker,"/alternatename:__imp_?CreateFileA@win32@fast_io@@YAPAXPBDIIPAUsecurity_attributes@12@IIPAX@Z=__imp_CreateFileA")
+#pragma comment(linker,"/alternatename:__imp_?CreateFileW@win32@fast_io@@YAPAXPB_SIIPAUsecurity_attributes@12@IIPAX@Z=__imp_CreateFileW")
+#pragma comment(linker,"/alternatename:__imp_?CreateIoCompletionPort@win32@fast_io@@YAPAXPAX0II@Z=__imp_CreateIoCompletionPort")
+#pragma comment(linker,"/alternatename:__imp_?SystemFunction036@win32@fast_io@@YAHPAXI@Z=__imp_SystemFunction036")
+#pragma comment(linker,"/alternatename:__imp_?CloseHandle@win32@fast_io@@YAHPAX@Z=__imp_CloseHandle")
+#pragma comment(linker,"/alternatename:__imp_?LockFileEx@win32@fast_io@@YAHPAXIIIIPAUoverlapped@12@@Z=__imp_LockFileEx")
+#pragma comment(linker,"/alternatename:__imp_?UnlockFileEx@win32@fast_io@@YAHPAXIIIPAUoverlapped@12@@Z=__imp_UnlockFileEx")
+#pragma comment(linker,"/alternatename:__imp_?DeviceIoControl@win32@fast_io@@YAHPAXI0I0I0PAUoverlapped@12@@Z=__imp_DeviceIoControl")
+#pragma comment(linker,"/alternatename:__imp_?GetFileType@win32@fast_io@@YAIPAX@Z=__imp_GetFileType")
+#pragma comment(linker,"/alternatename:__imp_?GetACP@win32@fast_io@@YAIXZ=__imp_GetACP")
+#pragma comment(linker,"/alternatename:__imp_?GetEnvironmentVariableA@win32@fast_io@@YAIPBDPADI@Z=__imp_GetEnvironmentVariableA")
+#pragma comment(linker,"/alternatename:__imp_?GetEnvironmentVariableW@win32@fast_io@@YAIPB_SPA_SI@Z=__imp_GetEnvironmentVariableW")
+#pragma comment(linker,"/alternatename:__imp_?MessageBoxA@win32@fast_io@@YAIPAXPBD1I@Z=__imp_MessageBoxA")
+#pragma comment(linker,"/alternatename:__imp_?MessageBoxW@win32@fast_io@@YAIPAXPB_S1I@Z=__imp_MessageBoxW")
+#pragma comment(linker,"/alternatename:__imp_?GetConsoleMode@win32@fast_io@@YAHPAXPAI@Z=__imp_GetConsoleMode")
+#pragma comment(linker,"/alternatename:__imp_?SetConsoleMode@win32@fast_io@@YAHPAXI@Z=__imp_SetConsoleMode")
+#pragma comment(linker,"/alternatename:__imp_?ReadConsoleA@win32@fast_io@@YAHPAX0IPAI0@Z=__imp_ReadConsoleA")
+#pragma comment(linker,"/alternatename:__imp_?ReadConsoleW@win32@fast_io@@YAHPAX0IPAI0@Z=__imp_ReadConsoleW")
+#pragma comment(linker,"/alternatename:__imp_?WriteConsoleA@win32@fast_io@@YAHPAXPBXIPAI0@Z=__imp_WriteConsoleA")
+#pragma comment(linker,"/alternatename:__imp_?WriteConsoleW@win32@fast_io@@YAHPAXPBXIPAI0@Z=__imp_WriteConsoleW")
+#pragma comment(linker,"/alternatename:__imp_?GetConsoleScreenBufferInfo@win32@fast_io@@YAHPAXPAUconsole_screen_buffer_info@12@@Z=__imp_GetConsoleScreenBufferInfo")
+#pragma comment(linker,"/alternatename:__imp_?ScrollConsoleScreenBufferA@win32@fast_io@@YAHPAXPBUsmall_rect@12@1Ucoord@12@PBUchar_info@12@@Z=__imp_ScrollConsoleScreenBufferA")
+#pragma comment(linker,"/alternatename:__imp_?ScrollConsoleScreenBufferW@win32@fast_io@@YAHPAXPBUsmall_rect@12@1Ucoord@12@PBUchar_info@12@@Z=__imp_ScrollConsoleScreenBufferW")
+#pragma comment(linker,"/alternatename:__imp_?SetConsoleCursorPosition@win32@fast_io@@YAHPAXUcoord@12@@Z=__imp_SetConsoleCursorPosition")
+#pragma comment(linker,"/alternatename:__imp_?InitializeCriticalSection@win32@fast_io@@YAXPAX@Z=__imp_InitializeCriticalSection")
+#pragma comment(linker,"/alternatename:__imp_?EnterCriticalSection@win32@fast_io@@YAXPAX@Z=__imp_EnterCriticalSection")
+#pragma comment(linker,"/alternatename:__imp_?TryEnterCriticalSection@win32@fast_io@@YAHPAX@Z=__imp_TryEnterCriticalSection")
+#pragma comment(linker,"/alternatename:__imp_?LeaveCriticalSection@win32@fast_io@@YAXPAX@Z=__imp_LeaveCriticalSection")
+#pragma comment(linker,"/alternatename:__imp_?DeleteCriticalSection@win32@fast_io@@YAXPAX@Z=__imp_DeleteCriticalSection")
+#pragma comment(linker,"/alternatename:__imp_?WSADuplicateSocketA@win32@fast_io@@YAHPAXIPAUwsaprotocol_infoa@12@@Z=__imp_WSADuplicateSocketA")
+#pragma comment(linker,"/alternatename:__imp_?WSADuplicateSocketW@win32@fast_io@@YAXPAXIPAUwsaprotocol_infow@12@@Z=__imp_WSADuplicateSocketW")
+#pragma comment(linker,"/alternatename:__imp_?WSACleanup@win32@fast_io@@YAHXZ=__imp_WSACleanup")
+#pragma comment(linker,"/alternatename:__imp_?WSAStartup@win32@fast_io@@YAHIPAUwsadata@12@@Z=__imp_WSAStartup")
+#pragma comment(linker,"/alternatename:__imp_?WSAGetLastError@win32@fast_io@@YAHXZ=__imp_WSAGetLastError")
+#pragma comment(linker,"/alternatename:__imp_?closesocket@win32@fast_io@@YAHI@Z=__imp_closesocket")
+#pragma comment(linker,"/alternatename:__imp_?WSASocketW@win32@fast_io@@YAIHHHPAUwsaprotocol_infow@12@II@Z=__imp_WSASocketW")
+#pragma comment(linker,"/alternatename:__imp_?WSASocketA@win32@fast_io@@YAIHHHPAUwsaprotocol_infoa@12@II@Z=__imp_WSASocketA")
+#pragma comment(linker,"/alternatename:__imp_?bind@win32@fast_io@@YAHIPBXH@Z=__imp_bind")
+#pragma comment(linker,"/alternatename:__imp_?listen@win32@fast_io@@YAHIH@Z=__imp_listen")
+#pragma comment(linker,"/alternatename:__imp_?WSAAccept@win32@fast_io@@YAIIPBXPAHP6AXPAUwsabuf@12@2PAUqualityofservice@12@322PAII@_EI@Z=__imp_WSAAccept")
+#pragma comment(linker,"/alternatename:__imp_?ioctlsocket@win32@fast_io@@YAHIJPAI@Z=__imp_ioctlsocket")
+#pragma comment(linker,"/alternatename:__imp_?sendto@win32@fast_io@@YAHIPBDHHPBXH@Z=__imp_sendto")
+#pragma comment(linker,"/alternatename:__imp_?WSASend@win32@fast_io@@YAHIPAUwsabuf@12@IPAIIPAUoverlapped@12@P6AXII2I@_E@Z=__imp_WSASend")
+#pragma comment(linker,"/alternatename:__imp_?WSASendMsg@win32@fast_io@@YAHIPAUwsamsg@12@IPAIPAUoverlapped@12@P6AXII2I@_E@Z=__imp_WSASendMsg")
+#pragma comment(linker,"/alternatename:__imp_?WSASendTo@win32@fast_io@@YAHIPAUwsabuf@12@IPAIIPBXHPAUoverlapped@12@P6AXII3I@_E@Z=__imp_WSASendTo")
+#pragma comment(linker,"/alternatename:__imp_?recv@win32@fast_io@@YAHIPADHH@Z=__imp_recv")
+#pragma comment(linker,"/alternatename:__imp_?recvfrom@win32@fast_io@@YAHIPADHHPAXPAH@Z=__imp_recvfrom")
+#pragma comment(linker,"/alternatename:__imp_?WSARecv@win32@fast_io@@YAHIPAUwsabuf@12@IPAI1PAUoverlapped@12@P6AXII2I@_E@Z=__imp_WSARecv")
+#pragma comment(linker,"/alternatename:__imp_?WSARecvFrom@win32@fast_io@@YAHIPAUwsabuf@12@IPAI1PAXPAHPAUoverlapped@12@P6AXII4I@_E@Z=__imp_WSARecvFrom")
+#pragma comment(linker,"/alternatename:__imp_?connect@win32@fast_io@@YAHIPBXH@Z=__imp_connect")
+#pragma comment(linker,"/alternatename:__imp_?WSAConnect@win32@fast_io@@YAHIPBXHPAUwsabuf@12@1PAUqualityofservice@12@2@Z=__imp_WSAConnect")
+#pragma comment(linker,"/alternatename:__imp_?shutdown@win32@fast_io@@YAHIPBXH@Z=__imp_shutdown")
+#pragma comment(linker,"/alternatename:__imp_?GetCurrentProcessId@win32@fast_io@@YAIXZ=__imp_GetCurrentProcessId")
+#pragma comment(linker,"/alternatename:__imp_?FlushFileBuffers@win32@fast_io@@YAHPAX@Z=__imp_FlushFileBuffers")
+#pragma comment(linker,"/alternatename:__imp_?GetQueuedCompletionStatus@win32@fast_io@@YAHPAXPAI1PAUoverlapped@12@I@Z=__imp_GetQueuedCompletionStatus")
+#pragma comment(linker,"/alternatename:__imp_?freeaddrinfo@win32@fast_io@@YAXPAU?$win32_family_addrinfo@$0A@@12@@Z=__imp_freeaddrinfo")
+#pragma comment(linker,"/alternatename:__imp_?FreeAddrInfoW@win32@fast_io@@YAXPAU?$win32_family_addrinfo@$00@12@@Z=__imp_FreeAddrInfoW")
+#pragma comment(linker,"/alternatename:__imp_?getaddrinfo@win32@fast_io@@YAHPBD0PBU?$win32_family_addrinfo@$0A@@12@PAPAU312@@Z=__imp_getaddrinfo")
+#pragma comment(linker,"/alternatename:__imp_?GetAddrInfoW@win32@fast_io@@YAHPB_S0PBU?$win32_family_addrinfo@$00@12@PAPAU312@@Z=__imp_GetAddrInfoW")
+#pragma comment(linker,"/alternatename:__imp_?CryptAcquireContextA@win32@fast_io@@YAHPAIPB_Q1II@Z=__imp_CryptAcquireContextA")
+#pragma comment(linker,"/alternatename:__imp_?CryptAcquireContextW@win32@fast_io@@YAHPAIPB_S1II@Z=__imp_CryptAcquireContextW")
+#pragma comment(linker,"/alternatename:__imp_?CryptReleaseContext@win32@fast_io@@YAHII@Z=__imp_CryptReleaseContext")
+#pragma comment(linker,"/alternatename:__imp_?CryptGenRandom@win32@fast_io@@YAHIIPAE@Z=__imp_CryptGenRandom")
+#pragma comment(linker,"/alternatename:__imp_?RegOpenKeyA@win32@fast_io@@YAHIPB_QPAI@Z=__imp_RegOpenKeyA")
+#pragma comment(linker,"/alternatename:__imp_?RegOpenKeyW@win32@fast_io@@YAHIPB_SPAI@Z=__imp_RegOpenKeyW")
+#pragma comment(linker,"/alternatename:__imp_?RegQueryValueExA@win32@fast_io@@YAHIPB_QPAI1PAX1@Z=__imp_RegQueryValueExA")
+#pragma comment(linker,"/alternatename:__imp_?RegQueryValueExW@win32@fast_io@@YAHIPB_SPAI1PAX1@Z=__imp_RegQueryValueExW")
+#pragma comment(linker,"/alternatename:__imp_?RegCloseKey@win32@fast_io@@YAHI@Z=__imp_RegCloseKey")
+#pragma comment(linker,"/alternatename:__imp_?GetTimeZoneInformation@win32@fast_io@@YAIPAUtime_zone_information@12@@Z=__imp_GetTimeZoneInformation")
+#pragma comment(linker,"/alternatename:__imp_?SetConsoleCP@win32@fast_io@@YAHI@Z=__imp_SetConsoleCP")
+#pragma comment(linker,"/alternatename:__imp_?SetConsoleOutputCP@win32@fast_io@@YAHI@Z=__imp_SetConsoleOutputCP")
+#pragma comment(linker,"/alternatename:__imp_?GetConsoleCP@win32@fast_io@@YAIXZ=__imp_GetConsoleCP")
+#pragma comment(linker,"/alternatename:__imp_?GetConsoleOutputCP@win32@fast_io@@YAIXZ=__imp_GetConsoleOutputCP")
+#pragma comment(linker,"/alternatename:__imp_?AcquireSRWLockExclusive@win32@fast_io@@YAXPAX@Z=__imp_AcquireSRWLockExclusive")
+#pragma comment(linker,"/alternatename:__imp_?TryAcquireSRWLockExclusive@win32@fast_io@@YAIPAX@Z=__imp_TryAcquireSRWLockExclusive")
+#pragma comment(linker,"/alternatename:__imp_?ReleaseSRWLockExclusive@win32@fast_io@@YAXPAX@Z=__imp_ReleaseSRWLockExclusive")
+#pragma comment(linker,"/alternatename:__imp_?rtl_nt_status_to_dos_error@nt@win32@fast_io@@YAII@Z=__imp_RtlNtStatusToDosError")
+#pragma comment(linker,"/alternatename:__imp_?NtClose@nt@win32@fast_io@@YAIPAX@Z=__imp_NtClose")
+#pragma comment(linker,"/alternatename:__imp_?ZwClose@nt@win32@fast_io@@YAIPAX@Z=__imp_ZwClose")
+#pragma comment(linker,"/alternatename:__imp_?NtCreateFile@nt@win32@fast_io@@YAIPAPAXIPAUobject_attributes@123@PAUio_status_block@123@PA_JIIIIPAXI@Z=__imp_NtCreateFile")
+#pragma comment(linker,"/alternatename:__imp_?ZwCreateFile@nt@win32@fast_io@@YAIPAPAXIPAUobject_attributes@123@PAUio_status_block@123@PA_JIIIIPAXI@Z=__imp_ZwCreateFile")
+#pragma comment(linker,"/alternatename:__imp_?NtCreateSection@nt@win32@fast_io@@YAIPIAPAXIPIAUobject_attributes@123@PA_KIIPIAX@Z=__imp_NtCreateSection")
+#pragma comment(linker,"/alternatename:__imp_?ZwCreateSection@nt@win32@fast_io@@YAIPIAPAXIPIAUobject_attributes@123@PA_KIIPIAX@Z=__imp_ZwCreateSection")
+#pragma comment(linker,"/alternatename:__imp_?NtQueryInformationProcess@nt@win32@fast_io@@YAIPIAXW4process_information_class@123@PAUprocess_basic_information@123@IPAI@Z=__imp_NtQueryInformationProcess")
+#pragma comment(linker,"/alternatename:__imp_?ZwQueryInformationProcess@nt@win32@fast_io@@YAIPIAXW4process_information_class@123@PAUprocess_basic_information@123@IPAI@Z=__imp_ZwQueryInformationProcess")
+#pragma comment(linker,"/alternatename:__imp_?NtWriteFile@nt@win32@fast_io@@YAIPAX0P6AX0PAUio_status_block@123@I@_E01PBXIPA_JPAI@Z=__imp_NtWriteFile")
+#pragma comment(linker,"/alternatename:__imp_?ZwWriteFile@nt@win32@fast_io@@YAIPAX0P6AX0PAUio_status_block@123@I@_E01PBXIPA_JPAI@Z=__imp_ZwWriteFile")
+#pragma comment(linker,"/alternatename:__imp_?NtReadFile@nt@win32@fast_io@@YAIPAX0P6AX0PAUio_status_block@123@I@_E01PBXIPA_JPAI@Z=__imp_NtReadFile")
+#pragma comment(linker,"/alternatename:__imp_?ZwReadFile@nt@win32@fast_io@@YAIPAX0P6AX0PAUio_status_block@123@I@_E01PBXIPA_JPAI@Z=__imp_ZwReadFile")
+#pragma comment(linker,"/alternatename:__imp_?NtQueryDirectoryFile@nt@win32@fast_io@@YAIPAX0P6AX0PAUio_status_block@123@I@_E010IW4file_information_class@123@HPAUunicode_string@123@H@Z=__imp_NtQueryDirectoryFile")
+#pragma comment(linker,"/alternatename:__imp_?ZwQueryDirectoryFile@nt@win32@fast_io@@YAIPAX0P6AX0PAUio_status_block@123@I@_E010IW4file_information_class@123@HPAUunicode_string@123@H@Z=__imp_ZwQueryDirectoryFile")
+#pragma comment(linker,"/alternatename:__imp_?NtQuerySection@nt@win32@fast_io@@YAIPAXW4section_information_class@123@0IPAI@Z=__imp_NtQuerySection")
+#pragma comment(linker,"/alternatename:__imp_?ZwQuerySection@nt@win32@fast_io@@YAIPAXW4section_information_class@123@0IPAI@Z=__imp_ZwQuerySection")
+#pragma comment(linker,"/alternatename:__imp_?NtQueryInformationFile@nt@win32@fast_io@@YAIPIAXPIAUio_status_block@123@0IW4file_information_class@123@@Z=__imp_NtQueryInformationFile")
+#pragma comment(linker,"/alternatename:__imp_?ZwQueryInformationFile@nt@win32@fast_io@@YAIPIAXPIAUio_status_block@123@0IW4file_information_class@123@@Z=__imp_ZwQueryInformationFile")
+#pragma comment(linker,"/alternatename:__imp_?NtSetInformationFile@nt@win32@fast_io@@YAIPIAXPIAUio_status_block@123@0IW4file_information_class@123@@Z=__imp_NtSetInformationFile")
+#pragma comment(linker,"/alternatename:__imp_?ZwSetInformationFile@nt@win32@fast_io@@YAIPIAXPIAUio_status_block@123@0IW4file_information_class@123@@Z=__imp_ZwSetInformationFile")
+#pragma comment(linker,"/alternatename:__imp_?NtDuplicateObject@nt@win32@fast_io@@YAIPAX00PAPAXIII@Z=__imp_NtDuplicateObject")
+#pragma comment(linker,"/alternatename:__imp_?ZwDuplicateObject@nt@win32@fast_io@@YAIPAX00PAPAXIII@Z=__imp_ZwDuplicateObject")
+#pragma comment(linker,"/alternatename:__imp_?NtWaitForSingleObject@nt@win32@fast_io@@YAIPAXHPA_K@Z=__imp_NtWaitForSingleObject")
+#pragma comment(linker,"/alternatename:__imp_?ZwWaitForSingleObject@nt@win32@fast_io@@YAIPAXHPA_K@Z=__imp_ZwWaitForSingleObject")
+#pragma comment(linker,"/alternatename:__imp_?NtSetSystemTime@nt@win32@fast_io@@YAIPA_K0@Z=__imp_NtSetSystemTime")
+#pragma comment(linker,"/alternatename:__imp_?ZwSetSystemTime@nt@win32@fast_io@@YAIPA_K0@Z=__imp_ZwSetSystemTime")
+#pragma comment(linker,"/alternatename:__imp_?NtCreateProcess@nt@win32@fast_io@@YAIPAPAXIPAUobject_attributes@123@PAXI222@Z=__imp_NtCreateProcess")
+#pragma comment(linker,"/alternatename:__imp_?ZwCreateProcess@nt@win32@fast_io@@YAIPAPAXIPAUobject_attributes@123@PAXI222@Z=__imp_ZwCreateProcess")
+#pragma comment(linker,"/alternatename:__imp_?rtl_dos_path_name_to_nt_path_name_u@nt@win32@fast_io@@YAEPB_WPAUunicode_string@123@PAPB_WPAUrtl_relative_name_u@123@@Z=__imp_RtlDosPathNameToNtPathName_U")
+#pragma comment(linker,"/alternatename:__imp_?rtl_dos_path_name_to_nt_path_name_u_with_status@nt@win32@fast_io@@YAIPB_WPAUunicode_string@123@PAPB_WPAUrtl_relative_name_u@123@@Z=__imp_RtlDosPathNameToNtPathName_U_WithStatus")
+#pragma comment(linker,"/alternatename:__imp_?rtl_free_unicode_string@nt@win32@fast_io@@YAXPAUunicode_string@123@@Z=__imp_RtlFreeUnicodeString")
+#pragma comment(linker,"/alternatename:__imp_?RtlInitializeCriticalSection@nt@win32@fast_io@@YAXPAX@Z=__imp_RtlInitializeCriticalSection")
+#pragma comment(linker,"/alternatename:__imp_?RtlEnterCriticalSection@nt@win32@fast_io@@YAXPAX@Z=__imp_RtlEnterCriticalSection")
+#pragma comment(linker,"/alternatename:__imp_?RtlTryEnterCriticalSection@nt@win32@fast_io@@YAHPAX@Z=__imp_RtlTryEnterCriticalSection")
+#pragma comment(linker,"/alternatename:__imp_?RtlLeaveCriticalSection@nt@win32@fast_io@@YAXPAX@Z=__imp_RtlLeaveCriticalSection")
+#pragma comment(linker,"/alternatename:__imp_?RtlDeleteCriticalSection@nt@win32@fast_io@@YAXPAX@Z=__imp_RtlDeleteCriticalSection")
+#pragma comment(linker,"/alternatename:__imp_?RtlCreateUserThread@nt@win32@fast_io@@YAIPAX0HIII00PAPAXPAUclient_id@123@@Z=__imp_RtlCreateUserThread")
+#pragma comment(linker,"/alternatename:__imp_?NtResumeThread@nt@win32@fast_io@@YAIPAXPAI@Z=__imp_NtResumeThread")
+#pragma comment(linker,"/alternatename:__imp_?ZwResumeThread@nt@win32@fast_io@@YAIPAXPAI@Z=__imp_ZwResumeThread")
+#pragma comment(linker,"/alternatename:__imp_?NtLockFile@nt@win32@fast_io@@YAIPAX0P6AX0PAUio_status_block@123@I@_E01PA_J3IEE@Z=__imp_NtLockFile")
+#pragma comment(linker,"/alternatename:__imp_?ZwLockFile@nt@win32@fast_io@@YAIPAX0P6AX0PAUio_status_block@123@I@_E01PA_J3IEE@Z=__imp_ZwLockFile")
+#pragma comment(linker,"/alternatename:__imp_?NtUnlockFile@nt@win32@fast_io@@YAIPAXPAUio_status_block@123@PA_J2I@Z=__imp_NtUnlockFile")
+#pragma comment(linker,"/alternatename:__imp_?ZwUnlockFile@nt@win32@fast_io@@YAIPAXPAUio_status_block@123@PA_J2I@Z=__imp_ZwUnlockFile")
+#pragma comment(linker,"/alternatename:__imp_?NtFlushBuffersFile@nt@win32@fast_io@@YAIPAXPAUio_status_block@123@@Z=__imp_NtFlushBuffersFile")
+#pragma comment(linker,"/alternatename:__imp_?ZwFlushBuffersFile@nt@win32@fast_io@@YAIPAXPAUio_status_block@123@@Z=__imp_ZwFlushBuffersFile")
+#pragma comment(linker,"/alternatename:__imp_?NtFlushBuffersFileEx@nt@win32@fast_io@@YAIPAXI0IPAUio_status_block@123@@Z=__imp_NtFlushBuffersFileEx")
+#pragma comment(linker,"/alternatename:__imp_?ZwFlushBuffersFileEx@nt@win32@fast_io@@YAIPAXI0IPAUio_status_block@123@@Z=__imp_ZwFlushBuffersFileEx")
+#pragma comment(linker,"/alternatename:__imp_?DbgPrint@nt@win32@fast_io@@YAIPBDZZ=__imp_DbgPrint")
+#pragma comment(linker,"/alternatename:__imp_?DbgPrintEx@nt@win32@fast_io@@YAIIIPBDZZ=__imp_DbgPrintEx")
+#pragma comment(linker,"/alternatename:__imp_?RtlCreateProcessParameters@nt@win32@fast_io@@YAIPAPAUrtl_user_process_parameters@123@PAUunicode_string@123@111PAX1111@Z=__imp_RtlCreateProcessParameters")
+#pragma comment(linker,"/alternatename:__imp_?RtlCreateProcessParametersEx@nt@win32@fast_io@@YAIPAPAUrtl_user_process_parameters@123@PAUunicode_string@123@111PAX1111I@Z=__imp_RtlCreateProcessParametersEx")
+#pragma comment(linker,"/alternatename:__imp_?RtlDestroyProcessParameters@nt@win32@fast_io@@YAIPAUrtl_user_process_parameters@123@@Z=__imp_RtlDestroyProcessParameters")
+#pragma comment(linker,"/alternatename:__imp_?NtCreateUserProcess@nt@win32@fast_io@@YAIPAX0IIPAUobject_attributes@123@1IIPAUrtl_user_process_parameters@123@PAUps_create_info@123@PAUps_attribute_list@123@@Z=__imp_NtCreateUserProcess")
+#pragma comment(linker,"/alternatename:__imp_?ZwCreateUserProcess@nt@win32@fast_io@@YAIPAX0IIPAUobject_attributes@123@1IIPAUrtl_user_process_parameters@123@PAUps_create_info@123@PAUps_attribute_list@123@@Z=__imp_ZwCreateUserProcess")
+#pragma comment(linker,"/alternatename:__imp_?RtlCreateUserProcess@nt@win32@fast_io@@YAIPAUunicode_string@123@IPAUrtl_user_process_parameters@123@PAUsecurity_descriptor@123@2PAXE33PAUrtl_user_process_information@123@@Z=__imp_RtlCreateUserProcess")
+#pragma comment(linker,"/alternatename:__imp_?NtMapViewOfSection@nt@win32@fast_io@@YAIPAX0PAPAXIIPBTlarge_integer@123@PAIW4section_inherit@123@II@Z=__imp_NtMapViewOfSection")
+#pragma comment(linker,"/alternatename:__imp_?ZwMapViewOfSection@nt@win32@fast_io@@YAIPAX0PAPAXIIPBTlarge_integer@123@PAIW4section_inherit@123@II@Z=__imp_ZwMapViewOfSection")
+#pragma comment(linker,"/alternatename:__imp_?NtUnmapViewOfSection@nt@win32@fast_io@@YAIPAX0@Z=__imp_NtUnmapViewOfSection")
+#pragma comment(linker,"/alternatename:__imp_?ZwUnmapViewOfSection@nt@win32@fast_io@@YAIPAX0@Z=__imp_ZwUnmapViewOfSection")
+#pragma comment(linker,"/alternatename:__imp_?NtReadVirtualMemory@nt@win32@fast_io@@YAIPAX00IPAI@Z=__imp_NtReadVirtualMemory")
+#pragma comment(linker,"/alternatename:__imp_?ZwReadVirtualMemory@nt@win32@fast_io@@YAIPAX00IPAI@Z=__imp_ZwReadVirtualMemory")
+#pragma comment(linker,"/alternatename:__imp_?NtWriteVirtualMemory@nt@win32@fast_io@@YAIPAX00IPAI@Z=__imp_NtWriteVirtualMemory")
+#pragma comment(linker,"/alternatename:__imp_?ZwWriteVirtualMemory@nt@win32@fast_io@@YAIPAX00IPAI@Z=__imp_ZwWriteVirtualMemory")
+#pragma comment(linker,"/alternatename:__imp_?RtlAcquirePebLock@nt@win32@fast_io@@YAIXZ=__imp_RtlAcquirePebLock")
+#pragma comment(linker,"/alternatename:__imp_?RtlReleasePebLock@nt@win32@fast_io@@YAIXZ=__imp_RtlReleasePebLock")
+#pragma comment(linker,"/alternatename:__imp_?NtAllocateVirtualMemory@nt@win32@fast_io@@YAIPAXPAPAXIPAIII@Z=__imp_NtAllocateVirtualMemory")
+#pragma comment(linker,"/alternatename:__imp_?ZwAllocateVirtualMemory@nt@win32@fast_io@@YAIPAXPAPAXIPAIII@Z=__imp_ZwAllocateVirtualMemory")
+#pragma comment(linker,"/alternatename:__imp_?RtlInitUnicodeString@nt@win32@fast_io@@YAIPAUunicode_string@123@PA_S@Z=__imp_RtlInitUnicodeString")
+#pragma comment(linker,"/alternatename:__imp_?CsrClientCallServer@nt@win32@fast_io@@YAIPAX0II@Z=__imp_CsrClientCallServer")
+#pragma comment(linker,"/alternatename:__imp_?RtlAcquireSRWLockExclusive@nt@win32@fast_io@@YAXPAX@Z=__imp_RtlAcquireSRWLockExclusive")
+#pragma comment(linker,"/alternatename:__imp_?RtlTryAcquireSRWLockExclusive@nt@win32@fast_io@@YAIPAX@Z=__imp_RtlTryAcquireSRWLockExclusive")
+#pragma comment(linker,"/alternatename:__imp_?RtlReleaseSRWLockExclusive@nt@win32@fast_io@@YAXPAX@Z=__imp_RtlReleaseSRWLockExclusive")
 #pragma comment(linker,"/alternatename:__imp_?msvc__RTtypeid@msvc@fast_io@@YAPAXPAX@Z=__imp___RTtypeid")
-#else
 #pragma comment(linker,"/alternatename:?msvc__RTtypeid@msvc@fast_io@@YAPAXPAX@Z=__RTtypeid")
-#endif
+// clang-format on

--- a/include/fast_io_hosted/platforms/win32/msvc_linker_32.h
+++ b/include/fast_io_hosted/platforms/win32/msvc_linker_32.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 // clang-format off
 #pragma comment(linker,"/alternatename:__imp_?GetLastError@win32@fast_io@@YAIXZ=__imp_GetLastError")

--- a/include/fast_io_hosted/platforms/win32/msvc_linker_32_i686.h
+++ b/include/fast_io_hosted/platforms/win32/msvc_linker_32_i686.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 // clang-format off
 #pragma comment(linker,"/alternatename:__imp_?GetLastError@win32@fast_io@@YGIXZ=__imp__GetLastError@0")

--- a/include/fast_io_hosted/platforms/win32/msvc_linker_32_i686.h
+++ b/include/fast_io_hosted/platforms/win32/msvc_linker_32_i686.h
@@ -1,406 +1,194 @@
-﻿#pragma once
+#pragma once
 
-#pragma comment(linker, "/alternatename:__imp_?GetLastError@win32@fast_io@@YGIXZ=__imp__GetLastError@0")
-#pragma comment(linker, "/alternatename:__imp_?LoadLibraryA@win32@fast_io@@YGPAXPBD@Z=__imp__LoadLibraryA@4")
-#pragma comment(linker, "/alternatename:__imp_?LoadLibraryW@win32@fast_io@@YGPAXPB_S@Z=__imp__LoadLibraryW@4")
-#pragma comment(linker, "/alternatename:__imp_?LoadLibraryExA@win32@fast_io@@YGPAXPBDPAXI@Z=__imp__LoadLibraryExA@12")
-#pragma comment(linker, "/alternatename:__imp_?LoadLibraryExW@win32@fast_io@@YGPAXPB_SPAXI@Z=__imp__LoadLibraryExW@12")
-#pragma comment(linker, \
-				"/alternatename:__imp_?FormatMessageA@win32@fast_io@@YGIIPBDIIPADIPAX@Z=__imp__FormatMessageA@28")
-#pragma comment(linker, \
-				"/alternatename:__imp_?FormatMessageW@win32@fast_io@@YGIIPB_SIIPA_SIPAX@Z=__imp__FormatMessageW@28")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?CreateFileMappingA@win32@fast_io@@YGPAXPAXPAUsecurity_attributes@12@IIIPBD@Z=__imp__CreateFileMappingA@24")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?CreateFileMappingW@win32@fast_io@@YGPAXPAXPAUsecurity_attributes@12@IIIPB_S@Z=__imp__CreateFileMappingW@24")
-#pragma comment(linker, "/alternatename:__imp_?MapViewOfFile@win32@fast_io@@YGPAXPAXIIII@Z=__imp__MapViewOfFile@20")
-#pragma comment(linker, "/alternatename:__imp_?SetEndOfFile@win32@fast_io@@YGHPAX@Z=__imp__SetEndOfFile@4")
-#pragma comment(linker, "/alternatename:__imp_?UnmapViewOfFile@win32@fast_io@@YGHPBX@Z=__imp__UnmapViewOfFile@4")
-#pragma comment(linker, \
-				"/alternatename:__imp_?WriteFile@win32@fast_io@@YGHPAXPBXIPAIPAUoverlapped@12@@Z=__imp__WriteFile@20")
-#pragma comment(linker, \
-				"/alternatename:__imp_?ReadFile@win32@fast_io@@YGHPAXPBXIPAIPAUoverlapped@12@@Z=__imp__ReadFile@20")
-#pragma comment(linker, "/alternatename:__imp_?SetFilePointer@win32@fast_io@@YGIPAXHPAHI@Z=__imp__SetFilePointer@16")
-#pragma comment(linker, \
-				"/alternatename:__imp_?SetFilePointerEx@win32@fast_io@@YGHPAX_JPA_JI@Z=__imp__SetFilePointerEx@20")
-#pragma comment(linker, \
-				"/alternatename:__imp_?DuplicateHandle@win32@fast_io@@YGHPAX00PAPAXIHI@Z=__imp__DuplicateHandle@28")
-#pragma comment(linker, "/alternatename:__imp_?GetStdHandle@win32@fast_io@@YGPAXI@Z=__imp__GetStdHandle@4")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?CreatePipe@win32@fast_io@@YGHPAPAX0PAUsecurity_attributes@12@I@Z=__imp__CreatePipe@16")
-#pragma comment(linker, "/alternatename:__imp_?FreeLibrary@win32@fast_io@@YGHPAX@Z=__imp__FreeLibrary@4")
-#pragma comment(linker, "/alternatename:__imp_?GetProcAddress@win32@fast_io@@YGP6GHX_EPAXPBD@Z=__imp__GetProcAddress@8")
-#pragma comment(linker, "/alternatename:__imp_?GetModuleHandleA@win32@fast_io@@YGPAXPBD@Z=__imp__GetModuleHandleA@4")
-#pragma comment(linker, "/alternatename:__imp_?GetModuleHandleW@win32@fast_io@@YGPAXPB_S@Z=__imp__GetModuleHandleW@4")
-#pragma comment(linker, \
-				"/alternatename:__imp_?WaitForSingleObject@win32@fast_io@@YGIPAXI@Z=__imp__WaitForSingleObject@8")
-#pragma comment(linker, "/alternatename:__imp_?CancelIo@win32@fast_io@@YGIPAX@Z=__imp__CancelIo@4")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?GetFileInformationByHandle@win32@fast_io@@YGHPIAXPIAUby_handle_file_information@12@@Z=__imp__GetFileInformationByHandle@8")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?GetUserDefaultLocaleName@win32@fast_io@@YGHPA_SH@Z=__imp__GetUserDefaultLocaleName@8")
-#pragma comment(linker, "/alternatename:__imp_?GetUserDefaultLCID@win32@fast_io@@YGIXZ=__imp__GetUserDefaultLCID@0")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?GetSystemTimePreciseAsFileTime@win32@fast_io@@YGXPAUfiletime@12@@Z=__imp__GetSystemTimePreciseAsFileTime@4")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?GetSystemTimeAsFileTime@win32@fast_io@@YGXPAUfiletime@12@@Z=__imp__GetSystemTimeAsFileTime@4")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?QueryUnbiasedInterruptTime@win32@fast_io@@YGHPA_K@Z=__imp__QueryUnbiasedInterruptTime@4")
-#pragma comment( \
-	linker, "/alternatename:__imp_?QueryPerformanceCounter@win32@fast_io@@YGHPA_J@Z=__imp__QueryPerformanceCounter@4")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?QueryPerformanceFrequency@win32@fast_io@@YGHPA_J@Z=__imp__QueryPerformanceFrequency@4")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?GetProcessTimes@win32@fast_io@@YGHPAXPAUfiletime@12@111@Z=__imp__GetProcessTimes@20")
-#pragma comment( \
-	linker, "/alternatename:__imp_?GetThreadTimes@win32@fast_io@@YGHPAXPAUfiletime@12@111@Z=__imp__GetThreadTimes@20")
-#pragma comment(linker, \
-				"/alternatename:__imp_?GetHandleInformation@win32@fast_io@@YGHPAXPAI@Z=__imp__GetHandleInformation@8")
-#pragma comment(linker, \
-				"/alternatename:__imp_?SetHandleInformation@win32@fast_io@@YGHPAXII@Z=__imp__SetHandleInformation@12")
-#pragma comment(linker, "/alternatename:__imp_?GetTempPathA@win32@fast_io@@YGIIPAD@Z=__imp__GetTempPathA@8")
-#pragma comment(linker, "/alternatename:__imp_?GetTempPathW@win32@fast_io@@YGIIPA_S@Z=__imp__GetTempPathW@8")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?CreateFileA@win32@fast_io@@YGPAXPBDIIPAUsecurity_attributes@12@IIPAX@Z=__imp__CreateFileA@28")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?CreateFileW@win32@fast_io@@YGPAXPB_SIIPAUsecurity_attributes@12@IIPAX@Z=__imp__CreateFileW@28")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?CreateIoCompletionPort@win32@fast_io@@YGPAXPAX0II@Z=__imp__CreateIoCompletionPort@16")
-#pragma comment(linker, "/alternatename:__imp_?SystemFunction036@win32@fast_io@@YGHPAXI@Z=__imp__SystemFunction036@8")
-#pragma comment(linker, "/alternatename:__imp_?CloseHandle@win32@fast_io@@YGHPAX@Z=__imp__CloseHandle@4")
-#pragma comment(linker, \
-				"/alternatename:__imp_?LockFileEx@win32@fast_io@@YGHPAXIIIIPAUoverlapped@12@@Z=__imp__LockFileEx@24")
-#pragma comment( \
-	linker, "/alternatename:__imp_?UnlockFileEx@win32@fast_io@@YGHPAXIIIPAUoverlapped@12@@Z=__imp__UnlockFileEx@20")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?DeviceIoControl@win32@fast_io@@YGHPAXI0I0I0PAUoverlapped@12@@Z=__imp__DeviceIoControl@32")
-#pragma comment(linker, "/alternatename:__imp_?GetFileType@win32@fast_io@@YGIPAX@Z=__imp__GetFileType@4")
-#pragma comment(linker, "/alternatename:__imp_?GetACP@win32@fast_io@@YGIXZ=__imp__GetACP@0")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?GetEnvironmentVariableA@win32@fast_io@@YGIPBDPADI@Z=__imp__GetEnvironmentVariableA@12")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?GetEnvironmentVariableW@win32@fast_io@@YGIPB_SPA_SI@Z=__imp__GetEnvironmentVariableW@12")
-#pragma comment(linker, "/alternatename:__imp_?MessageBoxA@win32@fast_io@@YGIPAXPBD1I@Z=__imp__MessageBoxA@16")
-#pragma comment(linker, "/alternatename:__imp_?MessageBoxW@win32@fast_io@@YGIPAXPB_S1I@Z=__imp__MessageBoxW@16")
-#pragma comment(linker, "/alternatename:__imp_?GetConsoleMode@win32@fast_io@@YGHPAXPAI@Z=__imp__GetConsoleMode@8")
-#pragma comment(linker, "/alternatename:__imp_?SetConsoleMode@win32@fast_io@@YGHPAXI@Z=__imp__SetConsoleMode@8")
-#pragma comment(linker, "/alternatename:__imp_?ReadConsoleA@win32@fast_io@@YGHPAX0IPAI0@Z=__imp__ReadConsoleA@20")
-#pragma comment(linker, "/alternatename:__imp_?ReadConsoleW@win32@fast_io@@YGHPAX0IPAI0@Z=__imp__ReadConsoleW@20")
-#pragma comment(linker, "/alternatename:__imp_?WriteConsoleA@win32@fast_io@@YGHPAXPBXIPAI0@Z=__imp__WriteConsoleA@20")
-#pragma comment(linker, "/alternatename:__imp_?WriteConsoleW@win32@fast_io@@YGHPAXPBXIPAI0@Z=__imp__WriteConsoleW@20")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?GetConsoleScreenBufferInfo@win32@fast_io@@YGHPAXPAUconsole_screen_buffer_info@12@@Z=__imp__GetConsoleScreenBufferInfo@8")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?ScrollConsoleScreenBufferA@win32@fast_io@@YGHPAXPBUsmall_rect@12@1Ucoord@12@PBUchar_info@12@@Z=__imp__ScrollConsoleScreenBufferA@20")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?ScrollConsoleScreenBufferW@win32@fast_io@@YGHPAXPBUsmall_rect@12@1Ucoord@12@PBUchar_info@12@@Z=__imp__ScrollConsoleScreenBufferW@20")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?SetConsoleCursorPosition@win32@fast_io@@YGHPAXUcoord@12@@Z=__imp__SetConsoleCursorPosition@8")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?InitializeCriticalSection@win32@fast_io@@YGXPAX@Z=__imp__InitializeCriticalSection@4")
-#pragma comment(linker, \
-				"/alternatename:__imp_?EnterCriticalSection@win32@fast_io@@YGXPAX@Z=__imp__EnterCriticalSection@4")
-#pragma comment( \
-	linker, "/alternatename:__imp_?TryEnterCriticalSection@win32@fast_io@@YGHPAX@Z=__imp__TryEnterCriticalSection@4")
-#pragma comment(linker, \
-				"/alternatename:__imp_?LeaveCriticalSection@win32@fast_io@@YGXPAX@Z=__imp__LeaveCriticalSection@4")
-#pragma comment(linker, \
-				"/alternatename:__imp_?DeleteCriticalSection@win32@fast_io@@YGXPAX@Z=__imp__DeleteCriticalSection@4")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?WSADuplicateSocketA@win32@fast_io@@YGHPAXIPAUwsaprotocol_infoa@12@@Z=__imp__WSADuplicateSocketA@12")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?WSADuplicateSocketW@win32@fast_io@@YGXPAXIPAUwsaprotocol_infow@12@@Z=__imp__WSADuplicateSocketW@12")
-#pragma comment(linker, "/alternatename:__imp_?WSACleanup@win32@fast_io@@YGHXZ=__imp__WSACleanup@0")
-#pragma comment(linker, "/alternatename:__imp_?WSAStartup@win32@fast_io@@YGHIPAUwsadata@12@@Z=__imp__WSAStartup@8")
-#pragma comment(linker, "/alternatename:__imp_?WSAGetLastError@win32@fast_io@@YGHXZ=__imp__WSAGetLastError@0")
-#pragma comment(linker, "/alternatename:__imp_?closesocket@win32@fast_io@@YGHI@Z=__imp__closesocket@4")
-#pragma comment( \
-	linker, "/alternatename:__imp_?WSASocketW@win32@fast_io@@YGIHHHPAUwsaprotocol_infow@12@II@Z=__imp__WSASocketW@24")
-#pragma comment( \
-	linker, "/alternatename:__imp_?WSASocketA@win32@fast_io@@YGIHHHPAUwsaprotocol_infoa@12@II@Z=__imp__WSASocketA@24")
-#pragma comment(linker, "/alternatename:__imp_?bind@win32@fast_io@@YGHIPBXH@Z=__imp__bind@12")
-#pragma comment(linker, "/alternatename:__imp_?listen@win32@fast_io@@YGHIH@Z=__imp__listen@8")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?WSAAccept@win32@fast_io@@YGIIPBXPAHP6GXPAUwsabuf@12@2PAUqualityofservice@12@322PAII@_EI@Z=__imp__WSAAccept@20")
-#pragma comment(linker, "/alternatename:__imp_?ioctlsocket@win32@fast_io@@YGHIJPAI@Z=__imp__ioctlsocket@12")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?WSASend@win32@fast_io@@YGHIPAUwsabuf@12@IPAIIPAUoverlapped@12@P6GXII2I@_E@Z=__imp__WSASend@28")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?WSASendMsg@win32@fast_io@@YGHIPAUwsamsg@12@IPAIPAUoverlapped@12@P6GXII2I@_E@Z=__imp__WSASendMsg@24")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?WSASendTo@win32@fast_io@@YGHIPAUwsabuf@12@IPAIIPBXHPAUoverlapped@12@P6GXII3I@_E@Z=__imp__WSASendTo@36")
-#pragma comment(linker, "/alternatename:__imp_?recv@win32@fast_io@@YGHIPADHH@Z=__imp__recv@16")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?WSARecv@win32@fast_io@@YGHIPAUwsabuf@12@IPAI1PAUoverlapped@12@P6GXII2I@_E@Z=__imp__WSARecv@28")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?WSARecvFrom@win32@fast_io@@YGHIPAUwsabuf@12@IPAI1PAXPAHPAUoverlapped@12@P6GXII4I@_E@Z=__imp__WSARecvFrom@36")
-#pragma comment(linker, "/alternatename:__imp_?connect@win32@fast_io@@YGHIPBXH@Z=__imp__connect@12")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?WSAConnect@win32@fast_io@@YGHIPBXHPAUwsabuf@12@1PAUqualityofservice@12@2@Z=__imp__WSAConnect@28")
-#pragma comment(linker, "/alternatename:__imp_?recvfrom@win32@fast_io@@YGHIPADHHPAXPAH@Z=__imp__recvfrom@24")
-#pragma comment(linker, "/alternatename:__imp_?sendto@win32@fast_io@@YGHIPBDHHPBXH@Z=__imp__sendto@24")
-#pragma comment(linker, "/alternatename:__imp_?shutdown@win32@fast_io@@YGHIPBXH@Z=__imp__shutdown@8")
-#pragma comment(linker, "/alternatename:__imp_?GetCurrentProcessId@win32@fast_io@@YGIXZ=__imp__GetCurrentProcessId@0")
-#pragma comment(linker, "/alternatename:__imp_?FlushFileBuffers@win32@fast_io@@YGHPAX@Z=__imp__FlushFileBuffers@4")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?GetQueuedCompletionStatus@win32@fast_io@@YGHPAXPAI1PAUoverlapped@12@I@Z=__imp__GetQueuedCompletionStatus@20")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?freeaddrinfo@win32@fast_io@@YGXPAU?$win32_family_addrinfo@$0A@@12@@Z=__imp__freeaddrinfo@4")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?FreeAddrInfoW@win32@fast_io@@YGXPAU?$win32_family_addrinfo@$00@12@@Z=__imp__FreeAddrInfoW@4")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?getaddrinfo@win32@fast_io@@YGHPBD0PBU?$win32_family_addrinfo@$0A@@12@PAPAU312@@Z=__imp__getaddrinfo@16")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?GetAddrInfoW@win32@fast_io@@YGHPB_S0PBU?$win32_family_addrinfo@$00@12@PAPAU312@@Z=__imp__GetAddrInfoW@16")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?CryptAcquireContextA@win32@fast_io@@YGHPAIPB_Q1II@Z=__imp__CryptAcquireContextA@20")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?CryptAcquireContextW@win32@fast_io@@YGHPAIPB_S1II@Z=__imp__CryptAcquireContextW@20")
-#pragma comment(linker, "/alternatename:__imp_?CryptReleaseContext@win32@fast_io@@YGHII@Z=__imp__CryptReleaseContext@8")
-#pragma comment(linker, "/alternatename:__imp_?CryptGenRandom@win32@fast_io@@YGHIIPAE@Z=__imp__CryptGenRandom@12")
-#pragma comment(linker, "/alternatename:__imp_?RegOpenKeyA@win32@fast_io@@YGHIPB_QPAI@Z=__imp__RegOpenKeyA@12")
-#pragma comment(linker, "/alternatename:__imp_?RegOpenKeyW@win32@fast_io@@YGHIPB_SPAI@Z=__imp__RegOpenKeyW@12")
-#pragma comment(linker, \
-				"/alternatename:__imp_?RegQueryValueExA@win32@fast_io@@YGHIPB_QPAI1PAX1@Z=__imp__RegQueryValueExA@24")
-#pragma comment(linker, \
-				"/alternatename:__imp_?RegQueryValueExW@win32@fast_io@@YGHIPB_SPAI1PAX1@Z=__imp__RegQueryValueExW@24")
-#pragma comment(linker, "/alternatename:__imp_?RegCloseKey@win32@fast_io@@YGHI@Z=__imp__RegCloseKey@4")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?GetTimeZoneInformation@win32@fast_io@@YGIPAUtime_zone_information@12@@Z=__imp__GetTimeZoneInformation@4")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?rtl_nt_status_to_dos_error@nt@win32@fast_io@@YGII@Z=__imp__RtlNtStatusToDosError@4")
-#pragma comment(linker, "/alternatename:__imp_?NtClose@nt@win32@fast_io@@YGIPAX@Z=__imp__NtClose@4")
-#pragma comment(linker, "/alternatename:__imp_?ZwClose@nt@win32@fast_io@@YGIPAX@Z=__imp__ZwClose@4")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?NtCreateFile@nt@win32@fast_io@@YGIPAPAXIPAUobject_attributes@123@PAUio_status_block@123@PA_JIIIIPAXI@Z=__imp__NtCreateFile@44")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?ZwCreateFile@nt@win32@fast_io@@YGIPAPAXIPAUobject_attributes@123@PAUio_status_block@123@PA_JIIIIPAXI@Z=__imp__ZwCreateFile@44")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?NtCreateSection@nt@win32@fast_io@@YGIPIAPAXIPIAUobject_attributes@123@PA_KIIPIAX@Z=__imp__NtCreateSection@28")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?ZwCreateSection@nt@win32@fast_io@@YGIPIAPAXIPIAUobject_attributes@123@PA_KIIPIAX@Z=__imp__ZwCreateSection@28")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?NtQueryInformationProcess@nt@win32@fast_io@@YGIPIAXW4process_information_class@123@PAXIPAI@Z=__imp__NtQueryInformationProcess@20")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?ZwQueryInformationProcess@nt@win32@fast_io@@YGIPIAXW4process_information_class@123@PAXIPAI@Z=__imp__ZwQueryInformationProcess@20")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?NtWriteFile@nt@win32@fast_io@@YGIPAX0P6AX0PAUio_status_block@123@I@_E01PBXIPA_JPAI@Z=__imp__NtWriteFile@36")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?ZwWriteFile@nt@win32@fast_io@@YGIPAX0P6AX0PAUio_status_block@123@I@_E01PBXIPA_JPAI@Z=__imp__ZwWriteFile@36")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?NtReadFile@nt@win32@fast_io@@YGIPAX0P6AX0PAUio_status_block@123@I@_E01PBXIPA_JPAI@Z=__imp__NtReadFile@36")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?ZwReadFile@nt@win32@fast_io@@YGIPAX0P6AX0PAUio_status_block@123@I@_E01PBXIPA_JPAI@Z=__imp__ZwReadFile@36")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?NtQueryDirectoryFile@nt@win32@fast_io@@YGIPAX0P6AX0PAUio_status_block@123@I@_E010IW4file_information_class@123@HPAUunicode_string@123@H@Z=__imp__NtQueryDirectoryFile@44")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?ZwQueryDirectoryFile@nt@win32@fast_io@@YGIPAX0P6AX0PAUio_status_block@123@I@_E010IW4file_information_class@123@HPAUunicode_string@123@H@Z=__imp__ZwQueryDirectoryFile@44")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?NtQuerySection@nt@win32@fast_io@@YGIPAXW4section_information_class@123@0IPAI@Z=__imp__NtQuerySection@20")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?ZwQuerySection@nt@win32@fast_io@@YGIPAXW4section_information_class@123@0IPAI@Z=__imp__ZwQuerySection@20")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?NtQueryInformationFile@nt@win32@fast_io@@YGIPIAXPIAUio_status_block@123@0IW4file_information_class@123@@Z=__imp__NtQueryInformationFile@20")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?ZwQueryInformationFile@nt@win32@fast_io@@YGIPIAXPIAUio_status_block@123@0IW4file_information_class@123@@Z=__imp__ZwQueryInformationFile@20")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?NtSetInformationFile@nt@win32@fast_io@@YGIPIAXPIAUio_status_block@123@0IW4file_information_class@123@@Z=__imp__NtSetInformationFile@20")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?ZwSetInformationFile@nt@win32@fast_io@@YGIPIAXPIAUio_status_block@123@0IW4file_information_class@123@@Z=__imp__ZwSetInformationFile@20")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?NtDuplicateObject@nt@win32@fast_io@@YGIPAX00PAPAXIII@Z=__imp__NtDuplicateObject@28")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?ZwDuplicateObject@nt@win32@fast_io@@YGIPAX00PAPAXIII@Z=__imp__ZwDuplicateObject@28")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?NtWaitForSingleObject@nt@win32@fast_io@@YGIPAXHPA_K@Z=__imp__NtWaitForSingleObject@12")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?ZwWaitForSingleObject@nt@win32@fast_io@@YGIPAXHPA_K@Z=__imp__ZwWaitForSingleObject@12")
-#pragma comment(linker, "/alternatename:__imp_?NtSetSystemTime@nt@win32@fast_io@@YGIPA_K0@Z=__imp__NtSetSystemTime@8")
-#pragma comment(linker, "/alternatename:__imp_?ZwSetSystemTime@nt@win32@fast_io@@YGIPA_K0@Z=__imp__ZwSetSystemTime@8")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?NtCreateProcess@nt@win32@fast_io@@YGIPAPAXIPAUobject_attributes@123@PAXI222@Z=__imp__NtCreateProcess@32")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?ZwCreateProcess@nt@win32@fast_io@@YGIPAPAXIPAUobject_attributes@123@PAXI222@Z=__imp__ZwCreateProcess@32")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?rtl_dos_path_name_to_nt_path_name_u@nt@win32@fast_io@@YGEPB_SPAUunicode_string@123@PAPB_SPAUrtl_relative_name_u@123@@Z=__imp__RtlDosPathNameToNtPathName_U@16")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?rtl_dos_path_name_to_nt_path_name_u_with_status@nt@win32@fast_io@@YGIPB_SPAUunicode_string@123@PAPB_SPAUrtl_relative_name_u@123@@Z=__imp__RtlDosPathNameToNtPathName_U_WithStatus@16")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?rtl_free_unicode_string@nt@win32@fast_io@@YGXPAUunicode_string@123@@Z=__imp__RtlFreeUnicodeString@4")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?RtlInitializeCriticalSection@nt@win32@fast_io@@YGXPAX@Z=__imp__RtlInitializeCriticalSection@4")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?RtlEnterCriticalSection@nt@win32@fast_io@@YGXPAX@Z=__imp__RtlEnterCriticalSection@4")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?RtlTryEnterCriticalSection@nt@win32@fast_io@@YGHPAX@Z=__imp__RtlTryEnterCriticalSection@4")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?RtlLeaveCriticalSection@nt@win32@fast_io@@YGXPAX@Z=__imp__RtlLeaveCriticalSection@4")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?RtlDeleteCriticalSection@nt@win32@fast_io@@YGXPAX@Z=__imp__RtlDeleteCriticalSection@4")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?RtlCreateUserThread@nt@win32@fast_io@@YGIPAX0HIII00PAPAXPAUclient_id@123@@Z=__imp__RtlCreateUserThread@40")
-#pragma comment(linker, "/alternatename:__imp_?NtResumeThread@nt@win32@fast_io@@YGIPAXPAI@Z=__imp__NtResumeThread@8")
-#pragma comment(linker, "/alternatename:__imp_?ZwResumeThread@nt@win32@fast_io@@YGIPAXPAI@Z=__imp__ZwResumeThread@8")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?NtLockFile@nt@win32@fast_io@@YGIPAX0P6AX0PAUio_status_block@123@I@_E01PA_J3IEE@Z=__imp__NtLockFile@40")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?ZwLockFile@nt@win32@fast_io@@YGIPAX0P6AX0PAUio_status_block@123@I@_E01PA_J3IEE@Z=__imp__ZwLockFile@40")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?NtUnlockFile@nt@win32@fast_io@@YGIPAXPAUio_status_block@123@PA_J2I@Z=__imp__NtUnlockFile@20")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?ZwUnlockFile@nt@win32@fast_io@@YGIPAXPAUio_status_block@123@PA_J2I@Z=__imp__ZwUnlockFile@20")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?NtFlushBuffersFile@nt@win32@fast_io@@YGIPAXPAUio_status_block@123@@Z=__imp__NtFlushBuffersFile@8")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?ZwFlushBuffersFile@nt@win32@fast_io@@YGIPAXPAUio_status_block@123@@Z=__imp__ZwFlushBuffersFile@8")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?NtFlushBuffersFileEx@nt@win32@fast_io@@YGIPAXI0IPAUio_status_block@123@@Z=__imp__NtFlushBuffersFileEx@20")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?ZwFlushBuffersFileEx@nt@win32@fast_io@@YGIPAXI0IPAUio_status_block@123@@Z=__imp__ZwFlushBuffersFileEx@20")
-#pragma comment(linker, "/alternatename:__imp_?DbgPrint@nt@win32@fast_io@@YAIPBDZZ=__imp__DbgPrint")
-#pragma comment(linker, "/alternatename:__imp_?DbgPrintEx@nt@win32@fast_io@@YAIIIPBDZZ=__imp__DbgPrintEx")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?RtlCreateProcessParameters@nt@win32@fast_io@@YGIPAPAUrtl_user_process_parameters@123@PAUunicode_string@123@111PAX1111@Z=__imp__RtlCreateProcessParameters@40")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?RtlCreateProcessParametersEx@nt@win32@fast_io@@YGIPAPAUrtl_user_process_parameters@123@PAUunicode_string@123@111PAX1111I@Z=__imp__RtlCreateProcessParametersEx@44")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?RtlDestroyProcessParameters@nt@win32@fast_io@@YGIPAUrtl_user_process_parameters@123@@Z=__imp__RtlDestroyProcessParameters@4")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?NtCreateUserProcess@nt@win32@fast_io@@YGIPAX0IIPAUobject_attributes@123@1IIPAUrtl_user_process_parameters@123@PAUps_create_info@123@PAUps_attribute_list@123@@Z=__imp__NtCreateUserProcess@44")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?ZwCreateUserProcess@nt@win32@fast_io@@YGIPAX0IIPAUobject_attributes@123@1IIPAUrtl_user_process_parameters@123@PAUps_create_info@123@PAUps_attribute_list@123@@Z=__imp__ZwCreateUserProcess@44")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?RtlCreateUserProcess@nt@win32@fast_io@@YGIPAUunicode_string@123@IPAUrtl_user_process_parameters@123@PAUsecurity_descriptor@123@2PAXE33PAUrtl_user_process_information@123@@Z=__imp__RtlCreateUserProcess@40")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?NtMapViewOfSection@nt@win32@fast_io@@YGIPAX0PAPAXIIPBTlarge_integer@123@PAIW4section_inherit@123@II@Z=__imp__NtMapViewOfSection@40")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?ZwMapViewOfSection@nt@win32@fast_io@@YGIPAX0PAPAXIIPBTlarge_integer@123@PAIW4section_inherit@123@II@Z=__imp__ZwMapViewOfSection@40")
-#pragma comment( \
-	linker, "/alternatename:__imp_?NtUnmapViewOfSection@nt@win32@fast_io@@YGIPAX0@Z=__imp__NtUnmapViewOfSection@8")
-#pragma comment( \
-	linker, "/alternatename:__imp_?ZwUnmapViewOfSection@nt@win32@fast_io@@YGIPAX0@Z=__imp__ZwUnmapViewOfSection@8")
-#pragma comment(linker, "/alternatename:__imp_?SetConsoleCP@win32@fast_io@@YGHI@Z=__imp__SetConsoleCP@4")
-#pragma comment(linker, "/alternatename:__imp_?SetConsoleOutputCP@win32@fast_io@@YGHI@Z=__imp__SetConsoleOutputCP@4")
-#pragma comment(linker, "/alternatename:__imp_?GetConsoleCP@win32@fast_io@@YGIXZ=__imp__GetConsoleCP@0")
-#pragma comment(linker, "/alternatename:__imp_?GetConsoleOutputCP@win32@fast_io@@YGIXZ=__imp__GetConsoleOutputCP@0")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?NtReadVirtualMemory@nt@win32@fast_io@@YGIPAX00IPAI@Z=__imp__NtReadVirtualMemory@20")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?ZwReadVirtualMemory@nt@win32@fast_io@@YGIPAX00IPAI@Z=__imp__ZwReadVirtualMemory@20")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?NtWriteVirtualMemory@nt@win32@fast_io@@YGIPAX00IPAI@Z=__imp__NtWriteVirtualMemory@20")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?ZwWriteVirtualMemory@nt@win32@fast_io@@YGIPAX00IPAI@Z=__imp__ZwWriteVirtualMemory@20")
-#pragma comment(linker, "/alternatename:__imp_?RtlAcquirePebLock@nt@win32@fast_io@@YGIXZ=__imp__RtlAcquirePebLock@0")
-#pragma comment(linker, "/alternatename:__imp_?RtlReleasePebLock@nt@win32@fast_io@@YGIXZ=__imp__RtlReleasePebLock@0")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?NtAllocateVirtualMemory@nt@win32@fast_io@@YGIPAXPAPAXIPAIII@Z=__imp__NtAllocateVirtualMemory@24")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?ZwAllocateVirtualMemory@nt@win32@fast_io@@YGIPAXPAPAXIPAIII@Z=__imp__ZwAllocateVirtualMemory@24")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?NtQueryObject@nt@win32@fast_io@@YGIPAXW4object_information_class@123@0IPAI@Z=__imp__NtQueryObject@20")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?ZwQueryObject@nt@win32@fast_io@@YGIPAXW4object_information_class@123@0IPAI@Z=__imp__ZwQueryObject@20")
-
-
-#if defined(_DLL)
+// clang-format off
+#pragma comment(linker,"/alternatename:__imp_?GetLastError@win32@fast_io@@YGIXZ=__imp__GetLastError@0")
+#pragma comment(linker,"/alternatename:__imp_?LoadLibraryA@win32@fast_io@@YGPAXPBD@Z=__imp__LoadLibraryA@4")
+#pragma comment(linker,"/alternatename:__imp_?LoadLibraryW@win32@fast_io@@YGPAXPB_S@Z=__imp__LoadLibraryW@4")
+#pragma comment(linker,"/alternatename:__imp_?LoadLibraryExA@win32@fast_io@@YGPAXPBDPAXI@Z=__imp__LoadLibraryExA@12")
+#pragma comment(linker,"/alternatename:__imp_?LoadLibraryExW@win32@fast_io@@YGPAXPB_SPAXI@Z=__imp__LoadLibraryExW@12")
+#pragma comment(linker,"/alternatename:__imp_?FormatMessageA@win32@fast_io@@YGIIPBDIIPADIPAX@Z=__imp__FormatMessageA@28")
+#pragma comment(linker,"/alternatename:__imp_?FormatMessageW@win32@fast_io@@YGIIPB_SIIPA_SIPAX@Z=__imp__FormatMessageW@28")
+#pragma comment(linker,"/alternatename:__imp_?CreateFileMappingA@win32@fast_io@@YGPAXPAXPAUsecurity_attributes@12@IIIPBD@Z=__imp__CreateFileMappingA@24")
+#pragma comment(linker,"/alternatename:__imp_?CreateFileMappingW@win32@fast_io@@YGPAXPAXPAUsecurity_attributes@12@IIIPB_S@Z=__imp__CreateFileMappingW@24")
+#pragma comment(linker,"/alternatename:__imp_?MapViewOfFile@win32@fast_io@@YGPAXPAXIIII@Z=__imp__MapViewOfFile@20")
+#pragma comment(linker,"/alternatename:__imp_?SetEndOfFile@win32@fast_io@@YGHPAX@Z=__imp__SetEndOfFile@4")
+#pragma comment(linker,"/alternatename:__imp_?UnmapViewOfFile@win32@fast_io@@YGHPBX@Z=__imp__UnmapViewOfFile@4")
+#pragma comment(linker,"/alternatename:__imp_?WriteFile@win32@fast_io@@YGHPAXPBXIPAIPAUoverlapped@12@@Z=__imp__WriteFile@20")
+#pragma comment(linker,"/alternatename:__imp_?ReadFile@win32@fast_io@@YGHPAXPBXIPAIPAUoverlapped@12@@Z=__imp__ReadFile@20")
+#pragma comment(linker,"/alternatename:__imp_?SetFilePointer@win32@fast_io@@YGIPAXHPAHI@Z=__imp__SetFilePointer@16")
+#pragma comment(linker,"/alternatename:__imp_?SetFilePointerEx@win32@fast_io@@YGHPAX_JPA_JI@Z=__imp__SetFilePointerEx@20")
+#pragma comment(linker,"/alternatename:__imp_?DuplicateHandle@win32@fast_io@@YGHPAX00PAPAXIHI@Z=__imp__DuplicateHandle@28")
+#pragma comment(linker,"/alternatename:__imp_?GetStdHandle@win32@fast_io@@YGPAXI@Z=__imp__GetStdHandle@4")
+#pragma comment(linker,"/alternatename:__imp_?CreatePipe@win32@fast_io@@YGHPAPAX0PAUsecurity_attributes@12@I@Z=__imp__CreatePipe@16")
+#pragma comment(linker,"/alternatename:__imp_?FreeLibrary@win32@fast_io@@YGHPAX@Z=__imp__FreeLibrary@4")
+#pragma comment(linker,"/alternatename:__imp_?GetProcAddress@win32@fast_io@@YGP6GHX_EPAXPBD@Z=__imp__GetProcAddress@8")
+#pragma comment(linker,"/alternatename:__imp_?GetModuleHandleA@win32@fast_io@@YGPAXPBD@Z=__imp__GetModuleHandleA@4")
+#pragma comment(linker,"/alternatename:__imp_?GetModuleHandleW@win32@fast_io@@YGPAXPB_S@Z=__imp__GetModuleHandleW@4")
+#pragma comment(linker,"/alternatename:__imp_?WaitForSingleObject@win32@fast_io@@YGIPAXI@Z=__imp__WaitForSingleObject@8")
+#pragma comment(linker,"/alternatename:__imp_?CancelIo@win32@fast_io@@YGIPAX@Z=__imp__CancelIo@4")
+#pragma comment(linker,"/alternatename:__imp_?GetFileInformationByHandle@win32@fast_io@@YGHPIAXPIAUby_handle_file_information@12@@Z=__imp__GetFileInformationByHandle@8")
+#pragma comment(linker,"/alternatename:__imp_?GetUserDefaultLocaleName@win32@fast_io@@YGHPA_SH@Z=__imp__GetUserDefaultLocaleName@8")
+#pragma comment(linker,"/alternatename:__imp_?GetUserDefaultLCID@win32@fast_io@@YGIXZ=__imp__GetUserDefaultLCID@0")
+#pragma comment(linker,"/alternatename:__imp_?GetSystemTimePreciseAsFileTime@win32@fast_io@@YGXPAUfiletime@12@@Z=__imp__GetSystemTimePreciseAsFileTime@4")
+#pragma comment(linker,"/alternatename:__imp_?GetSystemTimeAsFileTime@win32@fast_io@@YGXPAUfiletime@12@@Z=__imp__GetSystemTimeAsFileTime@4")
+#pragma comment(linker,"/alternatename:__imp_?QueryUnbiasedInterruptTime@win32@fast_io@@YGHPA_K@Z=__imp__QueryUnbiasedInterruptTime@4")
+#pragma comment(linker,"/alternatename:__imp_?QueryPerformanceCounter@win32@fast_io@@YGHPA_J@Z=__imp__QueryPerformanceCounter@4")
+#pragma comment(linker,"/alternatename:__imp_?QueryPerformanceFrequency@win32@fast_io@@YGHPA_J@Z=__imp__QueryPerformanceFrequency@4")
+#pragma comment(linker,"/alternatename:__imp_?GetProcessTimes@win32@fast_io@@YGHPAXPAUfiletime@12@111@Z=__imp__GetProcessTimes@20")
+#pragma comment(linker,"/alternatename:__imp_?GetThreadTimes@win32@fast_io@@YGHPAXPAUfiletime@12@111@Z=__imp__GetThreadTimes@20")
+#pragma comment(linker,"/alternatename:__imp_?GetHandleInformation@win32@fast_io@@YGHPAXPAI@Z=__imp__GetHandleInformation@8")
+#pragma comment(linker,"/alternatename:__imp_?SetHandleInformation@win32@fast_io@@YGHPAXII@Z=__imp__SetHandleInformation@12")
+#pragma comment(linker,"/alternatename:__imp_?GetTempPathA@win32@fast_io@@YGIIPAD@Z=__imp__GetTempPathA@8")
+#pragma comment(linker,"/alternatename:__imp_?GetTempPathW@win32@fast_io@@YGIIPA_S@Z=__imp__GetTempPathW@8")
+#pragma comment(linker,"/alternatename:__imp_?CreateFileA@win32@fast_io@@YGPAXPBDIIPAUsecurity_attributes@12@IIPAX@Z=__imp__CreateFileA@28")
+#pragma comment(linker,"/alternatename:__imp_?CreateFileW@win32@fast_io@@YGPAXPB_SIIPAUsecurity_attributes@12@IIPAX@Z=__imp__CreateFileW@28")
+#pragma comment(linker,"/alternatename:__imp_?CreateIoCompletionPort@win32@fast_io@@YGPAXPAX0II@Z=__imp__CreateIoCompletionPort@16")
+#pragma comment(linker,"/alternatename:__imp_?SystemFunction036@win32@fast_io@@YGHPAXI@Z=__imp__SystemFunction036@8")
+#pragma comment(linker,"/alternatename:__imp_?CloseHandle@win32@fast_io@@YGHPAX@Z=__imp__CloseHandle@4")
+#pragma comment(linker,"/alternatename:__imp_?LockFileEx@win32@fast_io@@YGHPAXIIIIPAUoverlapped@12@@Z=__imp__LockFileEx@24")
+#pragma comment(linker,"/alternatename:__imp_?UnlockFileEx@win32@fast_io@@YGHPAXIIIPAUoverlapped@12@@Z=__imp__UnlockFileEx@20")
+#pragma comment(linker,"/alternatename:__imp_?DeviceIoControl@win32@fast_io@@YGHPAXI0I0I0PAUoverlapped@12@@Z=__imp__DeviceIoControl@32")
+#pragma comment(linker,"/alternatename:__imp_?GetFileType@win32@fast_io@@YGIPAX@Z=__imp__GetFileType@4")
+#pragma comment(linker,"/alternatename:__imp_?GetACP@win32@fast_io@@YGIXZ=__imp__GetACP@0")
+#pragma comment(linker,"/alternatename:__imp_?GetEnvironmentVariableA@win32@fast_io@@YGIPBDPADI@Z=__imp__GetEnvironmentVariableA@12")
+#pragma comment(linker,"/alternatename:__imp_?GetEnvironmentVariableW@win32@fast_io@@YGIPB_SPA_SI@Z=__imp__GetEnvironmentVariableW@12")
+#pragma comment(linker,"/alternatename:__imp_?MessageBoxA@win32@fast_io@@YGIPAXPBD1I@Z=__imp__MessageBoxA@16")
+#pragma comment(linker,"/alternatename:__imp_?MessageBoxW@win32@fast_io@@YGIPAXPB_S1I@Z=__imp__MessageBoxW@16")
+#pragma comment(linker,"/alternatename:__imp_?GetConsoleMode@win32@fast_io@@YGHPAXPAI@Z=__imp__GetConsoleMode@8")
+#pragma comment(linker,"/alternatename:__imp_?SetConsoleMode@win32@fast_io@@YGHPAXI@Z=__imp__SetConsoleMode@8")
+#pragma comment(linker,"/alternatename:__imp_?ReadConsoleA@win32@fast_io@@YGHPAX0IPAI0@Z=__imp__ReadConsoleA@20")
+#pragma comment(linker,"/alternatename:__imp_?ReadConsoleW@win32@fast_io@@YGHPAX0IPAI0@Z=__imp__ReadConsoleW@20")
+#pragma comment(linker,"/alternatename:__imp_?WriteConsoleA@win32@fast_io@@YGHPAXPBXIPAI0@Z=__imp__WriteConsoleA@20")
+#pragma comment(linker,"/alternatename:__imp_?WriteConsoleW@win32@fast_io@@YGHPAXPBXIPAI0@Z=__imp__WriteConsoleW@20")
+#pragma comment(linker,"/alternatename:__imp_?GetConsoleScreenBufferInfo@win32@fast_io@@YGHPAXPAUconsole_screen_buffer_info@12@@Z=__imp__GetConsoleScreenBufferInfo@8")
+#pragma comment(linker,"/alternatename:__imp_?ScrollConsoleScreenBufferA@win32@fast_io@@YGHPAXPBUsmall_rect@12@1Ucoord@12@PBUchar_info@12@@Z=__imp__ScrollConsoleScreenBufferA@20")
+#pragma comment(linker,"/alternatename:__imp_?ScrollConsoleScreenBufferW@win32@fast_io@@YGHPAXPBUsmall_rect@12@1Ucoord@12@PBUchar_info@12@@Z=__imp__ScrollConsoleScreenBufferW@20")
+#pragma comment(linker,"/alternatename:__imp_?SetConsoleCursorPosition@win32@fast_io@@YGHPAXUcoord@12@@Z=__imp__SetConsoleCursorPosition@8")
+#pragma comment(linker,"/alternatename:__imp_?InitializeCriticalSection@win32@fast_io@@YGXPAX@Z=__imp__InitializeCriticalSection@4")
+#pragma comment(linker,"/alternatename:__imp_?EnterCriticalSection@win32@fast_io@@YGXPAX@Z=__imp__EnterCriticalSection@4")
+#pragma comment(linker,"/alternatename:__imp_?TryEnterCriticalSection@win32@fast_io@@YGHPAX@Z=__imp__TryEnterCriticalSection@4")
+#pragma comment(linker,"/alternatename:__imp_?LeaveCriticalSection@win32@fast_io@@YGXPAX@Z=__imp__LeaveCriticalSection@4")
+#pragma comment(linker,"/alternatename:__imp_?DeleteCriticalSection@win32@fast_io@@YGXPAX@Z=__imp__DeleteCriticalSection@4")
+#pragma comment(linker,"/alternatename:__imp_?WSADuplicateSocketA@win32@fast_io@@YGHPAXIPAUwsaprotocol_infoa@12@@Z=__imp__WSADuplicateSocketA@12")
+#pragma comment(linker,"/alternatename:__imp_?WSADuplicateSocketW@win32@fast_io@@YGXPAXIPAUwsaprotocol_infow@12@@Z=__imp__WSADuplicateSocketW@12")
+#pragma comment(linker,"/alternatename:__imp_?WSACleanup@win32@fast_io@@YGHXZ=__imp__WSACleanup@0")
+#pragma comment(linker,"/alternatename:__imp_?WSAStartup@win32@fast_io@@YGHIPAUwsadata@12@@Z=__imp__WSAStartup@8")
+#pragma comment(linker,"/alternatename:__imp_?WSAGetLastError@win32@fast_io@@YGHXZ=__imp__WSAGetLastError@0")
+#pragma comment(linker,"/alternatename:__imp_?closesocket@win32@fast_io@@YGHI@Z=__imp__closesocket@4")
+#pragma comment(linker,"/alternatename:__imp_?WSASocketW@win32@fast_io@@YGIHHHPAUwsaprotocol_infow@12@II@Z=__imp__WSASocketW@24")
+#pragma comment(linker,"/alternatename:__imp_?WSASocketA@win32@fast_io@@YGIHHHPAUwsaprotocol_infoa@12@II@Z=__imp__WSASocketA@24")
+#pragma comment(linker,"/alternatename:__imp_?bind@win32@fast_io@@YGHIPBXH@Z=__imp__bind@12")
+#pragma comment(linker,"/alternatename:__imp_?listen@win32@fast_io@@YGHIH@Z=__imp__listen@8")
+#pragma comment(linker,"/alternatename:__imp_?WSAAccept@win32@fast_io@@YGIIPBXPAHP6GXPAUwsabuf@12@2PAUqualityofservice@12@322PAII@_EI@Z=__imp__WSAAccept@20")
+#pragma comment(linker,"/alternatename:__imp_?ioctlsocket@win32@fast_io@@YGHIJPAI@Z=__imp__ioctlsocket@12")
+#pragma comment(linker,"/alternatename:__imp_?sendto@win32@fast_io@@YGHIPBDHHPBXH@Z=__imp__sendto@24")
+#pragma comment(linker,"/alternatename:__imp_?WSASend@win32@fast_io@@YGHIPAUwsabuf@12@IPAIIPAUoverlapped@12@P6GXII2I@_E@Z=__imp__WSASend@28")
+#pragma comment(linker,"/alternatename:__imp_?WSASendMsg@win32@fast_io@@YGHIPAUwsamsg@12@IPAIPAUoverlapped@12@P6GXII2I@_E@Z=__imp__WSASendMsg@24")
+#pragma comment(linker,"/alternatename:__imp_?WSASendTo@win32@fast_io@@YGHIPAUwsabuf@12@IPAIIPBXHPAUoverlapped@12@P6GXII3I@_E@Z=__imp__WSASendTo@36")
+#pragma comment(linker,"/alternatename:__imp_?recv@win32@fast_io@@YGHIPADHH@Z=__imp__recv@16")
+#pragma comment(linker,"/alternatename:__imp_?recvfrom@win32@fast_io@@YGHIPADHHPAXPAH@Z=__imp__recvfrom@24")
+#pragma comment(linker,"/alternatename:__imp_?WSARecv@win32@fast_io@@YGHIPAUwsabuf@12@IPAI1PAUoverlapped@12@P6GXII2I@_E@Z=__imp__WSARecv@28")
+#pragma comment(linker,"/alternatename:__imp_?WSARecvFrom@win32@fast_io@@YGHIPAUwsabuf@12@IPAI1PAXPAHPAUoverlapped@12@P6GXII4I@_E@Z=__imp__WSARecvFrom@36")
+#pragma comment(linker,"/alternatename:__imp_?connect@win32@fast_io@@YGHIPBXH@Z=__imp__connect@12")
+#pragma comment(linker,"/alternatename:__imp_?WSAConnect@win32@fast_io@@YGHIPBXHPAUwsabuf@12@1PAUqualityofservice@12@2@Z=__imp__WSAConnect@28")
+#pragma comment(linker,"/alternatename:__imp_?shutdown@win32@fast_io@@YGHIPBXH@Z=__imp__shutdown@8")
+#pragma comment(linker,"/alternatename:__imp_?GetCurrentProcessId@win32@fast_io@@YGIXZ=__imp__GetCurrentProcessId@0")
+#pragma comment(linker,"/alternatename:__imp_?FlushFileBuffers@win32@fast_io@@YGHPAX@Z=__imp__FlushFileBuffers@4")
+#pragma comment(linker,"/alternatename:__imp_?GetQueuedCompletionStatus@win32@fast_io@@YGHPAXPAI1PAUoverlapped@12@I@Z=__imp__GetQueuedCompletionStatus@20")
+#pragma comment(linker,"/alternatename:__imp_?freeaddrinfo@win32@fast_io@@YGXPAU?$win32_family_addrinfo@$0A@@12@@Z=__imp__freeaddrinfo@4")
+#pragma comment(linker,"/alternatename:__imp_?FreeAddrInfoW@win32@fast_io@@YGXPAU?$win32_family_addrinfo@$00@12@@Z=__imp__FreeAddrInfoW@4")
+#pragma comment(linker,"/alternatename:__imp_?getaddrinfo@win32@fast_io@@YGHPBD0PBU?$win32_family_addrinfo@$0A@@12@PAPAU312@@Z=__imp__getaddrinfo@16")
+#pragma comment(linker,"/alternatename:__imp_?GetAddrInfoW@win32@fast_io@@YGHPB_S0PBU?$win32_family_addrinfo@$00@12@PAPAU312@@Z=__imp__GetAddrInfoW@16")
+#pragma comment(linker,"/alternatename:__imp_?CryptAcquireContextA@win32@fast_io@@YGHPAIPB_Q1II@Z=__imp__CryptAcquireContextA@20")
+#pragma comment(linker,"/alternatename:__imp_?CryptAcquireContextW@win32@fast_io@@YGHPAIPB_S1II@Z=__imp__CryptAcquireContextW@20")
+#pragma comment(linker,"/alternatename:__imp_?CryptReleaseContext@win32@fast_io@@YGHII@Z=__imp__CryptReleaseContext@8")
+#pragma comment(linker,"/alternatename:__imp_?CryptGenRandom@win32@fast_io@@YGHIIPAE@Z=__imp__CryptGenRandom@12")
+#pragma comment(linker,"/alternatename:__imp_?RegOpenKeyA@win32@fast_io@@YGHIPB_QPAI@Z=__imp__RegOpenKeyA@12")
+#pragma comment(linker,"/alternatename:__imp_?RegOpenKeyW@win32@fast_io@@YGHIPB_SPAI@Z=__imp__RegOpenKeyW@12")
+#pragma comment(linker,"/alternatename:__imp_?RegQueryValueExA@win32@fast_io@@YGHIPB_QPAI1PAX1@Z=__imp__RegQueryValueExA@24")
+#pragma comment(linker,"/alternatename:__imp_?RegQueryValueExW@win32@fast_io@@YGHIPB_SPAI1PAX1@Z=__imp__RegQueryValueExW@24")
+#pragma comment(linker,"/alternatename:__imp_?RegCloseKey@win32@fast_io@@YGHI@Z=__imp__RegCloseKey@4")
+#pragma comment(linker,"/alternatename:__imp_?GetTimeZoneInformation@win32@fast_io@@YGIPAUtime_zone_information@12@@Z=__imp__GetTimeZoneInformation@4")
+#pragma comment(linker,"/alternatename:__imp_?SetConsoleCP@win32@fast_io@@YGHI@Z=__imp__SetConsoleCP@4")
+#pragma comment(linker,"/alternatename:__imp_?SetConsoleOutputCP@win32@fast_io@@YGHI@Z=__imp__SetConsoleOutputCP@4")
+#pragma comment(linker,"/alternatename:__imp_?GetConsoleCP@win32@fast_io@@YGIXZ=__imp__GetConsoleCP@0")
+#pragma comment(linker,"/alternatename:__imp_?GetConsoleOutputCP@win32@fast_io@@YGIXZ=__imp__GetConsoleOutputCP@0")
+#pragma comment(linker,"/alternatename:__imp_?AcquireSRWLockExclusive@win32@fast_io@@YGXPAX@Z=__imp__AcquireSRWLockExclusive@4")
+#pragma comment(linker,"/alternatename:__imp_?TryAcquireSRWLockExclusive@win32@fast_io@@YGIPAX@Z=__imp__TryAcquireSRWLockExclusive@4")
+#pragma comment(linker,"/alternatename:__imp_?ReleaseSRWLockExclusive@win32@fast_io@@YGXPAX@Z=__imp__ReleaseSRWLockExclusive@4")
+#pragma comment(linker,"/alternatename:__imp_?rtl_nt_status_to_dos_error@nt@win32@fast_io@@YGII@Z=__imp__RtlNtStatusToDosError@4")
+#pragma comment(linker,"/alternatename:__imp_?NtClose@nt@win32@fast_io@@YGIPAX@Z=__imp__NtClose@4")
+#pragma comment(linker,"/alternatename:__imp_?ZwClose@nt@win32@fast_io@@YGIPAX@Z=__imp__ZwClose@4")
+#pragma comment(linker,"/alternatename:__imp_?NtCreateFile@nt@win32@fast_io@@YGIPAPAXIPAUobject_attributes@123@PAUio_status_block@123@PA_JIIIIPAXI@Z=__imp__NtCreateFile@44")
+#pragma comment(linker,"/alternatename:__imp_?ZwCreateFile@nt@win32@fast_io@@YGIPAPAXIPAUobject_attributes@123@PAUio_status_block@123@PA_JIIIIPAXI@Z=__imp__ZwCreateFile@44")
+#pragma comment(linker,"/alternatename:__imp_?NtCreateSection@nt@win32@fast_io@@YGIPIAPAXIPIAUobject_attributes@123@PA_KIIPIAX@Z=__imp__NtCreateSection@28")
+#pragma comment(linker,"/alternatename:__imp_?ZwCreateSection@nt@win32@fast_io@@YGIPIAPAXIPIAUobject_attributes@123@PA_KIIPIAX@Z=__imp__ZwCreateSection@28")
+#pragma comment(linker,"/alternatename:__imp_?NtQueryInformationProcess@nt@win32@fast_io@@YGIPIAXW4process_information_class@123@PAUprocess_basic_information@123@IPAI@Z=__imp__NtQueryInformationProcess@20")
+#pragma comment(linker,"/alternatename:__imp_?ZwQueryInformationProcess@nt@win32@fast_io@@YGIPIAXW4process_information_class@123@PAUprocess_basic_information@123@IPAI@Z=__imp__ZwQueryInformationProcess@20")
+#pragma comment(linker,"/alternatename:__imp_?NtWriteFile@nt@win32@fast_io@@YGIPAX0P6AX0PAUio_status_block@123@I@_E01PBXIPA_JPAI@Z=__imp__NtWriteFile@36")
+#pragma comment(linker,"/alternatename:__imp_?ZwWriteFile@nt@win32@fast_io@@YGIPAX0P6AX0PAUio_status_block@123@I@_E01PBXIPA_JPAI@Z=__imp__ZwWriteFile@36")
+#pragma comment(linker,"/alternatename:__imp_?NtReadFile@nt@win32@fast_io@@YGIPAX0P6AX0PAUio_status_block@123@I@_E01PBXIPA_JPAI@Z=__imp__NtReadFile@36")
+#pragma comment(linker,"/alternatename:__imp_?ZwReadFile@nt@win32@fast_io@@YGIPAX0P6AX0PAUio_status_block@123@I@_E01PBXIPA_JPAI@Z=__imp__ZwReadFile@36")
+#pragma comment(linker,"/alternatename:__imp_?NtQueryDirectoryFile@nt@win32@fast_io@@YGIPAX0P6AX0PAUio_status_block@123@I@_E010IW4file_information_class@123@HPAUunicode_string@123@H@Z=__imp__NtQueryDirectoryFile@44")
+#pragma comment(linker,"/alternatename:__imp_?ZwQueryDirectoryFile@nt@win32@fast_io@@YGIPAX0P6AX0PAUio_status_block@123@I@_E010IW4file_information_class@123@HPAUunicode_string@123@H@Z=__imp__ZwQueryDirectoryFile@44")
+#pragma comment(linker,"/alternatename:__imp_?NtQuerySection@nt@win32@fast_io@@YGIPAXW4section_information_class@123@0IPAI@Z=__imp__NtQuerySection@20")
+#pragma comment(linker,"/alternatename:__imp_?ZwQuerySection@nt@win32@fast_io@@YGIPAXW4section_information_class@123@0IPAI@Z=__imp__ZwQuerySection@20")
+#pragma comment(linker,"/alternatename:__imp_?NtQueryInformationFile@nt@win32@fast_io@@YGIPIAXPIAUio_status_block@123@0IW4file_information_class@123@@Z=__imp__NtQueryInformationFile@20")
+#pragma comment(linker,"/alternatename:__imp_?ZwQueryInformationFile@nt@win32@fast_io@@YGIPIAXPIAUio_status_block@123@0IW4file_information_class@123@@Z=__imp__ZwQueryInformationFile@20")
+#pragma comment(linker,"/alternatename:__imp_?NtSetInformationFile@nt@win32@fast_io@@YGIPIAXPIAUio_status_block@123@0IW4file_information_class@123@@Z=__imp__NtSetInformationFile@20")
+#pragma comment(linker,"/alternatename:__imp_?ZwSetInformationFile@nt@win32@fast_io@@YGIPIAXPIAUio_status_block@123@0IW4file_information_class@123@@Z=__imp__ZwSetInformationFile@20")
+#pragma comment(linker,"/alternatename:__imp_?NtDuplicateObject@nt@win32@fast_io@@YGIPAX00PAPAXIII@Z=__imp__NtDuplicateObject@28")
+#pragma comment(linker,"/alternatename:__imp_?ZwDuplicateObject@nt@win32@fast_io@@YGIPAX00PAPAXIII@Z=__imp__ZwDuplicateObject@28")
+#pragma comment(linker,"/alternatename:__imp_?NtWaitForSingleObject@nt@win32@fast_io@@YGIPAXHPA_K@Z=__imp__NtWaitForSingleObject@12")
+#pragma comment(linker,"/alternatename:__imp_?ZwWaitForSingleObject@nt@win32@fast_io@@YGIPAXHPA_K@Z=__imp__ZwWaitForSingleObject@12")
+#pragma comment(linker,"/alternatename:__imp_?NtSetSystemTime@nt@win32@fast_io@@YGIPA_K0@Z=__imp__NtSetSystemTime@8")
+#pragma comment(linker,"/alternatename:__imp_?ZwSetSystemTime@nt@win32@fast_io@@YGIPA_K0@Z=__imp__ZwSetSystemTime@8")
+#pragma comment(linker,"/alternatename:__imp_?NtCreateProcess@nt@win32@fast_io@@YGIPAPAXIPAUobject_attributes@123@PAXI222@Z=__imp__NtCreateProcess@32")
+#pragma comment(linker,"/alternatename:__imp_?ZwCreateProcess@nt@win32@fast_io@@YGIPAPAXIPAUobject_attributes@123@PAXI222@Z=__imp__ZwCreateProcess@32")
+#pragma comment(linker,"/alternatename:__imp_?rtl_dos_path_name_to_nt_path_name_u@nt@win32@fast_io@@YGEPB_WPAUunicode_string@123@PAPB_WPAUrtl_relative_name_u@123@@Z=__imp__RtlDosPathNameToNtPathName_U@16")
+#pragma comment(linker,"/alternatename:__imp_?rtl_dos_path_name_to_nt_path_name_u_with_status@nt@win32@fast_io@@YGIPB_WPAUunicode_string@123@PAPB_WPAUrtl_relative_name_u@123@@Z=__imp__RtlDosPathNameToNtPathName_U_WithStatus@16")
+#pragma comment(linker,"/alternatename:__imp_?rtl_free_unicode_string@nt@win32@fast_io@@YGXPAUunicode_string@123@@Z=__imp__RtlFreeUnicodeString@4")
+#pragma comment(linker,"/alternatename:__imp_?RtlInitializeCriticalSection@nt@win32@fast_io@@YGXPAX@Z=__imp__RtlInitializeCriticalSection@4")
+#pragma comment(linker,"/alternatename:__imp_?RtlEnterCriticalSection@nt@win32@fast_io@@YGXPAX@Z=__imp__RtlEnterCriticalSection@4")
+#pragma comment(linker,"/alternatename:__imp_?RtlTryEnterCriticalSection@nt@win32@fast_io@@YGHPAX@Z=__imp__RtlTryEnterCriticalSection@4")
+#pragma comment(linker,"/alternatename:__imp_?RtlLeaveCriticalSection@nt@win32@fast_io@@YGXPAX@Z=__imp__RtlLeaveCriticalSection@4")
+#pragma comment(linker,"/alternatename:__imp_?RtlDeleteCriticalSection@nt@win32@fast_io@@YGXPAX@Z=__imp__RtlDeleteCriticalSection@4")
+#pragma comment(linker,"/alternatename:__imp_?RtlCreateUserThread@nt@win32@fast_io@@YGIPAX0HIII00PAPAXPAUclient_id@123@@Z=__imp__RtlCreateUserThread@40")
+#pragma comment(linker,"/alternatename:__imp_?NtResumeThread@nt@win32@fast_io@@YGIPAXPAI@Z=__imp__NtResumeThread@8")
+#pragma comment(linker,"/alternatename:__imp_?ZwResumeThread@nt@win32@fast_io@@YGIPAXPAI@Z=__imp__ZwResumeThread@8")
+#pragma comment(linker,"/alternatename:__imp_?NtLockFile@nt@win32@fast_io@@YGIPAX0P6AX0PAUio_status_block@123@I@_E01PA_J3IEE@Z=__imp__NtLockFile@40")
+#pragma comment(linker,"/alternatename:__imp_?ZwLockFile@nt@win32@fast_io@@YGIPAX0P6AX0PAUio_status_block@123@I@_E01PA_J3IEE@Z=__imp__ZwLockFile@40")
+#pragma comment(linker,"/alternatename:__imp_?NtUnlockFile@nt@win32@fast_io@@YGIPAXPAUio_status_block@123@PA_J2I@Z=__imp__NtUnlockFile@20")
+#pragma comment(linker,"/alternatename:__imp_?ZwUnlockFile@nt@win32@fast_io@@YGIPAXPAUio_status_block@123@PA_J2I@Z=__imp__ZwUnlockFile@20")
+#pragma comment(linker,"/alternatename:__imp_?NtFlushBuffersFile@nt@win32@fast_io@@YGIPAXPAUio_status_block@123@@Z=__imp__NtFlushBuffersFile@8")
+#pragma comment(linker,"/alternatename:__imp_?ZwFlushBuffersFile@nt@win32@fast_io@@YGIPAXPAUio_status_block@123@@Z=__imp__ZwFlushBuffersFile@8")
+#pragma comment(linker,"/alternatename:__imp_?NtFlushBuffersFileEx@nt@win32@fast_io@@YGIPAXI0IPAUio_status_block@123@@Z=__imp__NtFlushBuffersFileEx@20")
+#pragma comment(linker,"/alternatename:__imp_?ZwFlushBuffersFileEx@nt@win32@fast_io@@YGIPAXI0IPAUio_status_block@123@@Z=__imp__ZwFlushBuffersFileEx@20")
+#pragma comment(linker,"/alternatename:__imp_?DbgPrint@nt@win32@fast_io@@YAIPBDZZ=__imp__DbgPrint")
+#pragma comment(linker,"/alternatename:__imp_?DbgPrintEx@nt@win32@fast_io@@YAIIIPBDZZ=__imp__DbgPrintEx")
+#pragma comment(linker,"/alternatename:__imp_?RtlCreateProcessParameters@nt@win32@fast_io@@YGIPAPAUrtl_user_process_parameters@123@PAUunicode_string@123@111PAX1111@Z=__imp__RtlCreateProcessParameters@40")
+#pragma comment(linker,"/alternatename:__imp_?RtlCreateProcessParametersEx@nt@win32@fast_io@@YGIPAPAUrtl_user_process_parameters@123@PAUunicode_string@123@111PAX1111I@Z=__imp__RtlCreateProcessParametersEx@44")
+#pragma comment(linker,"/alternatename:__imp_?RtlDestroyProcessParameters@nt@win32@fast_io@@YGIPAUrtl_user_process_parameters@123@@Z=__imp__RtlDestroyProcessParameters@4")
+#pragma comment(linker,"/alternatename:__imp_?NtCreateUserProcess@nt@win32@fast_io@@YGIPAX0IIPAUobject_attributes@123@1IIPAUrtl_user_process_parameters@123@PAUps_create_info@123@PAUps_attribute_list@123@@Z=__imp__NtCreateUserProcess@44")
+#pragma comment(linker,"/alternatename:__imp_?ZwCreateUserProcess@nt@win32@fast_io@@YGIPAX0IIPAUobject_attributes@123@1IIPAUrtl_user_process_parameters@123@PAUps_create_info@123@PAUps_attribute_list@123@@Z=__imp__ZwCreateUserProcess@44")
+#pragma comment(linker,"/alternatename:__imp_?RtlCreateUserProcess@nt@win32@fast_io@@YGIPAUunicode_string@123@IPAUrtl_user_process_parameters@123@PAUsecurity_descriptor@123@2PAXE33PAUrtl_user_process_information@123@@Z=__imp__RtlCreateUserProcess@40")
+#pragma comment(linker,"/alternatename:__imp_?NtMapViewOfSection@nt@win32@fast_io@@YGIPAX0PAPAXIIPBTlarge_integer@123@PAIW4section_inherit@123@II@Z=__imp__NtMapViewOfSection@40")
+#pragma comment(linker,"/alternatename:__imp_?ZwMapViewOfSection@nt@win32@fast_io@@YGIPAX0PAPAXIIPBTlarge_integer@123@PAIW4section_inherit@123@II@Z=__imp__ZwMapViewOfSection@40")
+#pragma comment(linker,"/alternatename:__imp_?NtUnmapViewOfSection@nt@win32@fast_io@@YGIPAX0@Z=__imp__NtUnmapViewOfSection@8")
+#pragma comment(linker,"/alternatename:__imp_?ZwUnmapViewOfSection@nt@win32@fast_io@@YGIPAX0@Z=__imp__ZwUnmapViewOfSection@8")
+#pragma comment(linker,"/alternatename:__imp_?NtReadVirtualMemory@nt@win32@fast_io@@YGIPAX00IPAI@Z=__imp__NtReadVirtualMemory@20")
+#pragma comment(linker,"/alternatename:__imp_?ZwReadVirtualMemory@nt@win32@fast_io@@YGIPAX00IPAI@Z=__imp__ZwReadVirtualMemory@20")
+#pragma comment(linker,"/alternatename:__imp_?NtWriteVirtualMemory@nt@win32@fast_io@@YGIPAX00IPAI@Z=__imp__NtWriteVirtualMemory@20")
+#pragma comment(linker,"/alternatename:__imp_?ZwWriteVirtualMemory@nt@win32@fast_io@@YGIPAX00IPAI@Z=__imp__ZwWriteVirtualMemory@20")
+#pragma comment(linker,"/alternatename:__imp_?RtlAcquirePebLock@nt@win32@fast_io@@YGIXZ=__imp__RtlAcquirePebLock@0")
+#pragma comment(linker,"/alternatename:__imp_?RtlReleasePebLock@nt@win32@fast_io@@YGIXZ=__imp__RtlReleasePebLock@0")
+#pragma comment(linker,"/alternatename:__imp_?NtAllocateVirtualMemory@nt@win32@fast_io@@YGIPAXPAPAXIPAIII@Z=__imp__NtAllocateVirtualMemory@24")
+#pragma comment(linker,"/alternatename:__imp_?ZwAllocateVirtualMemory@nt@win32@fast_io@@YGIPAXPAPAXIPAIII@Z=__imp__ZwAllocateVirtualMemory@24")
+#pragma comment(linker,"/alternatename:__imp_?RtlInitUnicodeString@nt@win32@fast_io@@YGIPAUunicode_string@123@PA_S@Z=__imp__RtlInitUnicodeString@8")
+#pragma comment(linker,"/alternatename:__imp_?CsrClientCallServer@nt@win32@fast_io@@YGIPAX0II@Z=__imp__CsrClientCallServer@16")
+#pragma comment(linker,"/alternatename:__imp_?RtlAcquireSRWLockExclusive@nt@win32@fast_io@@YGXPAX@Z=__imp__RtlAcquireSRWLockExclusive@4")
+#pragma comment(linker,"/alternatename:__imp_?RtlTryAcquireSRWLockExclusive@nt@win32@fast_io@@YGIPAX@Z=__imp__RtlTryAcquireSRWLockExclusive@4")
+#pragma comment(linker,"/alternatename:__imp_?RtlReleaseSRWLockExclusive@nt@win32@fast_io@@YGXPAX@Z=__imp__RtlReleaseSRWLockExclusive@4")
 #pragma comment(linker,"/alternatename:__imp_?msvc__RTtypeid@msvc@fast_io@@YAPAXPAX@Z=__imp____RTtypeid")
-#else
 #pragma comment(linker,"/alternatename:?msvc__RTtypeid@msvc@fast_io@@YAPAXPAX@Z=___RTtypeid")
-#endif
+// clang-format on

--- a/include/fast_io_hosted/platforms/win32/msvc_linker_64.h
+++ b/include/fast_io_hosted/platforms/win32/msvc_linker_64.h
@@ -1,396 +1,194 @@
-﻿#pragma once
+#pragma once
 
-#pragma comment(linker, "/alternatename:__imp_?GetLastError@win32@fast_io@@YAIXZ=__imp_GetLastError")
-#pragma comment(linker, "/alternatename:__imp_?LoadLibraryA@win32@fast_io@@YAPEAXPEBD@Z=__imp_LoadLibraryA")
-#pragma comment(linker, "/alternatename:__imp_?LoadLibraryW@win32@fast_io@@YAPEAXPEB_S@Z=__imp_LoadLibraryW")
-#pragma comment(linker, "/alternatename:__imp_?LoadLibraryExA@win32@fast_io@@YAPEAXPEBDPEAXI@Z=__imp_LoadLibraryExA")
-#pragma comment(linker, "/alternatename:__imp_?LoadLibraryExW@win32@fast_io@@YAPEAXPEB_SPEAXI@Z=__imp_LoadLibraryExW")
-#pragma comment(linker, \
-				"/alternatename:__imp_?FormatMessageA@win32@fast_io@@YAIIPEBDIIPEADIPEAX@Z=__imp_FormatMessageA")
-#pragma comment(linker, \
-				"/alternatename:__imp_?FormatMessageW@win32@fast_io@@YAIIPEB_SIIPEA_SIPEAX@Z=__imp_FormatMessageW")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?CreateFileMappingA@win32@fast_io@@YAPEAXPEAXPEAUsecurity_attributes@12@IIIPEBD@Z=__imp_CreateFileMappingA")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?CreateFileMappingW@win32@fast_io@@YAPEAXPEAXPEAUsecurity_attributes@12@IIIPEB_S@Z=__imp_CreateFileMappingW")
-#pragma comment(linker, "/alternatename:__imp_?MapViewOfFile@win32@fast_io@@YAPEAXPEAXIII_K@Z=__imp_MapViewOfFile")
-#pragma comment(linker, "/alternatename:__imp_?SetEndOfFile@win32@fast_io@@YAHPEAX@Z=__imp_SetEndOfFile")
-#pragma comment(linker, "/alternatename:__imp_?UnmapViewOfFile@win32@fast_io@@YAHPEBX@Z=__imp_UnmapViewOfFile")
-#pragma comment(linker, \
-				"/alternatename:__imp_?WriteFile@win32@fast_io@@YAHPEAXPEBXIPEAIPEAUoverlapped@12@@Z=__imp_WriteFile")
-#pragma comment(linker, \
-				"/alternatename:__imp_?ReadFile@win32@fast_io@@YAHPEAXPEBXIPEAIPEAUoverlapped@12@@Z=__imp_ReadFile")
-#pragma comment(linker, "/alternatename:__imp_?SetFilePointer@win32@fast_io@@YAIPEAXHPEAHI@Z=__imp_SetFilePointer")
-#pragma comment(linker, \
-				"/alternatename:__imp_?SetFilePointerEx@win32@fast_io@@YAHPEAX_JPEA_JI@Z=__imp_SetFilePointerEx")
-#pragma comment(linker, \
-				"/alternatename:__imp_?DuplicateHandle@win32@fast_io@@YAHPEAX00PEAPEAXIHI@Z=__imp_DuplicateHandle")
-#pragma comment(linker, "/alternatename:__imp_?GetStdHandle@win32@fast_io@@YAPEAXI@Z=__imp_GetStdHandle")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?CreatePipe@win32@fast_io@@YAHPEAPEAX0PEAUsecurity_attributes@12@I@Z=__imp_CreatePipe")
-#pragma comment(linker, "/alternatename:__imp_?FreeLibrary@win32@fast_io@@YAHPEAX@Z=__imp_FreeLibrary")
-#pragma comment(linker, "/alternatename:__imp_?GetProcAddress@win32@fast_io@@YAP6A_JX_EPEAXPEBD@Z=__imp_GetProcAddress")
-#pragma comment(linker, "/alternatename:__imp_?GetModuleHandleA@win32@fast_io@@YAPEAXPEBD@Z=__imp_GetModuleHandleA")
-#pragma comment(linker, "/alternatename:__imp_?GetModuleHandleW@win32@fast_io@@YAPEAXPEB_S@Z=__imp_GetModuleHandleW")
-#pragma comment(linker, "/alternatename:__imp_?WaitForSingleObject@win32@fast_io@@YAIPEAXI@Z=__imp_WaitForSingleObject")
-#pragma comment(linker, "/alternatename:__imp_?CancelIo@win32@fast_io@@YAIPEAX@Z=__imp_CancelIo")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?GetFileInformationByHandle@win32@fast_io@@YAHPEIAXPEIAUby_handle_file_information@12@@Z=__imp_GetFileInformationByHandle")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?GetUserDefaultLocaleName@win32@fast_io@@YAHPEA_SH@Z=__imp_GetUserDefaultLocaleName")
-#pragma comment(linker, "/alternatename:__imp_?GetUserDefaultLCID@win32@fast_io@@YAIXZ=__imp_GetUserDefaultLCID")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?GetSystemTimePreciseAsFileTime@win32@fast_io@@YAXPEAUfiletime@12@@Z=__imp_GetSystemTimePreciseAsFileTime")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?GetSystemTimeAsFileTime@win32@fast_io@@YAXPEAUfiletime@12@@Z=__imp_GetSystemTimeAsFileTime")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?QueryUnbiasedInterruptTime@win32@fast_io@@YAHPEA_K@Z=__imp_QueryUnbiasedInterruptTime")
-#pragma comment( \
-	linker, "/alternatename:__imp_?QueryPerformanceCounter@win32@fast_io@@YAHPEA_J@Z=__imp_QueryPerformanceCounter")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?QueryPerformanceFrequency@win32@fast_io@@YAHPEA_J@Z=__imp_QueryPerformanceFrequency")
-#pragma comment( \
-	linker, "/alternatename:__imp_?GetProcessTimes@win32@fast_io@@YAHPEAXPEAUfiletime@12@111@Z=__imp_GetProcessTimes")
-#pragma comment( \
-	linker, "/alternatename:__imp_?GetThreadTimes@win32@fast_io@@YAHPEAXPEAUfiletime@12@111@Z=__imp_GetThreadTimes")
-#pragma comment(linker, \
-				"/alternatename:__imp_?GetHandleInformation@win32@fast_io@@YAHPEAXPEAI@Z=__imp_GetHandleInformation")
-#pragma comment(linker, \
-				"/alternatename:__imp_?SetHandleInformation@win32@fast_io@@YAHPEAXII@Z=__imp_SetHandleInformation")
-#pragma comment(linker, "/alternatename:__imp_?GetTempPathA@win32@fast_io@@YAIIPEAD@Z=__imp_GetTempPathA")
-#pragma comment(linker, "/alternatename:__imp_?GetTempPathW@win32@fast_io@@YAIIPEA_S@Z=__imp_GetTempPathW")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?CreateFileA@win32@fast_io@@YAPEAXPEBDIIPEAUsecurity_attributes@12@IIPEAX@Z=__imp_CreateFileA")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?CreateFileW@win32@fast_io@@YAPEAXPEB_SIIPEAUsecurity_attributes@12@IIPEAX@Z=__imp_CreateFileW")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?CreateIoCompletionPort@win32@fast_io@@YAPEAXPEAX0_KI@Z=__imp_CreateIoCompletionPort")
-#pragma comment(linker, "/alternatename:__imp_?SystemFunction036@win32@fast_io@@YAHPEAXI@Z=__imp_SystemFunction036")
-#pragma comment(linker, "/alternatename:__imp_?CloseHandle@win32@fast_io@@YAHPEAX@Z=__imp_CloseHandle")
-#pragma comment(linker, \
-				"/alternatename:__imp_?LockFileEx@win32@fast_io@@YAHPEAXIIIIPEAUoverlapped@12@@Z=__imp_LockFileEx")
-#pragma comment(linker, \
-				"/alternatename:__imp_?UnlockFileEx@win32@fast_io@@YAHPEAXIIIPEAUoverlapped@12@@Z=__imp_UnlockFileEx")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?DeviceIoControl@win32@fast_io@@YAHPEAXI0I0I0PEAUoverlapped@12@@Z=__imp_DeviceIoControl")
-#pragma comment(linker, "/alternatename:__imp_?GetFileType@win32@fast_io@@YAIPEAX@Z=__imp_GetFileType")
-#pragma comment(linker, "/alternatename:__imp_?GetACP@win32@fast_io@@YAIXZ=__imp_GetACP")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?GetEnvironmentVariableA@win32@fast_io@@YAIPEBDPEADI@Z=__imp_GetEnvironmentVariableA")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?GetEnvironmentVariableW@win32@fast_io@@YAIPEB_SPEA_SI@Z=__imp_GetEnvironmentVariableW")
-#pragma comment(linker, "/alternatename:__imp_?MessageBoxA@win32@fast_io@@YAIPEAXPEBD1I@Z=__imp_MessageBoxA")
-#pragma comment(linker, "/alternatename:__imp_?MessageBoxW@win32@fast_io@@YAIPEAXPEB_S1I@Z=__imp_MessageBoxW")
-#pragma comment(linker, "/alternatename:__imp_?GetConsoleMode@win32@fast_io@@YAHPEAXPEAI@Z=__imp_GetConsoleMode")
-#pragma comment(linker, "/alternatename:__imp_?SetConsoleMode@win32@fast_io@@YAHPEAXI@Z=__imp_SetConsoleMode")
-#pragma comment(linker, "/alternatename:__imp_?ReadConsoleA@win32@fast_io@@YAHPEAX0IPEAI0@Z=__imp_ReadConsoleA")
-#pragma comment(linker, "/alternatename:__imp_?ReadConsoleW@win32@fast_io@@YAHPEAX0IPEAI0@Z=__imp_ReadConsoleW")
-#pragma comment(linker, "/alternatename:__imp_?WriteConsoleA@win32@fast_io@@YAHPEAXPEBXIPEAI0@Z=__imp_WriteConsoleA")
-#pragma comment(linker, "/alternatename:__imp_?WriteConsoleW@win32@fast_io@@YAHPEAXPEBXIPEAI0@Z=__imp_WriteConsoleW")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?GetConsoleScreenBufferInfo@win32@fast_io@@YAHPEAXPEAUconsole_screen_buffer_info@12@@Z=__imp_GetConsoleScreenBufferInfo")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?ScrollConsoleScreenBufferA@win32@fast_io@@YAHPEAXPEBUsmall_rect@12@1Ucoord@12@PEBUchar_info@12@@Z=__imp_ScrollConsoleScreenBufferA")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?ScrollConsoleScreenBufferW@win32@fast_io@@YAHPEAXPEBUsmall_rect@12@1Ucoord@12@PEBUchar_info@12@@Z=__imp_ScrollConsoleScreenBufferW")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?SetConsoleCursorPosition@win32@fast_io@@YAHPEAXUcoord@12@@Z=__imp_SetConsoleCursorPosition")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?InitializeCriticalSection@win32@fast_io@@YAXPEAX@Z=__imp_InitializeCriticalSection")
-#pragma comment(linker, \
-				"/alternatename:__imp_?EnterCriticalSection@win32@fast_io@@YAXPEAX@Z=__imp_EnterCriticalSection")
-#pragma comment( \
-	linker, "/alternatename:__imp_?TryEnterCriticalSection@win32@fast_io@@YAHPEAX@Z=__imp_TryEnterCriticalSection")
-#pragma comment(linker, \
-				"/alternatename:__imp_?LeaveCriticalSection@win32@fast_io@@YAXPEAX@Z=__imp_LeaveCriticalSection")
-#pragma comment(linker, \
-				"/alternatename:__imp_?DeleteCriticalSection@win32@fast_io@@YAXPEAX@Z=__imp_DeleteCriticalSection")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?WSADuplicateSocketA@win32@fast_io@@YAHPEAXIPEAUwsaprotocol_infoa@12@@Z=__imp_WSADuplicateSocketA")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?WSADuplicateSocketW@win32@fast_io@@YAXPEAXIPEAUwsaprotocol_infow@12@@Z=__imp_WSADuplicateSocketW")
-#pragma comment(linker, "/alternatename:__imp_?WSACleanup@win32@fast_io@@YAHXZ=__imp_WSACleanup")
-#pragma comment(linker, "/alternatename:__imp_?WSAStartup@win32@fast_io@@YAHIPEAUwsadata@12@@Z=__imp_WSAStartup")
-#pragma comment(linker, "/alternatename:__imp_?WSAGetLastError@win32@fast_io@@YAHXZ=__imp_WSAGetLastError")
-#pragma comment(linker, "/alternatename:__imp_?closesocket@win32@fast_io@@YAH_K@Z=__imp_closesocket")
-#pragma comment( \
-	linker, "/alternatename:__imp_?WSASocketW@win32@fast_io@@YA_KHHHPEAUwsaprotocol_infow@12@II@Z=__imp_WSASocketW")
-#pragma comment( \
-	linker, "/alternatename:__imp_?WSASocketA@win32@fast_io@@YA_KHHHPEAUwsaprotocol_infoa@12@II@Z=__imp_WSASocketA")
-#pragma comment(linker, "/alternatename:__imp_?bind@win32@fast_io@@YAH_KPEBXH@Z=__imp_bind")
-#pragma comment(linker, "/alternatename:__imp_?listen@win32@fast_io@@YAH_KH@Z=__imp_listen")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?WSAAccept@win32@fast_io@@YA_K_KPEBXPEAHP6AXPEAUwsabuf@12@3PEAUqualityofservice@12@433PEAI0@_E0@Z=__imp_WSAAccept")
-#pragma comment(linker, "/alternatename:__imp_?ioctlsocket@win32@fast_io@@YAH_KJPEAI@Z=__imp_ioctlsocket")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?WSASend@win32@fast_io@@YAH_KPEAUwsabuf@12@IPEAIIPEAUoverlapped@12@P6AXII3I@_E@Z=__imp_WSASend")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?WSASendMsg@win32@fast_io@@YAH_KPEAUwsamsg@12@IPEAIPEAUoverlapped@12@P6AXII3I@_E@Z=__imp_WSASendMsg")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?WSASendTo@win32@fast_io@@YAH_KPEAUwsabuf@12@IPEAIIPEBXHPEAUoverlapped@12@P6AXII4I@_E@Z=__imp_WSASendTo")
-#pragma comment(linker, "/alternatename:__imp_?recv@win32@fast_io@@YAH_KPEADHH@Z=__imp_recv")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?WSARecv@win32@fast_io@@YAH_KPEAUwsabuf@12@IPEAI2PEAUoverlapped@12@P6AXII3I@_E@Z=__imp_WSARecv")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?WSARecvFrom@win32@fast_io@@YAH_KPEAUwsabuf@12@IPEAI2PEAXPEAHPEAUoverlapped@12@P6AXII5I@_E@Z=__imp_WSARecvFrom")
-#pragma comment(linker, "/alternatename:__imp_?connect@win32@fast_io@@YAH_KPEBXH@Z=__imp_connect")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?WSAConnect@win32@fast_io@@YAH_KPEBXHPEAUwsabuf@12@2PEAUqualityofservice@12@3@Z=__imp_WSAConnect")
-#pragma comment(linker, "/alternatename:__imp_?recvfrom@win32@fast_io@@YAH_KPEADHHPEAXPEAH@Z=__imp_recvfrom")
-#pragma comment(linker, "/alternatename:__imp_?sendto@win32@fast_io@@YAH_KPEBDHHPEBXH@Z=__imp_sendto")
-#pragma comment(linker, "/alternatename:__imp_?shutdown@win32@fast_io@@YAH_KPEBXH@Z=__imp_shutdown")
-#pragma comment(linker, "/alternatename:__imp_?GetCurrentProcessId@win32@fast_io@@YAIXZ=__imp_GetCurrentProcessId")
-#pragma comment(linker, "/alternatename:__imp_?FlushFileBuffers@win32@fast_io@@YAHPEAX@Z=__imp_FlushFileBuffers")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?GetQueuedCompletionStatus@win32@fast_io@@YAHPEAXPEAIPEA_KPEAUoverlapped@12@I@Z=__imp_GetQueuedCompletionStatus")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?freeaddrinfo@win32@fast_io@@YAXPEAU?$win32_family_addrinfo@$0A@@12@@Z=__imp_freeaddrinfo")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?FreeAddrInfoW@win32@fast_io@@YAXPEAU?$win32_family_addrinfo@$00@12@@Z=__imp_FreeAddrInfoW")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?getaddrinfo@win32@fast_io@@YAHPEBD0PEBU?$win32_family_addrinfo@$0A@@12@PEAPEAU312@@Z=__imp_getaddrinfo")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?GetAddrInfoW@win32@fast_io@@YAHPEB_S0PEBU?$win32_family_addrinfo@$00@12@PEAPEAU312@@Z=__imp_GetAddrInfoW")
-#pragma comment( \
-	linker, "/alternatename:__imp_?CryptAcquireContextA@win32@fast_io@@YAHPEA_KPEB_Q1II@Z=__imp_CryptAcquireContextA")
-#pragma comment( \
-	linker, "/alternatename:__imp_?CryptAcquireContextW@win32@fast_io@@YAHPEA_KPEB_S1II@Z=__imp_CryptAcquireContextW")
-#pragma comment(linker, "/alternatename:__imp_?CryptReleaseContext@win32@fast_io@@YAH_KI@Z=__imp_CryptReleaseContext")
-#pragma comment(linker, "/alternatename:__imp_?CryptGenRandom@win32@fast_io@@YAH_KIPEAE@Z=__imp_CryptGenRandom")
-#pragma comment(linker, "/alternatename:__imp_?RegOpenKeyA@win32@fast_io@@YAH_KPEB_QPEA_K@Z=__imp_RegOpenKeyA")
-#pragma comment(linker, "/alternatename:__imp_?RegOpenKeyW@win32@fast_io@@YAH_KPEB_SPEA_K@Z=__imp_RegOpenKeyW")
-#pragma comment(linker, \
-				"/alternatename:__imp_?RegQueryValueExA@win32@fast_io@@YAH_KPEB_QPEAI2PEAX2@Z=__imp_RegQueryValueExA")
-#pragma comment(linker, \
-				"/alternatename:__imp_?RegQueryValueExW@win32@fast_io@@YAH_KPEB_SPEAI2PEAX2@Z=__imp_RegQueryValueExW")
-#pragma comment(linker, "/alternatename:__imp_?RegCloseKey@win32@fast_io@@YAH_K@Z=__imp_RegCloseKey")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?GetTimeZoneInformation@win32@fast_io@@YAIPEAUtime_zone_information@12@@Z=__imp_GetTimeZoneInformation")
-#pragma comment( \
-	linker, "/alternatename:__imp_?rtl_nt_status_to_dos_error@nt@win32@fast_io@@YAII@Z=__imp_RtlNtStatusToDosError")
-#pragma comment(linker, "/alternatename:__imp_?NtClose@nt@win32@fast_io@@YAIPEAX@Z=__imp_NtClose")
-#pragma comment(linker, "/alternatename:__imp_?ZwClose@nt@win32@fast_io@@YAIPEAX@Z=__imp_ZwClose")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?NtCreateFile@nt@win32@fast_io@@YAIPEAPEAXIPEAUobject_attributes@123@PEAUio_status_block@123@PEA_JIIIIPEAXI@Z=__imp_NtCreateFile")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?ZwCreateFile@nt@win32@fast_io@@YAIPEAPEAXIPEAUobject_attributes@123@PEAUio_status_block@123@PEA_JIIIIPEAXI@Z=__imp_ZwCreateFile")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?NtCreateSection@nt@win32@fast_io@@YAIPEIAPEAXIPEIAUobject_attributes@123@PEA_KIIPEIAX@Z=__imp_NtCreateSection")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?ZwCreateSection@nt@win32@fast_io@@YAIPEIAPEAXIPEIAUobject_attributes@123@PEA_KIIPEIAX@Z=__imp_ZwCreateSection")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?NtQueryInformationProcess@nt@win32@fast_io@@YAIPEIAXW4process_information_class@123@PEAXIPEAI@Z=__imp_NtQueryInformationProcess")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?ZwQueryInformationProcess@nt@win32@fast_io@@YAIPEIAXW4process_information_class@123@PEAXIPEAI@Z=__imp_ZwQueryInformationProcess")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?NtWriteFile@nt@win32@fast_io@@YAIPEAX0P6AX0PEAUio_status_block@123@I@_E01PEBXIPEA_JPEAI@Z=__imp_NtWriteFile")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?ZwWriteFile@nt@win32@fast_io@@YAIPEAX0P6AX0PEAUio_status_block@123@I@_E01PEBXIPEA_JPEAI@Z=__imp_ZwWriteFile")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?NtReadFile@nt@win32@fast_io@@YAIPEAX0P6AX0PEAUio_status_block@123@I@_E01PEBXIPEA_JPEAI@Z=__imp_NtReadFile")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?ZwReadFile@nt@win32@fast_io@@YAIPEAX0P6AX0PEAUio_status_block@123@I@_E01PEBXIPEA_JPEAI@Z=__imp_ZwReadFile")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?NtQueryDirectoryFile@nt@win32@fast_io@@YAIPEAX0P6AX0PEAUio_status_block@123@I@_E010IW4file_information_class@123@HPEAUunicode_string@123@H@Z=__imp_NtQueryDirectoryFile")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?ZwQueryDirectoryFile@nt@win32@fast_io@@YAIPEAX0P6AX0PEAUio_status_block@123@I@_E010IW4file_information_class@123@HPEAUunicode_string@123@H@Z=__imp_ZwQueryDirectoryFile")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?NtQuerySection@nt@win32@fast_io@@YAIPEAXW4section_information_class@123@0_KPEA_K@Z=__imp_NtQuerySection")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?ZwQuerySection@nt@win32@fast_io@@YAIPEAXW4section_information_class@123@0_KPEA_K@Z=__imp_ZwQuerySection")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?NtQueryInformationFile@nt@win32@fast_io@@YAIPEIAXPEIAUio_status_block@123@0IW4file_information_class@123@@Z=__imp_NtQueryInformationFile")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?ZwQueryInformationFile@nt@win32@fast_io@@YAIPEIAXPEIAUio_status_block@123@0IW4file_information_class@123@@Z=__imp_ZwQueryInformationFile")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?NtSetInformationFile@nt@win32@fast_io@@YAIPEIAXPEIAUio_status_block@123@0IW4file_information_class@123@@Z=__imp_NtSetInformationFile")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?ZwSetInformationFile@nt@win32@fast_io@@YAIPEIAXPEIAUio_status_block@123@0IW4file_information_class@123@@Z=__imp_ZwSetInformationFile")
-#pragma comment( \
-	linker, "/alternatename:__imp_?NtDuplicateObject@nt@win32@fast_io@@YAIPEAX00PEAPEAXIII@Z=__imp_NtDuplicateObject")
-#pragma comment( \
-	linker, "/alternatename:__imp_?ZwDuplicateObject@nt@win32@fast_io@@YAIPEAX00PEAPEAXIII@Z=__imp_ZwDuplicateObject")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?NtWaitForSingleObject@nt@win32@fast_io@@YAIPEAXHPEA_K@Z=__imp_NtWaitForSingleObject")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?ZwWaitForSingleObject@nt@win32@fast_io@@YAIPEAXHPEA_K@Z=__imp_ZwWaitForSingleObject")
-#pragma comment(linker, "/alternatename:__imp_?NtSetSystemTime@nt@win32@fast_io@@YAIPEA_K0@Z=__imp_NtSetSystemTime")
-#pragma comment(linker, "/alternatename:__imp_?ZwSetSystemTime@nt@win32@fast_io@@YAIPEA_K0@Z=__imp_ZwSetSystemTime")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?NtCreateProcess@nt@win32@fast_io@@YAIPEAPEAXIPEAUobject_attributes@123@PEAXI222@Z=__imp_NtCreateProcess")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?ZwCreateProcess@nt@win32@fast_io@@YAIPEAPEAXIPEAUobject_attributes@123@PEAXI222@Z=__imp_ZwCreateProcess")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?rtl_dos_path_name_to_nt_path_name_u@nt@win32@fast_io@@YAEPEB_SPEAUunicode_string@123@PEAPEB_SPEAUrtl_relative_name_u@123@@Z=__imp_RtlDosPathNameToNtPathName_U")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?rtl_dos_path_name_to_nt_path_name_u_with_status@nt@win32@fast_io@@YAIPEB_SPEAUunicode_string@123@PEAPEB_SPEAUrtl_relative_name_u@123@@Z=__imp_RtlDosPathNameToNtPathName_U_WithStatus")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?rtl_free_unicode_string@nt@win32@fast_io@@YAXPEAUunicode_string@123@@Z=__imp_RtlFreeUnicodeString")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?RtlInitializeCriticalSection@nt@win32@fast_io@@YAXPEAX@Z=__imp_RtlInitializeCriticalSection")
-#pragma comment( \
-	linker, "/alternatename:__imp_?RtlEnterCriticalSection@nt@win32@fast_io@@YAXPEAX@Z=__imp_RtlEnterCriticalSection")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?RtlTryEnterCriticalSection@nt@win32@fast_io@@YAHPEAX@Z=__imp_RtlTryEnterCriticalSection")
-#pragma comment( \
-	linker, "/alternatename:__imp_?RtlLeaveCriticalSection@nt@win32@fast_io@@YAXPEAX@Z=__imp_RtlLeaveCriticalSection")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?RtlDeleteCriticalSection@nt@win32@fast_io@@YAXPEAX@Z=__imp_RtlDeleteCriticalSection")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?RtlCreateUserThread@nt@win32@fast_io@@YAIPEAX0HI_K100PEAPEAXPEAUclient_id@123@@Z=__imp_RtlCreateUserThread")
-#pragma comment(linker, "/alternatename:__imp_?NtResumeThread@nt@win32@fast_io@@YAIPEAXPEAI@Z=__imp_NtResumeThread")
-#pragma comment(linker, "/alternatename:__imp_?ZwResumeThread@nt@win32@fast_io@@YAIPEAXPEAI@Z=__imp_ZwResumeThread")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?NtLockFile@nt@win32@fast_io@@YAIPEAX0P6AX0PEAUio_status_block@123@I@_E01PEA_J3IEE@Z=__imp_NtLockFile")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?ZwLockFile@nt@win32@fast_io@@YAIPEAX0P6AX0PEAUio_status_block@123@I@_E01PEA_J3IEE@Z=__imp_ZwLockFile")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?NtUnlockFile@nt@win32@fast_io@@YAIPEAXPEAUio_status_block@123@PEA_J2I@Z=__imp_NtUnlockFile")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?ZwUnlockFile@nt@win32@fast_io@@YAIPEAXPEAUio_status_block@123@PEA_J2I@Z=__imp_ZwUnlockFile")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?NtFlushBuffersFile@nt@win32@fast_io@@YAIPEAXPEAUio_status_block@123@@Z=__imp_NtFlushBuffersFile")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?ZwFlushBuffersFile@nt@win32@fast_io@@YAIPEAXPEAUio_status_block@123@@Z=__imp_ZwFlushBuffersFile")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?NtFlushBuffersFileEx@nt@win32@fast_io@@YAIPEAXI0IPEAUio_status_block@123@@Z=__imp_NtFlushBuffersFileEx")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?ZwFlushBuffersFileEx@nt@win32@fast_io@@YAIPEAXI0IPEAUio_status_block@123@@Z=__imp_ZwFlushBuffersFileEx")
-#pragma comment(linker, "/alternatename:__imp_?DbgPrint@nt@win32@fast_io@@YAIPEBDZZ=__imp_DbgPrint")
-#pragma comment(linker, "/alternatename:__imp_?DbgPrintEx@nt@win32@fast_io@@YAIIIPEBDZZ=__imp_DbgPrintEx")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?RtlCreateProcessParameters@nt@win32@fast_io@@YAIPEAPEAUrtl_user_process_parameters@123@PEAUunicode_string@123@111PEAX1111@Z=__imp_RtlCreateProcessParameters")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?RtlCreateProcessParametersEx@nt@win32@fast_io@@YAIPEAPEAUrtl_user_process_parameters@123@PEAUunicode_string@123@111PEAX1111I@Z=__imp_RtlCreateProcessParametersEx")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?RtlDestroyProcessParameters@nt@win32@fast_io@@YAIPEAUrtl_user_process_parameters@123@@Z=__imp_RtlDestroyProcessParameters")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?NtCreateUserProcess@nt@win32@fast_io@@YAIPEAX0IIPEAUobject_attributes@123@1IIPEAUrtl_user_process_parameters@123@PEAUps_create_info@123@PEAUps_attribute_list@123@@Z=__imp_NtCreateUserProcess")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?ZwCreateUserProcess@nt@win32@fast_io@@YAIPEAX0IIPEAUobject_attributes@123@1IIPEAUrtl_user_process_parameters@123@PEAUps_create_info@123@PEAUps_attribute_list@123@@Z=__imp_ZwCreateUserProcess")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?RtlCreateUserProcess@nt@win32@fast_io@@YAIPEAUunicode_string@123@IPEAUrtl_user_process_parameters@123@PEAUsecurity_descriptor@123@2PEAXE33PEAUrtl_user_process_information@123@@Z=__imp_RtlCreateUserProcess")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?NtMapViewOfSection@nt@win32@fast_io@@YAIPEAX0PEAPEAX_K2PEBTlarge_integer@123@PEA_KW4section_inherit@123@II@Z=__imp_NtMapViewOfSection")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?ZwMapViewOfSection@nt@win32@fast_io@@YAIPEAX0PEAPEAX_K2PEBTlarge_integer@123@PEA_KW4section_inherit@123@II@Z=__imp_ZwMapViewOfSection")
-#pragma comment(linker, \
-				"/alternatename:__imp_?NtUnmapViewOfSection@nt@win32@fast_io@@YAIPEAX0@Z=__imp_NtUnmapViewOfSection")
-#pragma comment(linker, \
-				"/alternatename:__imp_?ZwUnmapViewOfSection@nt@win32@fast_io@@YAIPEAX0@Z=__imp_ZwUnmapViewOfSection")
-#pragma comment(linker, "/alternatename:__imp_?SetConsoleCP@win32@fast_io@@YAHI@Z=__imp_SetConsoleCP")
-#pragma comment(linker, "/alternatename:__imp_?SetConsoleOutputCP@win32@fast_io@@YAHI@Z=__imp_SetConsoleOutputCP")
-#pragma comment(linker, "/alternatename:__imp_?GetConsoleCP@win32@fast_io@@YAIXZ=__imp_GetConsoleCP")
-#pragma comment(linker, "/alternatename:__imp_?GetConsoleOutputCP@win32@fast_io@@YAIXZ=__imp_GetConsoleOutputCP")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?NtReadVirtualMemory@nt@win32@fast_io@@YAIPEAX00_KPEA_K@Z=__imp_NtReadVirtualMemory")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?ZwReadVirtualMemory@nt@win32@fast_io@@YAIPEAX00_KPEA_K@Z=__imp_ZwReadVirtualMemory")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?NtWriteVirtualMemory@nt@win32@fast_io@@YAIPEAX00_KPEA_K@Z=__imp_NtWriteVirtualMemory")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?ZwWriteVirtualMemory@nt@win32@fast_io@@YAIPEAX00_KPEA_K@Z=__imp_ZwWriteVirtualMemory")
-#pragma comment(linker, "/alternatename:__imp_?RtlAcquirePebLock@nt@win32@fast_io@@YAIXZ=__imp_RtlAcquirePebLock")
-#pragma comment(linker, "/alternatename:__imp_?RtlReleasePebLock@nt@win32@fast_io@@YAIXZ=__imp_RtlReleasePebLock")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?NtAllocateVirtualMemory@nt@win32@fast_io@@YAIPEAXPEAPEAX_KPEA_KII@Z=__imp_NtAllocateVirtualMemory")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?ZwAllocateVirtualMemory@nt@win32@fast_io@@YAIPEAXPEAPEAX_KPEA_KII@Z=__imp_ZwAllocateVirtualMemory")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?NtQueryObject@nt@win32@fast_io@@YAIPEAXW4object_information_class@123@0IPEAI@Z=__imp_NtQueryObject")
-#pragma comment( \
-	linker,      \
-	"/alternatename:__imp_?ZwQueryObject@nt@win32@fast_io@@YAIPEAXW4object_information_class@123@0IPEAI@Z=__imp_ZwQueryObject")
-
-#if defined(_DLL)
+// clang-format off
+#pragma comment(linker,"/alternatename:__imp_?GetLastError@win32@fast_io@@YAIXZ=__imp_GetLastError")
+#pragma comment(linker,"/alternatename:__imp_?LoadLibraryA@win32@fast_io@@YAPEAXPEBD@Z=__imp_LoadLibraryA")
+#pragma comment(linker,"/alternatename:__imp_?LoadLibraryW@win32@fast_io@@YAPEAXPEB_S@Z=__imp_LoadLibraryW")
+#pragma comment(linker,"/alternatename:__imp_?LoadLibraryExA@win32@fast_io@@YAPEAXPEBDPEAXI@Z=__imp_LoadLibraryExA")
+#pragma comment(linker,"/alternatename:__imp_?LoadLibraryExW@win32@fast_io@@YAPEAXPEB_SPEAXI@Z=__imp_LoadLibraryExW")
+#pragma comment(linker,"/alternatename:__imp_?FormatMessageA@win32@fast_io@@YAIIPEBDIIPEADIPEAX@Z=__imp_FormatMessageA")
+#pragma comment(linker,"/alternatename:__imp_?FormatMessageW@win32@fast_io@@YAIIPEB_SIIPEA_SIPEAX@Z=__imp_FormatMessageW")
+#pragma comment(linker,"/alternatename:__imp_?CreateFileMappingA@win32@fast_io@@YAPEAXPEAXPEAUsecurity_attributes@12@IIIPEBD@Z=__imp_CreateFileMappingA")
+#pragma comment(linker,"/alternatename:__imp_?CreateFileMappingW@win32@fast_io@@YAPEAXPEAXPEAUsecurity_attributes@12@IIIPEB_S@Z=__imp_CreateFileMappingW")
+#pragma comment(linker,"/alternatename:__imp_?MapViewOfFile@win32@fast_io@@YAPEAXPEAXIII_K@Z=__imp_MapViewOfFile")
+#pragma comment(linker,"/alternatename:__imp_?SetEndOfFile@win32@fast_io@@YAHPEAX@Z=__imp_SetEndOfFile")
+#pragma comment(linker,"/alternatename:__imp_?UnmapViewOfFile@win32@fast_io@@YAHPEBX@Z=__imp_UnmapViewOfFile")
+#pragma comment(linker,"/alternatename:__imp_?WriteFile@win32@fast_io@@YAHPEAXPEBXIPEAIPEAUoverlapped@12@@Z=__imp_WriteFile")
+#pragma comment(linker,"/alternatename:__imp_?ReadFile@win32@fast_io@@YAHPEAXPEBXIPEAIPEAUoverlapped@12@@Z=__imp_ReadFile")
+#pragma comment(linker,"/alternatename:__imp_?SetFilePointer@win32@fast_io@@YAIPEAXHPEAHI@Z=__imp_SetFilePointer")
+#pragma comment(linker,"/alternatename:__imp_?SetFilePointerEx@win32@fast_io@@YAHPEAX_JPEA_JI@Z=__imp_SetFilePointerEx")
+#pragma comment(linker,"/alternatename:__imp_?DuplicateHandle@win32@fast_io@@YAHPEAX00PEAPEAXIHI@Z=__imp_DuplicateHandle")
+#pragma comment(linker,"/alternatename:__imp_?GetStdHandle@win32@fast_io@@YAPEAXI@Z=__imp_GetStdHandle")
+#pragma comment(linker,"/alternatename:__imp_?CreatePipe@win32@fast_io@@YAHPEAPEAX0PEAUsecurity_attributes@12@I@Z=__imp_CreatePipe")
+#pragma comment(linker,"/alternatename:__imp_?FreeLibrary@win32@fast_io@@YAHPEAX@Z=__imp_FreeLibrary")
+#pragma comment(linker,"/alternatename:__imp_?GetProcAddress@win32@fast_io@@YAP6A_JX_EPEAXPEBD@Z=__imp_GetProcAddress")
+#pragma comment(linker,"/alternatename:__imp_?GetModuleHandleA@win32@fast_io@@YAPEAXPEBD@Z=__imp_GetModuleHandleA")
+#pragma comment(linker,"/alternatename:__imp_?GetModuleHandleW@win32@fast_io@@YAPEAXPEB_S@Z=__imp_GetModuleHandleW")
+#pragma comment(linker,"/alternatename:__imp_?WaitForSingleObject@win32@fast_io@@YAIPEAXI@Z=__imp_WaitForSingleObject")
+#pragma comment(linker,"/alternatename:__imp_?CancelIo@win32@fast_io@@YAIPEAX@Z=__imp_CancelIo")
+#pragma comment(linker,"/alternatename:__imp_?GetFileInformationByHandle@win32@fast_io@@YAHPEIAXPEIAUby_handle_file_information@12@@Z=__imp_GetFileInformationByHandle")
+#pragma comment(linker,"/alternatename:__imp_?GetUserDefaultLocaleName@win32@fast_io@@YAHPEA_SH@Z=__imp_GetUserDefaultLocaleName")
+#pragma comment(linker,"/alternatename:__imp_?GetUserDefaultLCID@win32@fast_io@@YAIXZ=__imp_GetUserDefaultLCID")
+#pragma comment(linker,"/alternatename:__imp_?GetSystemTimePreciseAsFileTime@win32@fast_io@@YAXPEAUfiletime@12@@Z=__imp_GetSystemTimePreciseAsFileTime")
+#pragma comment(linker,"/alternatename:__imp_?GetSystemTimeAsFileTime@win32@fast_io@@YAXPEAUfiletime@12@@Z=__imp_GetSystemTimeAsFileTime")
+#pragma comment(linker,"/alternatename:__imp_?QueryUnbiasedInterruptTime@win32@fast_io@@YAHPEA_K@Z=__imp_QueryUnbiasedInterruptTime")
+#pragma comment(linker,"/alternatename:__imp_?QueryPerformanceCounter@win32@fast_io@@YAHPEA_J@Z=__imp_QueryPerformanceCounter")
+#pragma comment(linker,"/alternatename:__imp_?QueryPerformanceFrequency@win32@fast_io@@YAHPEA_J@Z=__imp_QueryPerformanceFrequency")
+#pragma comment(linker,"/alternatename:__imp_?GetProcessTimes@win32@fast_io@@YAHPEAXPEAUfiletime@12@111@Z=__imp_GetProcessTimes")
+#pragma comment(linker,"/alternatename:__imp_?GetThreadTimes@win32@fast_io@@YAHPEAXPEAUfiletime@12@111@Z=__imp_GetThreadTimes")
+#pragma comment(linker,"/alternatename:__imp_?GetHandleInformation@win32@fast_io@@YAHPEAXPEAI@Z=__imp_GetHandleInformation")
+#pragma comment(linker,"/alternatename:__imp_?SetHandleInformation@win32@fast_io@@YAHPEAXII@Z=__imp_SetHandleInformation")
+#pragma comment(linker,"/alternatename:__imp_?GetTempPathA@win32@fast_io@@YAIIPEAD@Z=__imp_GetTempPathA")
+#pragma comment(linker,"/alternatename:__imp_?GetTempPathW@win32@fast_io@@YAIIPEA_S@Z=__imp_GetTempPathW")
+#pragma comment(linker,"/alternatename:__imp_?CreateFileA@win32@fast_io@@YAPEAXPEBDIIPEAUsecurity_attributes@12@IIPEAX@Z=__imp_CreateFileA")
+#pragma comment(linker,"/alternatename:__imp_?CreateFileW@win32@fast_io@@YAPEAXPEB_SIIPEAUsecurity_attributes@12@IIPEAX@Z=__imp_CreateFileW")
+#pragma comment(linker,"/alternatename:__imp_?CreateIoCompletionPort@win32@fast_io@@YAPEAXPEAX0_KI@Z=__imp_CreateIoCompletionPort")
+#pragma comment(linker,"/alternatename:__imp_?SystemFunction036@win32@fast_io@@YAHPEAXI@Z=__imp_SystemFunction036")
+#pragma comment(linker,"/alternatename:__imp_?CloseHandle@win32@fast_io@@YAHPEAX@Z=__imp_CloseHandle")
+#pragma comment(linker,"/alternatename:__imp_?LockFileEx@win32@fast_io@@YAHPEAXIIIIPEAUoverlapped@12@@Z=__imp_LockFileEx")
+#pragma comment(linker,"/alternatename:__imp_?UnlockFileEx@win32@fast_io@@YAHPEAXIIIPEAUoverlapped@12@@Z=__imp_UnlockFileEx")
+#pragma comment(linker,"/alternatename:__imp_?DeviceIoControl@win32@fast_io@@YAHPEAXI0I0I0PEAUoverlapped@12@@Z=__imp_DeviceIoControl")
+#pragma comment(linker,"/alternatename:__imp_?GetFileType@win32@fast_io@@YAIPEAX@Z=__imp_GetFileType")
+#pragma comment(linker,"/alternatename:__imp_?GetACP@win32@fast_io@@YAIXZ=__imp_GetACP")
+#pragma comment(linker,"/alternatename:__imp_?GetEnvironmentVariableA@win32@fast_io@@YAIPEBDPEADI@Z=__imp_GetEnvironmentVariableA")
+#pragma comment(linker,"/alternatename:__imp_?GetEnvironmentVariableW@win32@fast_io@@YAIPEB_SPEA_SI@Z=__imp_GetEnvironmentVariableW")
+#pragma comment(linker,"/alternatename:__imp_?MessageBoxA@win32@fast_io@@YAIPEAXPEBD1I@Z=__imp_MessageBoxA")
+#pragma comment(linker,"/alternatename:__imp_?MessageBoxW@win32@fast_io@@YAIPEAXPEB_S1I@Z=__imp_MessageBoxW")
+#pragma comment(linker,"/alternatename:__imp_?GetConsoleMode@win32@fast_io@@YAHPEAXPEAI@Z=__imp_GetConsoleMode")
+#pragma comment(linker,"/alternatename:__imp_?SetConsoleMode@win32@fast_io@@YAHPEAXI@Z=__imp_SetConsoleMode")
+#pragma comment(linker,"/alternatename:__imp_?ReadConsoleA@win32@fast_io@@YAHPEAX0IPEAI0@Z=__imp_ReadConsoleA")
+#pragma comment(linker,"/alternatename:__imp_?ReadConsoleW@win32@fast_io@@YAHPEAX0IPEAI0@Z=__imp_ReadConsoleW")
+#pragma comment(linker,"/alternatename:__imp_?WriteConsoleA@win32@fast_io@@YAHPEAXPEBXIPEAI0@Z=__imp_WriteConsoleA")
+#pragma comment(linker,"/alternatename:__imp_?WriteConsoleW@win32@fast_io@@YAHPEAXPEBXIPEAI0@Z=__imp_WriteConsoleW")
+#pragma comment(linker,"/alternatename:__imp_?GetConsoleScreenBufferInfo@win32@fast_io@@YAHPEAXPEAUconsole_screen_buffer_info@12@@Z=__imp_GetConsoleScreenBufferInfo")
+#pragma comment(linker,"/alternatename:__imp_?ScrollConsoleScreenBufferA@win32@fast_io@@YAHPEAXPEBUsmall_rect@12@1Ucoord@12@PEBUchar_info@12@@Z=__imp_ScrollConsoleScreenBufferA")
+#pragma comment(linker,"/alternatename:__imp_?ScrollConsoleScreenBufferW@win32@fast_io@@YAHPEAXPEBUsmall_rect@12@1Ucoord@12@PEBUchar_info@12@@Z=__imp_ScrollConsoleScreenBufferW")
+#pragma comment(linker,"/alternatename:__imp_?SetConsoleCursorPosition@win32@fast_io@@YAHPEAXUcoord@12@@Z=__imp_SetConsoleCursorPosition")
+#pragma comment(linker,"/alternatename:__imp_?InitializeCriticalSection@win32@fast_io@@YAXPEAX@Z=__imp_InitializeCriticalSection")
+#pragma comment(linker,"/alternatename:__imp_?EnterCriticalSection@win32@fast_io@@YAXPEAX@Z=__imp_EnterCriticalSection")
+#pragma comment(linker,"/alternatename:__imp_?TryEnterCriticalSection@win32@fast_io@@YAHPEAX@Z=__imp_TryEnterCriticalSection")
+#pragma comment(linker,"/alternatename:__imp_?LeaveCriticalSection@win32@fast_io@@YAXPEAX@Z=__imp_LeaveCriticalSection")
+#pragma comment(linker,"/alternatename:__imp_?DeleteCriticalSection@win32@fast_io@@YAXPEAX@Z=__imp_DeleteCriticalSection")
+#pragma comment(linker,"/alternatename:__imp_?WSADuplicateSocketA@win32@fast_io@@YAHPEAXIPEAUwsaprotocol_infoa@12@@Z=__imp_WSADuplicateSocketA")
+#pragma comment(linker,"/alternatename:__imp_?WSADuplicateSocketW@win32@fast_io@@YAXPEAXIPEAUwsaprotocol_infow@12@@Z=__imp_WSADuplicateSocketW")
+#pragma comment(linker,"/alternatename:__imp_?WSACleanup@win32@fast_io@@YAHXZ=__imp_WSACleanup")
+#pragma comment(linker,"/alternatename:__imp_?WSAStartup@win32@fast_io@@YAHIPEAUwsadata@12@@Z=__imp_WSAStartup")
+#pragma comment(linker,"/alternatename:__imp_?WSAGetLastError@win32@fast_io@@YAHXZ=__imp_WSAGetLastError")
+#pragma comment(linker,"/alternatename:__imp_?closesocket@win32@fast_io@@YAH_K@Z=__imp_closesocket")
+#pragma comment(linker,"/alternatename:__imp_?WSASocketW@win32@fast_io@@YA_KHHHPEAUwsaprotocol_infow@12@II@Z=__imp_WSASocketW")
+#pragma comment(linker,"/alternatename:__imp_?WSASocketA@win32@fast_io@@YA_KHHHPEAUwsaprotocol_infoa@12@II@Z=__imp_WSASocketA")
+#pragma comment(linker,"/alternatename:__imp_?bind@win32@fast_io@@YAH_KPEBXH@Z=__imp_bind")
+#pragma comment(linker,"/alternatename:__imp_?listen@win32@fast_io@@YAH_KH@Z=__imp_listen")
+#pragma comment(linker,"/alternatename:__imp_?WSAAccept@win32@fast_io@@YA_K_KPEBXPEAHP6AXPEAUwsabuf@12@3PEAUqualityofservice@12@433PEAI0@_E0@Z=__imp_WSAAccept")
+#pragma comment(linker,"/alternatename:__imp_?ioctlsocket@win32@fast_io@@YAH_KJPEAI@Z=__imp_ioctlsocket")
+#pragma comment(linker,"/alternatename:__imp_?sendto@win32@fast_io@@YAH_KPEBDHHPEBXH@Z=__imp_sendto")
+#pragma comment(linker,"/alternatename:__imp_?WSASend@win32@fast_io@@YAH_KPEAUwsabuf@12@IPEAIIPEAUoverlapped@12@P6AXII3I@_E@Z=__imp_WSASend")
+#pragma comment(linker,"/alternatename:__imp_?WSASendMsg@win32@fast_io@@YAH_KPEAUwsamsg@12@IPEAIPEAUoverlapped@12@P6AXII3I@_E@Z=__imp_WSASendMsg")
+#pragma comment(linker,"/alternatename:__imp_?WSASendTo@win32@fast_io@@YAH_KPEAUwsabuf@12@IPEAIIPEBXHPEAUoverlapped@12@P6AXII4I@_E@Z=__imp_WSASendTo")
+#pragma comment(linker,"/alternatename:__imp_?recv@win32@fast_io@@YAH_KPEADHH@Z=__imp_recv")
+#pragma comment(linker,"/alternatename:__imp_?recvfrom@win32@fast_io@@YAH_KPEADHHPEAXPEAH@Z=__imp_recvfrom")
+#pragma comment(linker,"/alternatename:__imp_?WSARecv@win32@fast_io@@YAH_KPEAUwsabuf@12@IPEAI2PEAUoverlapped@12@P6AXII3I@_E@Z=__imp_WSARecv")
+#pragma comment(linker,"/alternatename:__imp_?WSARecvFrom@win32@fast_io@@YAH_KPEAUwsabuf@12@IPEAI2PEAXPEAHPEAUoverlapped@12@P6AXII5I@_E@Z=__imp_WSARecvFrom")
+#pragma comment(linker,"/alternatename:__imp_?connect@win32@fast_io@@YAH_KPEBXH@Z=__imp_connect")
+#pragma comment(linker,"/alternatename:__imp_?WSAConnect@win32@fast_io@@YAH_KPEBXHPEAUwsabuf@12@2PEAUqualityofservice@12@3@Z=__imp_WSAConnect")
+#pragma comment(linker,"/alternatename:__imp_?shutdown@win32@fast_io@@YAH_KPEBXH@Z=__imp_shutdown")
+#pragma comment(linker,"/alternatename:__imp_?GetCurrentProcessId@win32@fast_io@@YAIXZ=__imp_GetCurrentProcessId")
+#pragma comment(linker,"/alternatename:__imp_?FlushFileBuffers@win32@fast_io@@YAHPEAX@Z=__imp_FlushFileBuffers")
+#pragma comment(linker,"/alternatename:__imp_?GetQueuedCompletionStatus@win32@fast_io@@YAHPEAXPEAIPEA_KPEAUoverlapped@12@I@Z=__imp_GetQueuedCompletionStatus")
+#pragma comment(linker,"/alternatename:__imp_?freeaddrinfo@win32@fast_io@@YAXPEAU?$win32_family_addrinfo@$0A@@12@@Z=__imp_freeaddrinfo")
+#pragma comment(linker,"/alternatename:__imp_?FreeAddrInfoW@win32@fast_io@@YAXPEAU?$win32_family_addrinfo@$00@12@@Z=__imp_FreeAddrInfoW")
+#pragma comment(linker,"/alternatename:__imp_?getaddrinfo@win32@fast_io@@YAHPEBD0PEBU?$win32_family_addrinfo@$0A@@12@PEAPEAU312@@Z=__imp_getaddrinfo")
+#pragma comment(linker,"/alternatename:__imp_?GetAddrInfoW@win32@fast_io@@YAHPEB_S0PEBU?$win32_family_addrinfo@$00@12@PEAPEAU312@@Z=__imp_GetAddrInfoW")
+#pragma comment(linker,"/alternatename:__imp_?CryptAcquireContextA@win32@fast_io@@YAHPEA_KPEB_Q1II@Z=__imp_CryptAcquireContextA")
+#pragma comment(linker,"/alternatename:__imp_?CryptAcquireContextW@win32@fast_io@@YAHPEA_KPEB_S1II@Z=__imp_CryptAcquireContextW")
+#pragma comment(linker,"/alternatename:__imp_?CryptReleaseContext@win32@fast_io@@YAH_KI@Z=__imp_CryptReleaseContext")
+#pragma comment(linker,"/alternatename:__imp_?CryptGenRandom@win32@fast_io@@YAH_KIPEAE@Z=__imp_CryptGenRandom")
+#pragma comment(linker,"/alternatename:__imp_?RegOpenKeyA@win32@fast_io@@YAH_KPEB_QPEA_K@Z=__imp_RegOpenKeyA")
+#pragma comment(linker,"/alternatename:__imp_?RegOpenKeyW@win32@fast_io@@YAH_KPEB_SPEA_K@Z=__imp_RegOpenKeyW")
+#pragma comment(linker,"/alternatename:__imp_?RegQueryValueExA@win32@fast_io@@YAH_KPEB_QPEAI2PEAX2@Z=__imp_RegQueryValueExA")
+#pragma comment(linker,"/alternatename:__imp_?RegQueryValueExW@win32@fast_io@@YAH_KPEB_SPEAI2PEAX2@Z=__imp_RegQueryValueExW")
+#pragma comment(linker,"/alternatename:__imp_?RegCloseKey@win32@fast_io@@YAH_K@Z=__imp_RegCloseKey")
+#pragma comment(linker,"/alternatename:__imp_?GetTimeZoneInformation@win32@fast_io@@YAIPEAUtime_zone_information@12@@Z=__imp_GetTimeZoneInformation")
+#pragma comment(linker,"/alternatename:__imp_?SetConsoleCP@win32@fast_io@@YAHI@Z=__imp_SetConsoleCP")
+#pragma comment(linker,"/alternatename:__imp_?SetConsoleOutputCP@win32@fast_io@@YAHI@Z=__imp_SetConsoleOutputCP")
+#pragma comment(linker,"/alternatename:__imp_?GetConsoleCP@win32@fast_io@@YAIXZ=__imp_GetConsoleCP")
+#pragma comment(linker,"/alternatename:__imp_?GetConsoleOutputCP@win32@fast_io@@YAIXZ=__imp_GetConsoleOutputCP")
+#pragma comment(linker,"/alternatename:__imp_?AcquireSRWLockExclusive@win32@fast_io@@YAXPEAX@Z=__imp_AcquireSRWLockExclusive")
+#pragma comment(linker,"/alternatename:__imp_?TryAcquireSRWLockExclusive@win32@fast_io@@YAIPEAX@Z=__imp_TryAcquireSRWLockExclusive")
+#pragma comment(linker,"/alternatename:__imp_?ReleaseSRWLockExclusive@win32@fast_io@@YAXPEAX@Z=__imp_ReleaseSRWLockExclusive")
+#pragma comment(linker,"/alternatename:__imp_?rtl_nt_status_to_dos_error@nt@win32@fast_io@@YAII@Z=__imp_RtlNtStatusToDosError")
+#pragma comment(linker,"/alternatename:__imp_?NtClose@nt@win32@fast_io@@YAIPEAX@Z=__imp_NtClose")
+#pragma comment(linker,"/alternatename:__imp_?ZwClose@nt@win32@fast_io@@YAIPEAX@Z=__imp_ZwClose")
+#pragma comment(linker,"/alternatename:__imp_?NtCreateFile@nt@win32@fast_io@@YAIPEAPEAXIPEAUobject_attributes@123@PEAUio_status_block@123@PEA_JIIIIPEAXI@Z=__imp_NtCreateFile")
+#pragma comment(linker,"/alternatename:__imp_?ZwCreateFile@nt@win32@fast_io@@YAIPEAPEAXIPEAUobject_attributes@123@PEAUio_status_block@123@PEA_JIIIIPEAXI@Z=__imp_ZwCreateFile")
+#pragma comment(linker,"/alternatename:__imp_?NtCreateSection@nt@win32@fast_io@@YAIPEIAPEAXIPEIAUobject_attributes@123@PEA_KIIPEIAX@Z=__imp_NtCreateSection")
+#pragma comment(linker,"/alternatename:__imp_?ZwCreateSection@nt@win32@fast_io@@YAIPEIAPEAXIPEIAUobject_attributes@123@PEA_KIIPEIAX@Z=__imp_ZwCreateSection")
+#pragma comment(linker,"/alternatename:__imp_?NtQueryInformationProcess@nt@win32@fast_io@@YAIPEIAXW4process_information_class@123@PEAUprocess_basic_information@123@IPEAI@Z=__imp_NtQueryInformationProcess")
+#pragma comment(linker,"/alternatename:__imp_?ZwQueryInformationProcess@nt@win32@fast_io@@YAIPEIAXW4process_information_class@123@PEAUprocess_basic_information@123@IPEAI@Z=__imp_ZwQueryInformationProcess")
+#pragma comment(linker,"/alternatename:__imp_?NtWriteFile@nt@win32@fast_io@@YAIPEAX0P6AX0PEAUio_status_block@123@I@_E01PEBXIPEA_JPEAI@Z=__imp_NtWriteFile")
+#pragma comment(linker,"/alternatename:__imp_?ZwWriteFile@nt@win32@fast_io@@YAIPEAX0P6AX0PEAUio_status_block@123@I@_E01PEBXIPEA_JPEAI@Z=__imp_ZwWriteFile")
+#pragma comment(linker,"/alternatename:__imp_?NtReadFile@nt@win32@fast_io@@YAIPEAX0P6AX0PEAUio_status_block@123@I@_E01PEBXIPEA_JPEAI@Z=__imp_NtReadFile")
+#pragma comment(linker,"/alternatename:__imp_?ZwReadFile@nt@win32@fast_io@@YAIPEAX0P6AX0PEAUio_status_block@123@I@_E01PEBXIPEA_JPEAI@Z=__imp_ZwReadFile")
+#pragma comment(linker,"/alternatename:__imp_?NtQueryDirectoryFile@nt@win32@fast_io@@YAIPEAX0P6AX0PEAUio_status_block@123@I@_E010IW4file_information_class@123@HPEAUunicode_string@123@H@Z=__imp_NtQueryDirectoryFile")
+#pragma comment(linker,"/alternatename:__imp_?ZwQueryDirectoryFile@nt@win32@fast_io@@YAIPEAX0P6AX0PEAUio_status_block@123@I@_E010IW4file_information_class@123@HPEAUunicode_string@123@H@Z=__imp_ZwQueryDirectoryFile")
+#pragma comment(linker,"/alternatename:__imp_?NtQuerySection@nt@win32@fast_io@@YAIPEAXW4section_information_class@123@0_KPEA_K@Z=__imp_NtQuerySection")
+#pragma comment(linker,"/alternatename:__imp_?ZwQuerySection@nt@win32@fast_io@@YAIPEAXW4section_information_class@123@0_KPEA_K@Z=__imp_ZwQuerySection")
+#pragma comment(linker,"/alternatename:__imp_?NtQueryInformationFile@nt@win32@fast_io@@YAIPEIAXPEIAUio_status_block@123@0IW4file_information_class@123@@Z=__imp_NtQueryInformationFile")
+#pragma comment(linker,"/alternatename:__imp_?ZwQueryInformationFile@nt@win32@fast_io@@YAIPEIAXPEIAUio_status_block@123@0IW4file_information_class@123@@Z=__imp_ZwQueryInformationFile")
+#pragma comment(linker,"/alternatename:__imp_?NtSetInformationFile@nt@win32@fast_io@@YAIPEIAXPEIAUio_status_block@123@0IW4file_information_class@123@@Z=__imp_NtSetInformationFile")
+#pragma comment(linker,"/alternatename:__imp_?ZwSetInformationFile@nt@win32@fast_io@@YAIPEIAXPEIAUio_status_block@123@0IW4file_information_class@123@@Z=__imp_ZwSetInformationFile")
+#pragma comment(linker,"/alternatename:__imp_?NtDuplicateObject@nt@win32@fast_io@@YAIPEAX00PEAPEAXIII@Z=__imp_NtDuplicateObject")
+#pragma comment(linker,"/alternatename:__imp_?ZwDuplicateObject@nt@win32@fast_io@@YAIPEAX00PEAPEAXIII@Z=__imp_ZwDuplicateObject")
+#pragma comment(linker,"/alternatename:__imp_?NtWaitForSingleObject@nt@win32@fast_io@@YAIPEAXHPEA_K@Z=__imp_NtWaitForSingleObject")
+#pragma comment(linker,"/alternatename:__imp_?ZwWaitForSingleObject@nt@win32@fast_io@@YAIPEAXHPEA_K@Z=__imp_ZwWaitForSingleObject")
+#pragma comment(linker,"/alternatename:__imp_?NtSetSystemTime@nt@win32@fast_io@@YAIPEA_K0@Z=__imp_NtSetSystemTime")
+#pragma comment(linker,"/alternatename:__imp_?ZwSetSystemTime@nt@win32@fast_io@@YAIPEA_K0@Z=__imp_ZwSetSystemTime")
+#pragma comment(linker,"/alternatename:__imp_?NtCreateProcess@nt@win32@fast_io@@YAIPEAPEAXIPEAUobject_attributes@123@PEAXI222@Z=__imp_NtCreateProcess")
+#pragma comment(linker,"/alternatename:__imp_?ZwCreateProcess@nt@win32@fast_io@@YAIPEAPEAXIPEAUobject_attributes@123@PEAXI222@Z=__imp_ZwCreateProcess")
+#pragma comment(linker,"/alternatename:__imp_?rtl_dos_path_name_to_nt_path_name_u@nt@win32@fast_io@@YAEPEB_WPEAUunicode_string@123@PEAPEB_WPEAUrtl_relative_name_u@123@@Z=__imp_RtlDosPathNameToNtPathName_U")
+#pragma comment(linker,"/alternatename:__imp_?rtl_dos_path_name_to_nt_path_name_u_with_status@nt@win32@fast_io@@YAIPEB_WPEAUunicode_string@123@PEAPEB_WPEAUrtl_relative_name_u@123@@Z=__imp_RtlDosPathNameToNtPathName_U_WithStatus")
+#pragma comment(linker,"/alternatename:__imp_?rtl_free_unicode_string@nt@win32@fast_io@@YAXPEAUunicode_string@123@@Z=__imp_RtlFreeUnicodeString")
+#pragma comment(linker,"/alternatename:__imp_?RtlInitializeCriticalSection@nt@win32@fast_io@@YAXPEAX@Z=__imp_RtlInitializeCriticalSection")
+#pragma comment(linker,"/alternatename:__imp_?RtlEnterCriticalSection@nt@win32@fast_io@@YAXPEAX@Z=__imp_RtlEnterCriticalSection")
+#pragma comment(linker,"/alternatename:__imp_?RtlTryEnterCriticalSection@nt@win32@fast_io@@YAHPEAX@Z=__imp_RtlTryEnterCriticalSection")
+#pragma comment(linker,"/alternatename:__imp_?RtlLeaveCriticalSection@nt@win32@fast_io@@YAXPEAX@Z=__imp_RtlLeaveCriticalSection")
+#pragma comment(linker,"/alternatename:__imp_?RtlDeleteCriticalSection@nt@win32@fast_io@@YAXPEAX@Z=__imp_RtlDeleteCriticalSection")
+#pragma comment(linker,"/alternatename:__imp_?RtlCreateUserThread@nt@win32@fast_io@@YAIPEAX0HI_K100PEAPEAXPEAUclient_id@123@@Z=__imp_RtlCreateUserThread")
+#pragma comment(linker,"/alternatename:__imp_?NtResumeThread@nt@win32@fast_io@@YAIPEAXPEAI@Z=__imp_NtResumeThread")
+#pragma comment(linker,"/alternatename:__imp_?ZwResumeThread@nt@win32@fast_io@@YAIPEAXPEAI@Z=__imp_ZwResumeThread")
+#pragma comment(linker,"/alternatename:__imp_?NtLockFile@nt@win32@fast_io@@YAIPEAX0P6AX0PEAUio_status_block@123@I@_E01PEA_J3IEE@Z=__imp_NtLockFile")
+#pragma comment(linker,"/alternatename:__imp_?ZwLockFile@nt@win32@fast_io@@YAIPEAX0P6AX0PEAUio_status_block@123@I@_E01PEA_J3IEE@Z=__imp_ZwLockFile")
+#pragma comment(linker,"/alternatename:__imp_?NtUnlockFile@nt@win32@fast_io@@YAIPEAXPEAUio_status_block@123@PEA_J2I@Z=__imp_NtUnlockFile")
+#pragma comment(linker,"/alternatename:__imp_?ZwUnlockFile@nt@win32@fast_io@@YAIPEAXPEAUio_status_block@123@PEA_J2I@Z=__imp_ZwUnlockFile")
+#pragma comment(linker,"/alternatename:__imp_?NtFlushBuffersFile@nt@win32@fast_io@@YAIPEAXPEAUio_status_block@123@@Z=__imp_NtFlushBuffersFile")
+#pragma comment(linker,"/alternatename:__imp_?ZwFlushBuffersFile@nt@win32@fast_io@@YAIPEAXPEAUio_status_block@123@@Z=__imp_ZwFlushBuffersFile")
+#pragma comment(linker,"/alternatename:__imp_?NtFlushBuffersFileEx@nt@win32@fast_io@@YAIPEAXI0IPEAUio_status_block@123@@Z=__imp_NtFlushBuffersFileEx")
+#pragma comment(linker,"/alternatename:__imp_?ZwFlushBuffersFileEx@nt@win32@fast_io@@YAIPEAXI0IPEAUio_status_block@123@@Z=__imp_ZwFlushBuffersFileEx")
+#pragma comment(linker,"/alternatename:__imp_?DbgPrint@nt@win32@fast_io@@YAIPEBDZZ=__imp_DbgPrint")
+#pragma comment(linker,"/alternatename:__imp_?DbgPrintEx@nt@win32@fast_io@@YAIIIPEBDZZ=__imp_DbgPrintEx")
+#pragma comment(linker,"/alternatename:__imp_?RtlCreateProcessParameters@nt@win32@fast_io@@YAIPEAPEAUrtl_user_process_parameters@123@PEAUunicode_string@123@111PEAX1111@Z=__imp_RtlCreateProcessParameters")
+#pragma comment(linker,"/alternatename:__imp_?RtlCreateProcessParametersEx@nt@win32@fast_io@@YAIPEAPEAUrtl_user_process_parameters@123@PEAUunicode_string@123@111PEAX1111I@Z=__imp_RtlCreateProcessParametersEx")
+#pragma comment(linker,"/alternatename:__imp_?RtlDestroyProcessParameters@nt@win32@fast_io@@YAIPEAUrtl_user_process_parameters@123@@Z=__imp_RtlDestroyProcessParameters")
+#pragma comment(linker,"/alternatename:__imp_?NtCreateUserProcess@nt@win32@fast_io@@YAIPEAX0IIPEAUobject_attributes@123@1IIPEAUrtl_user_process_parameters@123@PEAUps_create_info@123@PEAUps_attribute_list@123@@Z=__imp_NtCreateUserProcess")
+#pragma comment(linker,"/alternatename:__imp_?ZwCreateUserProcess@nt@win32@fast_io@@YAIPEAX0IIPEAUobject_attributes@123@1IIPEAUrtl_user_process_parameters@123@PEAUps_create_info@123@PEAUps_attribute_list@123@@Z=__imp_ZwCreateUserProcess")
+#pragma comment(linker,"/alternatename:__imp_?RtlCreateUserProcess@nt@win32@fast_io@@YAIPEAUunicode_string@123@IPEAUrtl_user_process_parameters@123@PEAUsecurity_descriptor@123@2PEAXE33PEAUrtl_user_process_information@123@@Z=__imp_RtlCreateUserProcess")
+#pragma comment(linker,"/alternatename:__imp_?NtMapViewOfSection@nt@win32@fast_io@@YAIPEAX0PEAPEAX_K2PEBTlarge_integer@123@PEA_KW4section_inherit@123@II@Z=__imp_NtMapViewOfSection")
+#pragma comment(linker,"/alternatename:__imp_?ZwMapViewOfSection@nt@win32@fast_io@@YAIPEAX0PEAPEAX_K2PEBTlarge_integer@123@PEA_KW4section_inherit@123@II@Z=__imp_ZwMapViewOfSection")
+#pragma comment(linker,"/alternatename:__imp_?NtUnmapViewOfSection@nt@win32@fast_io@@YAIPEAX0@Z=__imp_NtUnmapViewOfSection")
+#pragma comment(linker,"/alternatename:__imp_?ZwUnmapViewOfSection@nt@win32@fast_io@@YAIPEAX0@Z=__imp_ZwUnmapViewOfSection")
+#pragma comment(linker,"/alternatename:__imp_?NtReadVirtualMemory@nt@win32@fast_io@@YAIPEAX00_KPEA_K@Z=__imp_NtReadVirtualMemory")
+#pragma comment(linker,"/alternatename:__imp_?ZwReadVirtualMemory@nt@win32@fast_io@@YAIPEAX00_KPEA_K@Z=__imp_ZwReadVirtualMemory")
+#pragma comment(linker,"/alternatename:__imp_?NtWriteVirtualMemory@nt@win32@fast_io@@YAIPEAX00_KPEA_K@Z=__imp_NtWriteVirtualMemory")
+#pragma comment(linker,"/alternatename:__imp_?ZwWriteVirtualMemory@nt@win32@fast_io@@YAIPEAX00_KPEA_K@Z=__imp_ZwWriteVirtualMemory")
+#pragma comment(linker,"/alternatename:__imp_?RtlAcquirePebLock@nt@win32@fast_io@@YAIXZ=__imp_RtlAcquirePebLock")
+#pragma comment(linker,"/alternatename:__imp_?RtlReleasePebLock@nt@win32@fast_io@@YAIXZ=__imp_RtlReleasePebLock")
+#pragma comment(linker,"/alternatename:__imp_?NtAllocateVirtualMemory@nt@win32@fast_io@@YAIPEAXPEAPEAX_KPEA_KII@Z=__imp_NtAllocateVirtualMemory")
+#pragma comment(linker,"/alternatename:__imp_?ZwAllocateVirtualMemory@nt@win32@fast_io@@YAIPEAXPEAPEAX_KPEA_KII@Z=__imp_ZwAllocateVirtualMemory")
+#pragma comment(linker,"/alternatename:__imp_?RtlInitUnicodeString@nt@win32@fast_io@@YAIPEAUunicode_string@123@PEA_S@Z=__imp_RtlInitUnicodeString")
+#pragma comment(linker,"/alternatename:__imp_?CsrClientCallServer@nt@win32@fast_io@@YAIPEAX0II@Z=__imp_CsrClientCallServer")
+#pragma comment(linker,"/alternatename:__imp_?RtlAcquireSRWLockExclusive@nt@win32@fast_io@@YAXPEAX@Z=__imp_RtlAcquireSRWLockExclusive")
+#pragma comment(linker,"/alternatename:__imp_?RtlTryAcquireSRWLockExclusive@nt@win32@fast_io@@YAIPEAX@Z=__imp_RtlTryAcquireSRWLockExclusive")
+#pragma comment(linker,"/alternatename:__imp_?RtlReleaseSRWLockExclusive@nt@win32@fast_io@@YAXPEAX@Z=__imp_RtlReleaseSRWLockExclusive")
 #pragma comment(linker,"/alternatename:__imp_?msvc__RTtypeid@msvc@fast_io@@YAPEAXPEAX@Z=__imp___RTtypeid")
-#else
 #pragma comment(linker,"/alternatename:?msvc__RTtypeid@msvc@fast_io@@YAPEAXPEAX@Z=__RTtypeid")
-#endif
+// clang-format on

--- a/include/fast_io_hosted/platforms/win32/msvc_linker_64.h
+++ b/include/fast_io_hosted/platforms/win32/msvc_linker_64.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 // clang-format off
 #pragma comment(linker,"/alternatename:__imp_?GetLastError@win32@fast_io@@YAIXZ=__imp_GetLastError")

--- a/include/fast_io_hosted/process/base.h
+++ b/include/fast_io_hosted/process/base.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 namespace fast_io
 {

--- a/include/fast_io_hosted/threads/mutex/impl.h
+++ b/include/fast_io_hosted/threads/mutex/impl.h
@@ -23,7 +23,7 @@ using native_mutex =
 #ifdef __USING_MCFGTHREAD__
 	mcf_gthread_mutex
 #elif (defined(_WIN32) && !defined(__WINE__)) || defined(__CYGWIN__)
-#if (!defined(_WIN32_WINNT) || _WIN32_WINNT >= 0x0600) && 0
+#if (!defined(_WIN32_WINNT) || _WIN32_WINNT >= 0x0600) && !defined(_WIN32_WINDOWS)
 	win32_srwlock
 #else
 	win32_critical_section

--- a/include/fast_io_hosted/threads/mutex/rtl_srwlock.h
+++ b/include/fast_io_hosted/threads/mutex/rtl_srwlock.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 /*
 Referenced from
 https://learn.microsoft.com/en-us/archive/msdn-magazine/2012/november/windows-with-c-the-evolution-of-synchronization-in-windows-and-c

--- a/include/fast_io_hosted/threads/mutex/win32_srwlock.h
+++ b/include/fast_io_hosted/threads/mutex/win32_srwlock.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 /*
 Referenced from
 https://learn.microsoft.com/en-us/archive/msdn-magazine/2012/november/windows-with-c-the-evolution-of-synchronization-in-windows-and-c

--- a/include/fast_io_legacy_impl/filebuf/fp_hack/libstdc++symbol.h
+++ b/include/fast_io_legacy_impl/filebuf/fp_hack/libstdc++symbol.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 namespace fast_io::details
 {

--- a/include/fast_io_legacy_impl/filebuf/rtti_hack/generic.h
+++ b/include/fast_io_legacy_impl/filebuf/rtti_hack/generic.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 namespace fast_io
 {

--- a/include/fast_io_legacy_impl/filebuf/rtti_hack/impl.h
+++ b/include/fast_io_legacy_impl/filebuf/rtti_hack/impl.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include <typeinfo>
 

--- a/include/fast_io_legacy_impl/filebuf/rtti_hack/itanium.h
+++ b/include/fast_io_legacy_impl/filebuf/rtti_hack/itanium.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 /*
 Referenced from
 https://stackoverflow.com/questions/44618230/in-the-msvc-abi-how-do-i-reliably-find-the-vtable-given-only-a-void

--- a/include/fast_io_legacy_impl/filebuf/rtti_hack/msvc.h
+++ b/include/fast_io_legacy_impl/filebuf/rtti_hack/msvc.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include <vcruntime_typeinfo.h>
 

--- a/tests/0026.container/0001.vector/append_range.cc
+++ b/tests/0026.container/0001.vector/append_range.cc
@@ -1,4 +1,4 @@
-#include <cassert>
+﻿#include <cassert>
 #include <algorithm>
 #include <list>
 #include <fast_io.h>

--- a/tests/0026.container/0001.vector/assign.cc
+++ b/tests/0026.container/0001.vector/assign.cc
@@ -1,4 +1,4 @@
-#include <string>
+﻿#include <string>
 #include <fast_io.h>
 #include <fast_io_dsal/vector.h>
 using namespace fast_io::io;

--- a/tests/0026.container/0001.vector/assign_range.cc
+++ b/tests/0026.container/0001.vector/assign_range.cc
@@ -1,4 +1,4 @@
-#include <algorithm>
+﻿#include <algorithm>
 #include <cassert>
 #include <list>
 #include <fast_io.h>

--- a/tests/0026.container/0001.vector/back.cc
+++ b/tests/0026.container/0001.vector/back.cc
@@ -1,4 +1,4 @@
-#include <fast_io.h>
+﻿#include <fast_io.h>
 #include <fast_io_dsal/vector.h>
 using namespace fast_io::io;
 using namespace fast_io::mnp;

--- a/tests/0026.container/0001.vector/begin.cc
+++ b/tests/0026.container/0001.vector/begin.cc
@@ -1,4 +1,4 @@
-#include <algorithm>
+﻿#include <algorithm>
 #include <numeric>
 #include <string>
 #include <fast_io.h>

--- a/tests/0026.container/0001.vector/capacity.cc
+++ b/tests/0026.container/0001.vector/capacity.cc
@@ -1,4 +1,4 @@
-#include <fast_io.h>
+﻿#include <fast_io.h>
 #include <fast_io_dsal/vector.h>
 using namespace fast_io::io;
 using namespace fast_io::mnp;

--- a/tests/0026.container/0001.vector/clear.cc
+++ b/tests/0026.container/0001.vector/clear.cc
@@ -1,4 +1,4 @@
-#include <string_view>
+﻿#include <string_view>
 #include <fast_io.h>
 #include <fast_io_dsal/vector.h>
 using namespace fast_io::io;

--- a/tests/0026.container/0001.vector/data.cc
+++ b/tests/0026.container/0001.vector/data.cc
@@ -1,4 +1,4 @@
-#include <cstddef>
+﻿#include <cstddef>
 #include <span>
 #include <fast_io.h>
 #include <fast_io_dsal/vector.h>

--- a/tests/0026.container/0001.vector/emplace.cc
+++ b/tests/0026.container/0001.vector/emplace.cc
@@ -1,4 +1,4 @@
-#include <algorithm>
+﻿#include <algorithm>
 #include <ranges>
 #include <string>
 #include <fast_io.h>

--- a/tests/0026.container/0001.vector/emplace_back.cc
+++ b/tests/0026.container/0001.vector/emplace_back.cc
@@ -1,4 +1,4 @@
-#include <cassert>
+﻿#include <cassert>
 #include <string>
 #include <fast_io.h>
 #include <fast_io_dsal/vector.h>

--- a/tests/0026.container/0001.vector/emplace_index.cc
+++ b/tests/0026.container/0001.vector/emplace_index.cc
@@ -1,4 +1,4 @@
-#include <algorithm>
+﻿#include <algorithm>
 #include <ranges>
 #include <string>
 #include <fast_io.h>

--- a/tests/0026.container/0001.vector/empty.cc
+++ b/tests/0026.container/0001.vector/empty.cc
@@ -1,4 +1,4 @@
-#include <fast_io.h>
+﻿#include <fast_io.h>
 #include <fast_io_dsal/vector.h>
 using namespace fast_io::io;
 using namespace fast_io::mnp;

--- a/tests/0026.container/0001.vector/end.cc
+++ b/tests/0026.container/0001.vector/end.cc
@@ -1,4 +1,4 @@
-#include <algorithm>
+﻿#include <algorithm>
 #include <numeric>
 #include <string>
 #include <fast_io.h>

--- a/tests/0026.container/0001.vector/erase.cc
+++ b/tests/0026.container/0001.vector/erase.cc
@@ -1,4 +1,4 @@
-#include <fast_io.h>
+﻿#include <fast_io.h>
 #include <fast_io_dsal/vector.h>
 using namespace fast_io::io;
 using namespace fast_io::mnp;

--- a/tests/0026.container/0001.vector/erase_index.cc
+++ b/tests/0026.container/0001.vector/erase_index.cc
@@ -1,4 +1,4 @@
-#include <fast_io.h>
+﻿#include <fast_io.h>
 #include <fast_io_dsal/vector.h>
 using namespace fast_io::io;
 using namespace fast_io::mnp;

--- a/tests/0026.container/0001.vector/front.cc
+++ b/tests/0026.container/0001.vector/front.cc
@@ -1,4 +1,4 @@
-#include <fast_io.h>
+﻿#include <fast_io.h>
 #include <fast_io_dsal/vector.h>
 using namespace fast_io::io;
 using namespace fast_io::mnp;

--- a/tests/0026.container/0001.vector/insert.cc
+++ b/tests/0026.container/0001.vector/insert.cc
@@ -1,4 +1,4 @@
-#include <iterator>
+﻿#include <iterator>
 #include <fast_io.h>
 #include <fast_io_dsal/vector.h>
 using namespace fast_io::io;

--- a/tests/0026.container/0001.vector/insert_range.cc
+++ b/tests/0026.container/0001.vector/insert_range.cc
@@ -1,4 +1,4 @@
-#include <cassert>
+﻿#include <cassert>
 #include <iterator>
 #include <algorithm>
 #include <list>

--- a/tests/0026.container/0001.vector/max_size.cc
+++ b/tests/0026.container/0001.vector/max_size.cc
@@ -1,4 +1,4 @@
-#include <fast_io.h>
+﻿#include <fast_io.h>
 #include <fast_io_i18n.h>
 #include <fast_io_dsal/vector.h>
 using namespace fast_io::io;

--- a/tests/0026.container/0001.vector/operator=.cc
+++ b/tests/0026.container/0001.vector/operator=.cc
@@ -1,4 +1,4 @@
-#include <initializer_list>
+﻿#include <initializer_list>
 #include <iterator>
 #include <fast_io.h>
 #include <fast_io_dsal/vector.h>

--- a/tests/0026.container/0001.vector/operator_at.cc
+++ b/tests/0026.container/0001.vector/operator_at.cc
@@ -1,4 +1,4 @@
-#include <fast_io.h>
+﻿#include <fast_io.h>
 #include <fast_io_dsal/vector.h>
 using namespace fast_io::io;
 using namespace fast_io::mnp;

--- a/tests/0026.container/0001.vector/operator_cmp.cc
+++ b/tests/0026.container/0001.vector/operator_cmp.cc
@@ -1,4 +1,4 @@
-#include <cassert>
+﻿#include <cassert>
 #include <fast_io.h>
 #include <fast_io_dsal/vector.h>
 using namespace fast_io::io;

--- a/tests/0026.container/0001.vector/pop_back.cc
+++ b/tests/0026.container/0001.vector/pop_back.cc
@@ -1,4 +1,4 @@
-#include <fast_io.h>
+﻿#include <fast_io.h>
 #include <fast_io_dsal/vector.h>
 using namespace fast_io::io;
 using namespace fast_io::mnp;

--- a/tests/0026.container/0001.vector/push_back.cc
+++ b/tests/0026.container/0001.vector/push_back.cc
@@ -1,4 +1,4 @@
-#include <string>
+﻿#include <string>
 #include <fast_io.h>
 #include <fast_io_dsal/vector.h>
 using namespace fast_io::io;

--- a/tests/0026.container/0001.vector/reserve.cc
+++ b/tests/0026.container/0001.vector/reserve.cc
@@ -1,4 +1,4 @@
-#include <cstddef>
+﻿#include <cstddef>
 #include <new>
 #include <fast_io.h>
 #include <fast_io_dsal/vector.h>

--- a/tests/0026.container/0001.vector/resize.cc
+++ b/tests/0026.container/0001.vector/resize.cc
@@ -1,4 +1,4 @@
-#include <fast_io.h>
+﻿#include <fast_io.h>
 #include <fast_io_dsal/vector.h>
 using namespace fast_io::io;
 using namespace fast_io::mnp;

--- a/tests/0026.container/0001.vector/shared_ptr.cc
+++ b/tests/0026.container/0001.vector/shared_ptr.cc
@@ -1,4 +1,4 @@
-#include <fast_io_dsal/vector.h>
+﻿#include <fast_io_dsal/vector.h>
 #include <fast_io.h>
 #include <memory>
 

--- a/tests/0026.container/0001.vector/shared_ptr_index.cc
+++ b/tests/0026.container/0001.vector/shared_ptr_index.cc
@@ -1,4 +1,4 @@
-#include <fast_io_dsal/vector.h>
+﻿#include <fast_io_dsal/vector.h>
 #include <fast_io.h>
 #include <memory>
 

--- a/tests/0026.container/0001.vector/shared_ptr_index_not_trivial.cc
+++ b/tests/0026.container/0001.vector/shared_ptr_index_not_trivial.cc
@@ -1,4 +1,4 @@
-#include <fast_io_dsal/vector.h>
+﻿#include <fast_io_dsal/vector.h>
 #include <fast_io.h>
 #include <memory>
 

--- a/tests/0026.container/0001.vector/shrink_to_fit.cc
+++ b/tests/0026.container/0001.vector/shrink_to_fit.cc
@@ -1,4 +1,4 @@
-#include <fast_io.h>
+﻿#include <fast_io.h>
 #include <fast_io_dsal/vector.h>
 using namespace fast_io::io;
 using namespace fast_io::mnp;

--- a/tests/0026.container/0001.vector/size.cc
+++ b/tests/0026.container/0001.vector/size.cc
@@ -1,4 +1,4 @@
-#include <fast_io.h>
+﻿#include <fast_io.h>
 #include <fast_io_dsal/vector.h>
 using namespace fast_io::io;
 using namespace fast_io::mnp;

--- a/tests/0026.container/0001.vector/swap.cc
+++ b/tests/0026.container/0001.vector/swap.cc
@@ -1,4 +1,4 @@
-#include <fast_io.h>
+﻿#include <fast_io.h>
 #include <fast_io_dsal/vector.h>
 using namespace fast_io::io;
 using namespace fast_io::mnp;

--- a/tests/0026.container/0001.vector/vector.cc
+++ b/tests/0026.container/0001.vector/vector.cc
@@ -1,4 +1,4 @@
-#include <string>
+﻿#include <string>
 #include <fast_io.h>
 #include <fast_io_dsal/vector.h>
 using namespace fast_io::io;

--- a/tests/0026.container/0001.vector/vector_allocate_at_least.cc
+++ b/tests/0026.container/0001.vector/vector_allocate_at_least.cc
@@ -1,4 +1,4 @@
-#include <fast_io.h>
+﻿#include <fast_io.h>
 #include <fast_io_dsal/vector.h>
 using namespace fast_io::io;
 using namespace fast_io::mnp;

--- a/tests/0026.container/0002.list/list_loop.cc
+++ b/tests/0026.container/0002.list/list_loop.cc
@@ -1,4 +1,4 @@
-#include <fast_io_dsal/list.h>
+﻿#include <fast_io_dsal/list.h>
 #include <fast_io.h>
 using namespace fast_io::io;
 using namespace fast_io::mnp;

--- a/tests/0026.container/0002.list/list_merge.cc
+++ b/tests/0026.container/0002.list/list_merge.cc
@@ -1,4 +1,4 @@
-#include <fast_io_dsal/list.h>
+﻿#include <fast_io_dsal/list.h>
 #include <fast_io.h>
 
 int main()

--- a/tests/0026.container/0002.list/list_sort.cc
+++ b/tests/0026.container/0002.list/list_sort.cc
@@ -1,4 +1,4 @@
-#include <fast_io_dsal/list.h>
+﻿#include <fast_io_dsal/list.h>
 #include <fast_io_dsal/vector.h>
 #include <fast_io.h>
 #include <random>

--- a/tests/0026.container/0002.list/list_splice.cc
+++ b/tests/0026.container/0002.list/list_splice.cc
@@ -1,4 +1,4 @@
-#include <fast_io.h>
+﻿#include <fast_io.h>
 #include <fast_io_dsal/list.h>
 #include <iterator>
 

--- a/tests/0026.container/0002.list/shared_ptr_insert.cc
+++ b/tests/0026.container/0002.list/shared_ptr_insert.cc
@@ -1,4 +1,4 @@
-#include <fast_io_dsal/list.h>
+﻿#include <fast_io_dsal/list.h>
 #include <fast_io.h>
 #include <memory>
 

--- a/tests/0026.container/0003.deque/deque_push.cc
+++ b/tests/0026.container/0003.deque/deque_push.cc
@@ -1,4 +1,4 @@
-#include <fast_io_dsal/deque.h>
+﻿#include <fast_io_dsal/deque.h>
 #include <fast_io.h>
 
 int main()

--- a/tests/0026.container/0003.deque/dequeasm.cc
+++ b/tests/0026.container/0003.deque/dequeasm.cc
@@ -1,4 +1,4 @@
-#include <fast_io_dsal/deque.h>
+﻿#include <fast_io_dsal/deque.h>
 
 auto test(::fast_io::deque<::std::size_t>::iterator a, ::fast_io::deque<::std::size_t>::iterator b)
 {

--- a/tests/0026.container/0003.deque/test_deque.cc
+++ b/tests/0026.container/0003.deque/test_deque.cc
@@ -1,4 +1,4 @@
-#include <fast_io_dsal/deque.h>
+﻿#include <fast_io_dsal/deque.h>
 #include <fast_io.h>
 
 int main()

--- a/tests/0026.container/0005.stack/test_stack.cc
+++ b/tests/0026.container/0005.stack/test_stack.cc
@@ -1,4 +1,4 @@
-#include <fast_io_dsal/stack.h>
+﻿#include <fast_io_dsal/stack.h>
 #include <cstddef>
 #include <fast_io.h>
 

--- a/tests/0026.container/0006.queue/test_queue.cc
+++ b/tests/0026.container/0006.queue/test_queue.cc
@@ -1,4 +1,4 @@
-#include <fast_io_dsal/queue.h>
+﻿#include <fast_io_dsal/queue.h>
 #include <cstddef>
 #include <fast_io.h>
 

--- a/tests/0026.container/0007.array/test_array.cc
+++ b/tests/0026.container/0007.array/test_array.cc
@@ -1,4 +1,4 @@
-#include <fast_io_dsal/array.h>
+﻿#include <fast_io_dsal/array.h>
 #include <fast_io.h>
 
 int main()

--- a/tests/0026.container/0008.priority_queue/test_priority_queue.cc
+++ b/tests/0026.container/0008.priority_queue/test_priority_queue.cc
@@ -1,4 +1,4 @@
-#include <fast_io_dsal/priority_queue.h>
+﻿#include <fast_io_dsal/priority_queue.h>
 #include <cstddef>
 #include <fast_io.h>
 

--- a/tests/0026.container/0009.string_view/string_view.cc
+++ b/tests/0026.container/0009.string_view/string_view.cc
@@ -1,4 +1,4 @@
-#include <fast_io_dsal/string_view.h>
+﻿#include <fast_io_dsal/string_view.h>
 #include <fast_io.h>
 
 int main()

--- a/tests/0026.container/0010.cstring_view/cstring_view.cc
+++ b/tests/0026.container/0010.cstring_view/cstring_view.cc
@@ -1,4 +1,4 @@
-#include <fast_io_dsal/cstring_view.h>
+﻿#include <fast_io_dsal/cstring_view.h>
 #include <fast_io.h>
 
 int main()

--- a/tests/0026.container/0011.span/index_span.cc
+++ b/tests/0026.container/0011.span/index_span.cc
@@ -1,4 +1,4 @@
-#include <fast_io_dsal/array.h>
+﻿#include <fast_io_dsal/array.h>
 #include <fast_io_dsal/index_span.h>
 #include <fast_io.h>
 

--- a/tests/0026.container/0011.span/span.cc
+++ b/tests/0026.container/0011.span/span.cc
@@ -1,4 +1,4 @@
-#include<fast_io_dsal/array.h>
+﻿#include<fast_io_dsal/array.h>
 #include<fast_io_dsal/span.h>
 #include<fast_io.h>
 

--- a/tests/0031.tpeb/peb.cc
+++ b/tests/0031.tpeb/peb.cc
@@ -1,4 +1,4 @@
-#include <cstdio>
+﻿#include <cstdio>
 #include <fast_io_core.h>
 
 int main()

--- a/tests/0031.tpeb/stdout.cc
+++ b/tests/0031.tpeb/stdout.cc
@@ -1,4 +1,4 @@
-#include <fast_io.h>
+﻿#include <fast_io.h>
 
 void test_nt_stdout()
 {

--- a/tests/0032.process/nt.cc
+++ b/tests/0032.process/nt.cc
@@ -1,4 +1,4 @@
-#include <fast_io.h>
+﻿#include <fast_io.h>
 
 int main()
 {

--- a/tests/0033.legacy/getfd.cc
+++ b/tests/0033.legacy/getfd.cc
@@ -1,4 +1,4 @@
-#include<fast_io_legacy.h>
+﻿#include<fast_io_legacy.h>
 #ifdef __GLIBCXX__
 #include<ext/stdio_sync_filebuf.h>
 #include<ext/stdio_filebuf.h>

--- a/tests/0033.legacy/kreckelfileno/fileno.cpp
+++ b/tests/0033.legacy/kreckelfileno/fileno.cpp
@@ -1,4 +1,4 @@
-#include <fast_io_legacy.h>
+﻿#include <fast_io_legacy.h>
 #include "fileno.hpp"
 
 /*

--- a/tests/0033.legacy/kreckelfileno/fileno.hpp
+++ b/tests/0033.legacy/kreckelfileno/fileno.hpp
@@ -1,4 +1,4 @@
-#include <iosfwd>
+﻿#include <iosfwd>
 
 template <typename charT, typename traits>
 int fileno(std::basic_ios<charT, traits> const &stream) noexcept;

--- a/tests/0033.legacy/kreckelfileno/main.cpp
+++ b/tests/0033.legacy/kreckelfileno/main.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
 https://www.ginac.de/~kreckel/fileno/main.cpp
 */
 #include <iostream>

--- a/tests/0034.string/stringtest.cc
+++ b/tests/0034.string/stringtest.cc
@@ -1,4 +1,4 @@
-#include <string>
+﻿#include <string>
 #include <fast_io.h>
 
 int main()


### PR DESCRIPTION
1. Use SRWLock for default mutex above Windows Vista.
2. Add UTF8 BOM to the files that do not have it.
3. Revamp linkage for msvc linkage, they should never use clang-format.
