### PR TITLE
remove redundant 	using namespace ::fast_io::mnp;

### DIFF
--- a/tests/0024.timestamp/fixed.cc
+++ b/tests/0024.timestamp/fixed.cc
@@ -36,8 +36,6 @@ inline void test_val(::fast_io::unix_timestamp ts)
 
 int main()
 {
-	using namespace ::fast_io::mnp;
-	using namespace ::fast_io::io;
 	test_val({0, 0});
 	test_val({0, ::fast_io::uint_least64_subseconds_per_second - 1u});
 	test_val({0, ::fast_io::uint_least64_subseconds_per_second >> 1u});


### PR DESCRIPTION
	using namespace ::fast_io::io; in the test