### PR TITLE
fix the example in process that does not return 1 when usage is print…

### DIFF
--- a/examples/0035.process/process.cc
+++ b/examples/0035.process/process.cc
@@ -1,14 +1,15 @@
 #include <fast_io.h>
 
-int main(int argc, char** argv)
+int main(int argc, char **argv)
 {
 	if (argc != 2)
 	{
-		if (argc == 0)  [[unlikely]]
+		if (argc == 0) [[unlikely]]
 		{
-			return -1;
+			return 1;
 		}
 		::fast_io::io::perr("Usage: ", ::fast_io::mnp::os_c_str(*argv), " <exe>\n");
+		return 1;
 	}
 	::fast_io::native_process p{::fast_io::mnp::os_c_str(argv[1]), {}, {}, {}};
 	auto ec{wait(p)};


### PR DESCRIPTION
…ed out