### PR TITLE
Clear more `#pragma warning` and `#pragma {push,pop}_macro` directives

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -34,7 +34,7 @@ jobs:
     - name: prebuild
       run: cmake -GNinja . -DCMAKE_BUILD_TYPE=Release -DTESTS_PREBUILD=On -DCMAKE_CXX_STANDARD=23 -DCMAKE_CXX_EXTENSIONS=OFF && ninja && ninja run_test_prebuild
     - name: cmake
-      run: cmake -GNinja . -DCMAKE_BUILD_TYPE=Release -DENABLE_TESTS=On -DCMAKE_CXX_FLAGS="/EHsc" -DCMAKE_C_COMPILER=cl -DCMAKE_CXX_COMPILER=cl
+      run: cmake -GNinja . -DCMAKE_BUILD_TYPE=Release -DENABLE_TESTS=On -DCMAKE_CXX_FLAGS="/EHsc /sdl /Wall" -DCMAKE_C_COMPILER=cl -DCMAKE_CXX_COMPILER=cl
     - name: ninja
       run: ninja
     - name: ninja test
@@ -48,9 +48,9 @@ jobs:
     - uses: actions/checkout@v4
     - uses: ilammy/msvc-dev-cmd@v1.13.0
     - name: prebuild
-      run: cmake -GNinja . -DCMAKE_BUILD_TYPE=Release -DCMAKE_MSVC_RUNTIME_LIBRARY="MultiThreadedDebugDLL" -DTESTS_PREBUILD=On -DCMAKE_CXX_STANDARD=23 -DCMAKE_CXX_EXTENSIONS=OFF && ninja && ninja run_test_prebuild
+      run: cmake -GNinja . -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_MSVC_RUNTIME_LIBRARY="MultiThreadedDebugDLL" -DTESTS_PREBUILD=On -DCMAKE_CXX_STANDARD=23 -DCMAKE_CXX_EXTENSIONS=OFF && ninja && ninja run_test_prebuild
     - name: cmake
-      run: cmake -GNinja . -DCMAKE_BUILD_TYPE=Release -DCMAKE_MSVC_RUNTIME_LIBRARY="MultiThreadedDebugDLL" -DENABLE_TESTS=On -DCMAKE_CXX_FLAGS="/fsanitize=address /EHsc" -DCMAKE_C_COMPILER=cl -DCMAKE_CXX_COMPILER=cl
+      run: cmake -GNinja . -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_MSVC_RUNTIME_LIBRARY="MultiThreadedDebugDLL" -DENABLE_TESTS=On -DCMAKE_CXX_FLAGS="/EHsc /fsanitize=address /sdl /Wall" -DCMAKE_C_COMPILER=cl -DCMAKE_CXX_COMPILER=cl
     - name: ninja
       run: ninja
     - name: ninja test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,6 +99,10 @@ endif()
 
 endif()
 
+if(WIN32)
+	add_definitions(-D_CRT_SECURE_NO_WARNINGS -D_CRT_NONSTDC_NO_DEPRECATE)
+endif()
+
 option(TESTS_PREBUILD "prebuild cmake files for test" OFF)
 
 if(${TESTS_PREBUILD})

--- a/include/fast_io_core_impl/allocation/adapters.h
+++ b/include/fast_io_core_impl/allocation/adapters.h
@@ -5,9 +5,6 @@
 // https://github.com/microsoft/STL/issues/4002 gcc and clang provide constexpr new, but still won't compile.
 // ::std::allocator<T> is NOT freestanding.
 
-#pragma push_macro("new")
-#undef new
-
 namespace fast_io
 {
 
@@ -1987,5 +1984,3 @@ inline constexpr ::fast_io::allocation_least_result status_allocator_pointer_ali
 } // namespace details
 
 } // namespace fast_io
-
-#pragma pop_macro("new")

--- a/include/fast_io_core_impl/allocation/c_malloc.h
+++ b/include/fast_io_core_impl/allocation/c_malloc.h
@@ -1,8 +1,4 @@
 ﻿#pragma once
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable : 6308)
-#endif
 
 #if __has_include(<malloc.h>)
 #include <malloc.h>
@@ -247,7 +243,3 @@ public:
 };
 
 } // namespace fast_io
-
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif

--- a/include/fast_io_core_impl/allocation/wincrt_malloc_dbg.h
+++ b/include/fast_io_core_impl/allocation/wincrt_malloc_dbg.h
@@ -1,10 +1,5 @@
 ﻿#pragma once
 
-#if defined(_MSC_VER) && !defined(__clang__)
-#pragma warning(push)
-#pragma warning(disable : 6308)
-#endif
-
 #include <crtdbg.h>
 
 namespace fast_io
@@ -90,7 +85,3 @@ public:
 };
 
 } // namespace fast_io
-
-#if defined(_MSC_VER) && !defined(__clang__)
-#pragma warning(pop)
-#endif

--- a/include/fast_io_core_impl/freestanding/algorithm.h
+++ b/include/fast_io_core_impl/freestanding/algorithm.h
@@ -3,10 +3,6 @@
 #if defined(__GNUC__) || defined(__clang__)
 #pragma GCC system_header
 #endif
-#if defined(_MSC_VER) && !defined(__clang__)
-#pragma warning(push)
-#pragma warning(disable : 4365)
-#endif
 
 #if 0
 //__STDC_HOSTED__==1 && (!defined(_GLIBCXX_HOSTED) || _GLIBCXX_HOSTED==1)
@@ -841,7 +837,3 @@ using ::fast_io::freestanding::non_overlapped_copy;
 using ::fast_io::freestanding::non_overlapped_copy_n;
 
 } // namespace fast_io::details
-
-#if defined(_MSC_VER) && !defined(__clang__)
-#pragma warning(pop)
-#endif

--- a/include/fast_io_core_impl/integers/sto/sto_contiguous.h
+++ b/include/fast_io_core_impl/integers/sto/sto_contiguous.h
@@ -1,8 +1,4 @@
 ﻿#pragma once
-#if defined(_MSC_VER) && !defined(__clang__)
-#pragma warning(push)
-#pragma warning(disable : 4061)
-#endif
 #include "sto_generate_base_tb.h"
 
 namespace fast_io
@@ -1474,6 +1470,3 @@ inline constexpr parse_code scan_context_eof_define(io_reserve_type_t<char_type,
 }
 
 } // namespace fast_io
-#if defined(_MSC_VER) && !defined(__clang__)
-#pragma warning(pop)
-#endif

--- a/include/fast_io_core_impl/intrinsics.h
+++ b/include/fast_io_core_impl/intrinsics.h
@@ -1,9 +1,7 @@
 ﻿#pragma once
+
 #if defined(_MSC_VER) && !defined(__clang__)
 #include <intrin.h>
-#pragma warning(push)
-#pragma warning(disable : 4668)
-#pragma warning(disable : 4800)
 #endif
 
 namespace fast_io::details::intrinsics
@@ -978,7 +976,3 @@ inline constexpr U shiftright(U low_part, U high_part, ::std::uint_least8_t shif
 }
 
 } // namespace fast_io::details::intrinsics
-
-#if defined(_MSC_VER) && !defined(__clang__)
-#pragma warning(pop)
-#endif

--- a/include/fast_io_core_impl/socket/posix_sockaddr.h
+++ b/include/fast_io_core_impl/socket/posix_sockaddr.h
@@ -2,10 +2,7 @@
 
 namespace fast_io
 {
-#if defined(_MSC_VER) && !defined(__clang__)
-#pragma warning(push, _STL_WARNING_LEVEL)
-#pragma warning(disable : 4324)
-#endif
+
 struct
 #if __has_cpp_attribute(__gnu__::__may_alias__)
 	[[__gnu__::__may_alias__]]
@@ -58,7 +55,4 @@ struct
 	::std::uint_least16_t ss_family{};
 };
 
-#if defined(_MSC_VER) && !defined(__clang__)
-#pragma warning(pop)
-#endif
 } // namespace fast_io

--- a/include/fast_io_driver/win32_internet.h
+++ b/include/fast_io_driver/win32_internet.h
@@ -2,10 +2,6 @@
 #include <windows.h>
 #include <wininet.h>
 
-#undef min
-#undef max
-#undef interface
-
 namespace fast_io
 {
 

--- a/include/fast_io_dsal/impl/misc/pop_macros.h
+++ b/include/fast_io_dsal/impl/misc/pop_macros.h
@@ -1,6 +1,8 @@
 // Please keep it in reverse order with the macros in push_macros.h
-#pragma pop_macro("erase")
-#pragma pop_macro("move")
 #pragma pop_macro("refresh")
-#pragma pop_macro("max")
+#pragma pop_macro("new")
+#pragma pop_macro("move")
 #pragma pop_macro("min")
+#pragma pop_macro("max")
+#pragma pop_macro("interface")
+#pragma pop_macro("erase")

--- a/include/fast_io_dsal/impl/misc/push_macros.h
+++ b/include/fast_io_dsal/impl/misc/push_macros.h
@@ -1,14 +1,20 @@
-#pragma push_macro("min")
-#undef min
+#pragma push_macro("erase")
+#undef erase
+
+#pragma push_macro("interface")
+#undef interface
 
 #pragma push_macro("max")
 #undef max
 
-#pragma push_macro("refresh")
-#undef refresh
+#pragma push_macro("min")
+#undef min
 
 #pragma push_macro("move")
 #undef move
 
-#pragma push_macro("erase")
-#undef erase
+#pragma push_macro("new")
+#undef new
+
+#pragma push_macro("refresh")
+#undef refresh

--- a/include/fast_io_dsal/impl/misc/push_warnings.h
+++ b/include/fast_io_dsal/impl/misc/push_warnings.h
@@ -1,6 +1,7 @@
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && !defined(__clang__)
 #pragma warning(push)
 #pragma warning(disable : 4061)
+#pragma warning(disable : 4324)
 #pragma warning(disable : 4365)
 #pragma warning(disable : 4464)
 #pragma warning(disable : 4514)
@@ -9,7 +10,9 @@
 #pragma warning(disable : 4668)
 #pragma warning(disable : 4710)
 #pragma warning(disable : 4711)
+#pragma warning(disable : 4800)
 #pragma warning(disable : 4820)
 #pragma warning(disable : 5027)
 #pragma warning(disable : 5045)
+#pragma warning(disable : 6308)
 #endif

--- a/include/fast_io_freestanding.h
+++ b/include/fast_io_freestanding.h
@@ -11,7 +11,7 @@
 
 #include "fast_io_core.h"
 
-#include "fast_io_dsal/impl/misc/push_macros.h"
+#include "fast_io_dsal/impl/misc/push_warnings.h"
 
 #include "fast_io_freestanding_impl/exception.h"
 // #include"fast_io_freestanding_impl/posix_error.h"

--- a/include/fast_io_legacy_impl/c/wincrt.h
+++ b/include/fast_io_legacy_impl/c/wincrt.h
@@ -1,11 +1,5 @@
 ﻿#pragma once
 
-#if defined(_MSC_VER) && !defined(__clang__)
-#pragma warning(push)
-#pragma warning(disable : 4710)
-#pragma warning(disable : 4820)
-#endif
-
 namespace fast_io
 {
 
@@ -605,7 +599,3 @@ inline u32c_io_observer u32c_stderr() noexcept
 }
 
 } // namespace fast_io
-
-#if defined(_MSC_VER) && !defined(__clang__)
-#pragma warning(pop)
-#endif

--- a/include/fast_io_unit/floating/punning.h
+++ b/include/fast_io_unit/floating/punning.h
@@ -1,10 +1,5 @@
 ﻿#pragma once
 
-#if defined(_MSC_VER) && !defined(__clang__)
-#pragma warning(push)
-#pragma warning(disable : 4820)
-#endif
-
 namespace fast_io::details
 {
 
@@ -804,7 +799,3 @@ inline constexpr char_type *prt_rsv_exponent_impl(char_type *iter, U u) noexcept
 }
 
 } // namespace fast_io::details
-
-#if defined(_MSC_VER) && !defined(__clang__)
-#pragma warning(pop)
-#endif


### PR DESCRIPTION
但是仍然有一些警告
```text
E:\repo\fast_io\include\fast_io_dsal/impl/misc/pop_warnings.h(2): warning C5031: #pragma warning(pop): 可能不匹配，正在 弹出的警告状态已推送到其他文件
E:\repo\fast_io\include\fast_io_dsal/impl/misc/push_warnings.h(2): note: #pragma warning(push)
E:\repo\fast_io\include\fast_io_dsal/impl/misc/pop_warnings.h(2): warning C5031: #pragma warning(pop): 可能不匹配，正在 弹出的警告状态已推送到其他文件
E:\repo\fast_io\include\fast_io_dsal/impl/misc/push_warnings.h(2): note: #pragma warning(push)
E:\repo\fast_io\include\fast_io_dsal/impl/misc/pop_warnings.h(2): warning C5031: #pragma warning(pop): 可能不匹配，正在 弹出的警告状态已推送到其他文件
E:\repo\fast_io\include\fast_io_dsal/impl/misc/push_warnings.h(2): note: #pragma warning(push)
E:\repo\fast_io\include\fast_io_dsal/impl/misc/pop_warnings.h(2): warning C5031: #pragma warning(pop): 可能不匹配，正在 弹出的警告状态已推送到其他文件
E:\repo\fast_io\include\fast_io_dsal/impl/misc/push_warnings.h(2): note: #pragma warning(push)
E:\repo\fast_io\include\fast_io_dsal/impl/misc/pop_warnings.h(2): warning C5031: #pragma warning(pop): 可能不匹配，正在 弹出的警告状态已推送到其他文件
E:\repo\fast_io\include\fast_io_dsal/impl/misc/push_warnings.h(2): note: #pragma warning(push)
```