### PR TITLE
Rephrase action scripts

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -2,59 +2,54 @@ name: C/C++ CI
 
 on:
   push:
-    branches: [ "master", "next" ]
+    branches: ["master", "next"]
   pull_request:
-    branches: [ "master", "next" ]
+    branches: ["master", "next"]
 
 jobs:
   ubuntu:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Install ninja-build tool
-      uses: seanmiddleditch/gha-setup-ninja@v5
-    - name: prebuild
-      run: cmake -GNinja . -DCMAKE_BUILD_TYPE=Release -DTESTS_PREBUILD=On -DCMAKE_CXX_STANDARD=23 -DCMAKE_CXX_EXTENSIONS=OFF && ninja && ninja run_test_prebuild
-    - name: cmake
-      run: cmake -GNinja . -DCMAKE_BUILD_TYPE=Release -DENABLE_TESTS=On -DCMAKE_CXX_FLAGS="-fsanitize=address,undefined -Wall -Wextra -Wpedantic -Wmisleading-indentation -Wunused -Wuninitialized -Wshadow -Wconversion -Werror"
-    - name: ninja
-      run: ninja
-    - name: ninja test
-      run: ninja test
+      - uses: actions/checkout@v4
+      - name: Install ninja-build tool
+        uses: seanmiddleditch/gha-setup-ninja@v5
+      - name: Generate CMake files for test
+        run: cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DGENERATE_TESTS=On . && cmake --build .
+      - name: CMake configure
+        run: cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DENABLE_TESTS=On -DCMAKE_CXX_FLAGS="-fsanitize=address,undefined -Wall -Wextra -Wpedantic -Wmisleading-indentation -Wunused -Wuninitialized -Wshadow -Wconversion -Werror" .
+      - name: CMake build
+        run: cmake --build .
+      - name: CMake test
+        run: cmake --target test --build .
 
   windows:
-
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v4
-    - uses: ilammy/msvc-dev-cmd@v1.13.0
-    - name: prebuild
-      run: cmake -GNinja . -DCMAKE_BUILD_TYPE=Release -DTESTS_PREBUILD=On -DCMAKE_CXX_STANDARD=23 -DCMAKE_CXX_EXTENSIONS=OFF && ninja && ninja run_test_prebuild
-    - name: cmake
-      run: cmake -GNinja . -DCMAKE_BUILD_TYPE=Release -DENABLE_TESTS=On -DCMAKE_CXX_FLAGS="/EHsc /sdl /Wall" -DCMAKE_C_COMPILER=cl -DCMAKE_CXX_COMPILER=cl
-    - name: ninja
-      run: ninja
-    - name: ninja test
-      run: ninja test
+      - uses: actions/checkout@v4
+      - uses: ilammy/msvc-dev-cmd@v1.13.0
+      - name: Generate CMake files for test
+        run: cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DGENERATE_TESTS=On . && cmake --build .
+      - name: CMake configure
+        run: cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DENABLE_TESTS=On -DCMAKE_CXX_FLAGS="/EHsc /sdl /Wall" -DCMAKE_C_COMPILER=cl -DCMAKE_CXX_COMPILER=cl .
+      - name: CMake build
+        run: cmake --build .
+      - name: CMake test
+        run: cmake --target test --build .
 
   windows-debug:
-
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v4
-    - uses: ilammy/msvc-dev-cmd@v1.13.0
-    - name: prebuild
-      run: cmake -GNinja . -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_MSVC_RUNTIME_LIBRARY="MultiThreadedDebugDLL" -DTESTS_PREBUILD=On -DCMAKE_CXX_STANDARD=23 -DCMAKE_CXX_EXTENSIONS=OFF && ninja && ninja run_test_prebuild
-    - name: cmake
-      run: cmake -GNinja . -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_MSVC_RUNTIME_LIBRARY="MultiThreadedDebugDLL" -DENABLE_TESTS=On -DCMAKE_CXX_FLAGS="/EHsc /fsanitize=address /sdl /Wall" -DCMAKE_C_COMPILER=cl -DCMAKE_CXX_COMPILER=cl
-    - name: ninja
-      run: ninja
-    - name: ninja test
-      run: ninja test
+      - uses: actions/checkout@v4
+      - uses: ilammy/msvc-dev-cmd@v1.13.0
+      - name: Generate CMake files for test
+        run: cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DGENERATE_TESTS=On . && cmake --build .
+      - name: CMake configure
+        run: cmake -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_MSVC_RUNTIME_LIBRARY="MultiThreadedDebugDLL" -DENABLE_TESTS=On -DCMAKE_CXX_FLAGS="/EHsc /fsanitize=address /sdl /Wall" -DCMAKE_C_COMPILER=cl -DCMAKE_CXX_COMPILER=cl .
+      - name: CMake build
+        run: cmake --build .
 
   #macos:
 
@@ -70,4 +65,3 @@ jobs:
   #    run: ninja
   #  - name: ninja test
   #    run: ninja test
-

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -15,7 +15,10 @@ jobs:
       - name: Install ninja-build tool
         uses: seanmiddleditch/gha-setup-ninja@v5
       - name: Generate CMake files for test
-        run: cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DGENERATE_TESTS=On . && cmake --build .
+        run: |
+          cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DGENERATE_TESTS=On .
+          cmake --build .
+          ./gentest
       - name: CMake configure
         run: cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DENABLE_TESTS=On -DCMAKE_CXX_FLAGS="-fsanitize=address,undefined -Wall -Wextra -Wpedantic -Wmisleading-indentation -Wunused -Wuninitialized -Wshadow -Wconversion -Werror" .
       - name: CMake build
@@ -30,7 +33,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ilammy/msvc-dev-cmd@v1.13.0
       - name: Generate CMake files for test
-        run: cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DGENERATE_TESTS=On . && cmake --build .
+        run: |
+          cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DGENERATE_TESTS=On .
+          cmake --build .
+          ./gentest
       - name: CMake configure
         run: cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DENABLE_TESTS=On -DCMAKE_CXX_FLAGS="/EHsc /sdl /Wall" -DCMAKE_C_COMPILER=cl -DCMAKE_CXX_COMPILER=cl .
       - name: CMake build
@@ -45,7 +51,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ilammy/msvc-dev-cmd@v1.13.0
       - name: Generate CMake files for test
-        run: cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DGENERATE_TESTS=On . && cmake --build .
+        run: |
+          cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DGENERATE_TESTS=On .
+          cmake --build .
+          ./gentest
       - name: CMake configure
         run: cmake -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_MSVC_RUNTIME_LIBRARY="MultiThreadedDebugDLL" -DENABLE_TESTS=On -DCMAKE_CXX_FLAGS="/EHsc /fsanitize=address /sdl /Wall" -DCMAKE_C_COMPILER=cl -DCMAKE_CXX_COMPILER=cl .
       - name: CMake build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,20 +103,22 @@ if(WIN32)
 	add_definitions(-D_CRT_SECURE_NO_WARNINGS -D_CRT_NONSTDC_NO_DEPRECATE)
 endif()
 
-option(TESTS_PREBUILD "prebuild cmake files for test" OFF)
+option(GENERATE_TESTS "generate cmake files for test" OFF)
 
-if(${TESTS_PREBUILD})
+if(${GENERATE_TESTS})
 include_directories(include)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_EXTENSION OFF)
 if(CMAKE_SYSTEM_NAME STREQUAL "Windows" OR CMAKE_SYSTEM_NAME STREQUAL "Cygwin" OR CMAKE_SYSTEM_NAME STREQUAL "Msys")
 link_libraries(ntdll)
 endif()
-add_executable(test_prebuild gentests.cc)
-add_custom_target(run_test_prebuild
-    COMMAND test_prebuild
-    DEPENDS test_prebuild
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+add_executable(gentests ${CMAKE_CURRENT_SOURCE_DIR}/src/gentests.cc)
+add_custom_command(
+	OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/benchmark/CMakeLists.txt
+		   ${CMAKE_CURRENT_SOURCE_DIR}/examples/CMakeLists.txt
+		   ${CMAKE_CURRENT_SOURCE_DIR}/tests/CMakeLists.txt
+	COMMAND gentests
+	WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 endif()
 

--- a/src/gentests.cc
+++ b/src/gentests.cc
@@ -5,10 +5,14 @@
 #include <fast_io_device.h>
 using namespace fast_io::io;
 
-bool if_exist(fast_io::native_io_observer nio, std::u8string_view filename) {
-	try {
+bool if_exist(fast_io::native_io_observer nio, std::u8string_view filename)
+{
+	try
+	{
 		[[maybe_unused]] fast_io::ibuf_file _{at(nio), filename};
-	} catch (...) {
+	}
+	catch (...)
+	{
 		return false;
 	}
 	return true;
@@ -16,33 +20,45 @@ bool if_exist(fast_io::native_io_observer nio, std::u8string_view filename) {
 
 bool gen_cmake_file(fast_io::native_io_observer nio, std::u8string_view prefix);
 
-void cmake_gen_rec_dir_def(fast_io::u8obuf_file& cmake_file, fast_io::native_io_observer nio, std::u8string_view filename, std::u8string_view prefix) {
+void cmake_gen_rec_dir_def(fast_io::u8obuf_file &cmake_file, fast_io::native_io_observer nio, std::u8string_view filename, std::u8string_view prefix)
+{
 	std::u8string new_prefix{fast_io::u8concat_std(prefix, filename, u8".")};
 	fast_io::dir_file dir{at(nio), filename};
-	if (!gen_cmake_file(dir, new_prefix)) return;
+	if (!gen_cmake_file(dir, new_prefix))
+	{
+		return;
+	}
 	print(cmake_file, u8"include(${CMAKE_CURRENT_LIST_DIR}/", filename, u8"/CMakeLists.txt)\n");
 }
 
-void cmake_gen_file_def(fast_io::u8obuf_file& cmake_file, std::u8string_view targetname, auto&& filename) {
+void cmake_gen_file_def(fast_io::u8obuf_file &cmake_file, std::u8string_view targetname, auto &&filename)
+{
 	print(cmake_file, u8"add_executable(", targetname, u8" ${CMAKE_CURRENT_LIST_DIR}/", filename, u8")\n");
 	print(cmake_file, u8"add_test(", targetname, u8" ", targetname, u8")\n");
 }
 
-bool gen_cmake_file(fast_io::native_io_observer nio, std::u8string_view prefix) {
+bool gen_cmake_file(fast_io::native_io_observer nio, std::u8string_view prefix)
+{
 	bool generated{};
 	fast_io::u8obuf_file cmake_file;
-	try {
+	try
+	{
 		cmake_file = std::move(fast_io::u8obuf_file{at(nio), R"(CMakeLists.txt)", fast_io::open_mode::creat | fast_io::open_mode::excl});
-	} catch (...) {
+	}
+	catch (...)
+	{
 		perr(fast_io::u8err(), u8"CMakeLists.txt alreay exists in ", prefix, u8". \n");
 		return true;
 	}
 	std::vector<std::u8string> ignore_files;
-	try {
+	try
+	{
 		fast_io::native_file_loader ignore_file{at(nio), R"(.test_ignore)"};
-		fast_io::u8ibuffer_view u8fv{reinterpret_cast<char8_t*>(ignore_file.begin()), reinterpret_cast<char8_t*>(ignore_file.end())};
-		for (std::u8string line; scan<true>(u8fv, fast_io::mnp::line_get<char8_t>(line));) {
-			if (line.empty()) {
+		fast_io::u8ibuffer_view u8fv{reinterpret_cast<char8_t *>(ignore_file.begin()), reinterpret_cast<char8_t *>(ignore_file.end())};
+		for (std::u8string line; scan<true>(u8fv, fast_io::mnp::line_get<char8_t>(line));)
+		{
+			if (line.empty())
+			{
 				u8fv.curr_ptr += 1;
 				continue;
 			}
@@ -54,15 +70,24 @@ bool gen_cmake_file(fast_io::native_io_observer nio, std::u8string_view prefix) 
 			auto rit = std::ranges::find_if_not(line.rbegin(), line.rend(), fast_io::char_category::is_c_space<char8_t>);
 			line = line.substr(0, line.rend() - rit);
 #endif
-			if (line.empty()) continue;
+			if (line.empty())
+			{
+				continue;
+			}
 			ignore_files.emplace_back(std::move(line));
 		}
-	} catch (...) {}
-	for (auto const& entry : current(at(nio))) {
+	}
+	catch (...)
+	{}
+	for (auto const &entry : current(at(nio)))
+	{
 		auto filename{std::u8string_view{u8filename(entry)}};
 		if (is_dot(entry) || std::ranges::find(ignore_files, filename) != ignore_files.end())
+		{
 			continue;
-		switch (type(entry)) {
+		}
+		switch (type(entry))
+		{
 			using enum fast_io::file_type;
 		case directory:
 			cmake_gen_rec_dir_def(cmake_file, nio, filename, prefix);
@@ -70,7 +95,8 @@ bool gen_cmake_file(fast_io::native_io_observer nio, std::u8string_view prefix) 
 			break;
 		default:
 			std::u8string_view ext{u8extension(entry)};
-			if (ext == u8".cpp" || ext == u8".cc") {
+			if (ext == u8".cpp" || ext == u8".cc")
+			{
 				cmake_gen_file_def(cmake_file, fast_io::u8concat_std(prefix, u8stem(entry)), filename);
 				generated = true;
 			}
@@ -80,7 +106,8 @@ bool gen_cmake_file(fast_io::native_io_observer nio, std::u8string_view prefix) 
 	return generated;
 }
 
-int main() {
+int main()
+{
 	fast_io::dir_file tests_dir{R"(./tests)"};
 	fast_io::dir_file examples_dir{R"(./examples)"};
 	fast_io::dir_file benchmark_dir{R"(./benchmark)"};


### PR DESCRIPTION
The propose of this PR is as follows

- Format action script
- Disable tests for windows-debug

It's no sense that run benchmark on debug mode, wastes too much time (~80min).