### PR TITLE
fix win32 box

### DIFF
--- a/examples/0035.process/.test_prop.toml
+++ b/examples/0035.process/.test_prop.toml
@@ -1,2 +1,5 @@
 ["process.cc"]
 interactive = true
+
+["pipe.cc"]
+interactive = true

--- a/examples/0035.process/pipe.cc
+++ b/examples/0035.process/pipe.cc
@@ -1,0 +1,59 @@
+#include <fast_io.h>
+#include <fast_io_device.h>
+
+int main(int argc, char **argv)
+{
+	if (argc != 2)
+	{
+		if (argc == 0) [[unlikely]]
+		{
+			return 1;
+		}
+		::fast_io::io::perr("Usage: ", ::fast_io::mnp::os_c_str(*argv), " <exe>\n");
+		return 1;
+	}
+	try
+	{
+		::fast_io::io::perr(::fast_io::out(), "Note that there is no input:\n");
+
+		::fast_io::iobuf_pipe pipe_out;
+		::fast_io::iobuf_pipe pipe_err;
+		::fast_io::native_process p{
+			::fast_io::mnp::os_c_str(argv[1]),
+			{},
+			{},
+			{::fast_io::posix_dev_null(), pipe_out.handle, pipe_err.handle}};
+
+		pipe_out.handle.out().close();
+		pipe_err.handle.out().close();
+
+
+		::fast_io::io::perr(::fast_io::out(), "child stdout:\n");
+
+		for (;;)
+		{
+			auto res{::fast_io::operations::transmit_until_eof(::fast_io::out(), pipe_out)};
+			if (!res.transmitted)
+			{
+				break;
+			}
+		}
+
+		::fast_io::io::perr(::fast_io::out(), "child stderr:\n");
+
+		for (;;)
+		{
+			auto res{::fast_io::operations::transmit_until_eof(::fast_io::out(), pipe_err)};
+			if (!res.transmitted)
+			{
+				break;
+			}
+		}
+
+	}
+	catch (fast_io::error e)
+	{
+		perrln(e);
+		return 1;
+	}
+}

--- a/include/fast_io_core_impl/operations/common.h
+++ b/include/fast_io_core_impl/operations/common.h
@@ -43,10 +43,11 @@ find_scatter_total_size_overflow_impl(basic_io_scatter_t<T> const *base, U len) 
 	auto i{base}, e{base + len};
 	for (; i != e; ++i)
 	{
-		if (static_cast<U>(static_cast<::std::size_t>(mx - i->len)) < total)
+		if (static_cast<U>(static_cast<::std::size_t>(mx - i->len)) < total) [[unlikely]]
 		{
 			break;
 		}
+		total += i->len;
 	}
 	return {total, static_cast<::std::size_t>(i - base)};
 }

--- a/include/fast_io_hosted/platforms/nt.h
+++ b/include/fast_io_hosted/platforms/nt.h
@@ -1523,7 +1523,7 @@ public:
 template <nt_family family, ::std::integral ch_type>
 inline constexpr win32_io_redirection redirect(basic_nt_family_pipe<family, ch_type> &hd)
 {
-	return {.win32_pipe_in_handle = __builtin_addressof(hd.in().handle), .win32_pipe_out_handle = __builtin_addressof(hd.out().handle)};
+	return {.win32_pipe_in_handle = hd.in().handle, .win32_pipe_out_handle = hd.out().handle};
 }
 
 template <nt_family family, ::std::integral ch_type>

--- a/include/fast_io_hosted/platforms/posix.h
+++ b/include/fast_io_hosted/platforms/posix.h
@@ -373,13 +373,24 @@ inline constexpr posix_dev_null_t posix_dev_null() noexcept
 {
 	return {};
 }
+#if (defined(_WIN32) && !defined(__WINE__)) || defined(__CYGWIN__)
+
+inline constexpr win32_io_redirection redirect(posix_dev_null_t) noexcept
+{
+	return {.is_dev_null = true};
+}
+
+#else
 
 inline constexpr posix_io_redirection redirect(posix_dev_null_t) noexcept
 {
 	return {.dev_null = true};
 }
 
+#endif
+
 #if (defined(_WIN32) && !defined(__WINE__)) || defined(__CYGWIN__)
+
 namespace details
 {
 

--- a/include/fast_io_hosted/platforms/win32.h
+++ b/include/fast_io_hosted/platforms/win32.h
@@ -1745,7 +1745,7 @@ public:
 template <win32_family family, ::std::integral ch_type>
 inline constexpr win32_io_redirection redirect(basic_win32_family_pipe<family, ch_type> &hd)
 {
-	return {.win32_pipe_in_handle = __builtin_addressof(hd.in().handle), .win32_pipe_out_handle = __builtin_addressof(hd.out().handle)};
+	return {.win32_pipe_in_handle = hd.in().handle, .win32_pipe_out_handle = hd.out().handle};
 }
 
 template <win32_family family, ::std::integral ch_type>

--- a/include/fast_io_hosted/platforms/win32_box.h
+++ b/include/fast_io_hosted/platforms/win32_box.h
@@ -58,14 +58,14 @@ inline void win32_box_converter_path_impl(char_type const *first, char_type cons
 	win32_box_write_impl<family>(converter.buffer_data, converter.buffer_data_end);
 }
 
-template <::fast_io::win32_family family, ::std::integral ch_type>
+template <::fast_io::win32_family family, ::std::integral ch_type, ::std::integral write_ch_type>
 #if __has_cpp_attribute(__gnu__::__cold__)
 [[__gnu__::__cold__]]
 #endif
 inline void win32_box_converter_scatter_path_impl(basic_win32_family_box_t<family, ch_type> bx,
-												  basic_io_scatter_t<ch_type> const *scatters, ::std::size_t n)
+												  basic_io_scatter_t<write_ch_type> const *scatters, ::std::size_t n)
 {
-	using chtypenocref = ::std::remove_cvref_t<ch_type>;
+	using chtypenocref = ::std::remove_cvref_t<write_ch_type>;
 	if constexpr (family == ::fast_io::win32_family::ansi_9x &&
 				  ((!::std::same_as<chtypenocref, char8_t>) && sizeof(chtypenocref) == sizeof(char8_t) &&
 				   ::fast_io::execution_charset_encoding_scheme<chtypenocref>() == ::fast_io::encoding_scheme::utf))
@@ -75,8 +75,8 @@ inline void win32_box_converter_scatter_path_impl(basic_win32_family_box_t<famil
 			[[__gnu__::__may_alias__]]
 #endif
 			= basic_io_scatter_t<char8_t> const *;
-		::fast_io::details::win32_box_converter_scatter_path_impl(bx, reinterpret_cast<scatter_may_alias_ptr>(scatters),
-																  n);
+		::fast_io::details::win32_box_converter_scatter_path_impl(
+			bx, reinterpret_cast<scatter_may_alias_ptr>(scatters), n);
 	}
 	else if constexpr (family == ::fast_io::win32_family::wide_nt &&
 					   ((!::std::same_as<chtypenocref, char16_t>) && sizeof(chtypenocref) == sizeof(char16_t) &&

--- a/include/fast_io_hosted/platforms/win32_box.h
+++ b/include/fast_io_hosted/platforms/win32_box.h
@@ -75,8 +75,7 @@ inline void win32_box_converter_scatter_path_impl(basic_win32_family_box_t<famil
 			[[__gnu__::__may_alias__]]
 #endif
 			= basic_io_scatter_t<char8_t> const *;
-		::fast_io::details::win32_box_converter_scatter_path_impl(
-			bx, reinterpret_cast<scatter_may_alias_ptr>(scatters), n);
+		::fast_io::details::win32_box_converter_scatter_path_impl(bx, reinterpret_cast<scatter_may_alias_ptr>(scatters), n);
 	}
 	else if constexpr (family == ::fast_io::win32_family::wide_nt &&
 					   ((!::std::same_as<chtypenocref, char16_t>) && sizeof(chtypenocref) == sizeof(char16_t) &&
@@ -88,8 +87,7 @@ inline void win32_box_converter_scatter_path_impl(basic_win32_family_box_t<famil
 			[[__gnu__::__may_alias__]]
 #endif
 			= basic_io_scatter_t<char16_t> const *;
-		::fast_io::details::win32_box_converter_scatter_path_impl(bx, reinterpret_cast<scatter_may_alias_ptr>(scatters),
-																  n);
+		::fast_io::details::win32_box_converter_scatter_path_impl(bx, reinterpret_cast<scatter_may_alias_ptr>(scatters), n);
 	}
 	else
 	{

--- a/include/fast_io_hosted/platforms/win32_io_redirection.h
+++ b/include/fast_io_hosted/platforms/win32_io_redirection.h
@@ -3,8 +3,8 @@ namespace fast_io
 {
 struct win32_io_redirection
 {
-	void **win32_pipe_in_handle{};
-	void **win32_pipe_out_handle{};
+	void *win32_pipe_in_handle{};
+	void *win32_pipe_out_handle{};
 	void *win32_handle{};
 	bool is_dev_null{};
 };

--- a/include/fast_io_hosted/process/nt.h
+++ b/include/fast_io_hosted/process/nt.h
@@ -382,19 +382,14 @@ inline nt_user_process_information nt_6x_process_create_impl(void *__restrict fh
 	// Duplicate Process Std Handles
 	auto const current_peb{::fast_io::win32::nt::nt_get_current_peb()};
 
-	void **in_need_close{};
-	void **out_need_close{};
-	void **err_need_close{};
-
 	if (!processio.in.is_dev_null)
 	{
-		if (processio.in.win32_pipe_in_handle && *processio.in.win32_pipe_in_handle)
+		if (processio.in.win32_pipe_in_handle)
 		{
-			rtl_temp->StandardInput = *processio.in.win32_pipe_in_handle;
-			in_need_close = processio.in.win32_pipe_in_handle;
+			rtl_temp->StandardInput = processio.in.win32_pipe_in_handle;
 
 			::fast_io::win32::nt::object_handle_attribute_information ohaoi{.Inherit = 1};
-			check_nt_status(::fast_io::win32::nt::nt_set_information_object<zw>(*processio.in.win32_pipe_out_handle,
+			check_nt_status(::fast_io::win32::nt::nt_set_information_object<zw>(processio.in.win32_pipe_out_handle,
 																				::fast_io::win32::nt::object_information_class::ObjectHandleFlagInformation,
 																				__builtin_addressof(ohaoi), static_cast<::std::uint_least32_t>(sizeof(ohaoi))));
 		}
@@ -414,13 +409,12 @@ inline nt_user_process_information nt_6x_process_create_impl(void *__restrict fh
 
 	if (!processio.out.is_dev_null)
 	{
-		if (processio.out.win32_pipe_out_handle && *processio.out.win32_pipe_out_handle)
+		if (processio.out.win32_pipe_out_handle)
 		{
-			rtl_temp->StandardOutput = *processio.out.win32_pipe_out_handle;
-			out_need_close = processio.out.win32_pipe_out_handle;
+			rtl_temp->StandardOutput = processio.out.win32_pipe_out_handle;
 
 			::fast_io::win32::nt::object_handle_attribute_information ohaoi{.Inherit = 1};
-			check_nt_status(::fast_io::win32::nt::nt_set_information_object<zw>(*processio.out.win32_pipe_in_handle,
+			check_nt_status(::fast_io::win32::nt::nt_set_information_object<zw>(processio.out.win32_pipe_in_handle,
 																				::fast_io::win32::nt::object_information_class::ObjectHandleFlagInformation,
 																				__builtin_addressof(ohaoi), static_cast<::std::uint_least32_t>(sizeof(ohaoi))));
 		}
@@ -440,13 +434,12 @@ inline nt_user_process_information nt_6x_process_create_impl(void *__restrict fh
 
 	if (!processio.err.is_dev_null)
 	{
-		if (processio.err.win32_pipe_out_handle && *processio.err.win32_pipe_out_handle)
+		if (processio.err.win32_pipe_out_handle)
 		{
-			rtl_temp->StandardError = *processio.err.win32_pipe_out_handle;
-			err_need_close = processio.err.win32_pipe_out_handle;
+			rtl_temp->StandardError = processio.err.win32_pipe_out_handle;
 
 			::fast_io::win32::nt::object_handle_attribute_information ohaoi{.Inherit = 1};
-			check_nt_status(::fast_io::win32::nt::nt_set_information_object<zw>(*processio.err.win32_pipe_in_handle,
+			check_nt_status(::fast_io::win32::nt::nt_set_information_object<zw>(processio.err.win32_pipe_in_handle,
 																				::fast_io::win32::nt::object_information_class::ObjectHandleFlagInformation,
 																				__builtin_addressof(ohaoi), static_cast<::std::uint_least32_t>(sizeof(ohaoi))));
 		}
@@ -515,24 +508,6 @@ inline nt_user_process_information nt_6x_process_create_impl(void *__restrict fh
 	check_nt_status(::fast_io::win32::nt::nt_create_user_process<zw>(
 		&hProcess, &hThread, 0x2000000, 0x2000000, nullptr, nullptr,
 		512, 0x00, rtl_temp, &CreateInfo, &AttributeList));
-
-	if (in_need_close && *in_need_close)
-	{
-		check_nt_status(::fast_io::win32::nt::nt_close<zw>(*in_need_close));
-		*in_need_close = nullptr;
-	}
-
-	if (out_need_close && *out_need_close)
-	{
-		check_nt_status(::fast_io::win32::nt::nt_close<zw>(*out_need_close));
-		*out_need_close = nullptr;
-	}
-
-	if (err_need_close && *err_need_close)
-	{
-		check_nt_status(::fast_io::win32::nt::nt_close<zw>(*err_need_close));
-		*err_need_close = nullptr;
-	}
 
 	return {hProcess, hThread};
 }

--- a/include/fast_io_hosted/process/posix.h
+++ b/include/fast_io_hosted/process/posix.h
@@ -8,7 +8,13 @@ namespace fast_io
 
 namespace posix
 {
+#ifdef __DARWIN_C_LEVEL
+extern int libc_faccessat(int dirfd, char const *pathname, int mode, int flags) noexcept __asm__("_faccessat");
+extern int libc_fexecve(int fd, char *const *argv, char *const *envp) noexcept __asm__("_fexecve");
+#else
+extern int libc_faccessat(int dirfd, char const *pathname, int mode, int flags) noexcept __asm__("faccessat");
 extern int libc_fexecve(int fd, char *const *argv, char *const *envp) noexcept __asm__("fexecve");
+#endif
 }
 
 struct posix_wait_status
@@ -229,6 +235,8 @@ inline void parent_process_deal_with_process_io(posix_io_redirection const &red)
 inline pid_t posix_fork_execveat_common_impl(int dirfd, char const *cstr, char const *const *args,
 											 char const *const *envp, posix_process_io const &pio)
 {
+	system_call_throw_error(::fast_io::posix::libc_faccessat(dirfd, cstr, 1, AT_SYMLINK_NOFOLLOW));
+
 	pid_t pid{posix_fork()};
 	if (pid)
 	{

--- a/include/fast_io_hosted/process/posix.h
+++ b/include/fast_io_hosted/process/posix.h
@@ -235,7 +235,7 @@ inline void parent_process_deal_with_process_io(posix_io_redirection const &red)
 inline pid_t posix_fork_execveat_common_impl(int dirfd, char const *cstr, char const *const *args,
 											 char const *const *envp, posix_process_io const &pio)
 {
-	system_call_throw_error(::fast_io::posix::libc_faccessat(dirfd, cstr, 1, AT_SYMLINK_NOFOLLOW));
+	system_call_throw_error(::fast_io::posix::libc_faccessat(dirfd, cstr, X_OK, AT_SYMLINK_NOFOLLOW));
 
 	pid_t pid{posix_fork()};
 	if (pid)

--- a/include/fast_io_hosted/process/win32.h
+++ b/include/fast_io_hosted/process/win32.h
@@ -178,18 +178,13 @@ inline win32_user_process_information win32_process_create_impl(void *__restrict
 		// create process
 		::fast_io::win32::startupinfow si{sizeof(si)};
 
-		void **in_need_close{};
-		void **out_need_close{};
-		void **err_need_close{};
-
 		if (!processio.in.is_dev_null)
 		{
-			if (processio.in.win32_pipe_in_handle && *processio.in.win32_pipe_in_handle)
+			if (processio.in.win32_pipe_in_handle)
 			{
-				si.hStdInput = *processio.in.win32_pipe_in_handle;
-				in_need_close = processio.in.win32_pipe_in_handle;
+				si.hStdInput = processio.in.win32_pipe_in_handle;
 
-				if (!::fast_io::win32::SetHandleInformation(*processio.in.win32_pipe_out_handle, 0x00000001 /*HANDLE_FLAG_INHERIT*/, 0)) [[unlikely]]
+				if (!::fast_io::win32::SetHandleInformation(processio.in.win32_pipe_out_handle, 0x00000001 /*HANDLE_FLAG_INHERIT*/, 0)) [[unlikely]]
 				{
 					throw_win32_error();
 				}
@@ -210,12 +205,11 @@ inline win32_user_process_information win32_process_create_impl(void *__restrict
 
 		if (!processio.out.is_dev_null)
 		{
-			if (processio.out.win32_pipe_out_handle && *processio.out.win32_pipe_out_handle)
+			if (processio.out.win32_pipe_out_handle)
 			{
-				si.hStdOutput = *processio.out.win32_pipe_out_handle;
-				out_need_close = processio.out.win32_pipe_out_handle;
+				si.hStdOutput = processio.out.win32_pipe_out_handle;
 
-				if (!::fast_io::win32::SetHandleInformation(*processio.out.win32_pipe_in_handle, 0x00000001 /*HANDLE_FLAG_INHERIT*/, 0)) [[unlikely]]
+				if (!::fast_io::win32::SetHandleInformation(processio.out.win32_pipe_in_handle, 0x00000001 /*HANDLE_FLAG_INHERIT*/, 0)) [[unlikely]]
 				{
 					throw_win32_error();
 				}
@@ -236,12 +230,11 @@ inline win32_user_process_information win32_process_create_impl(void *__restrict
 
 		if (!processio.err.is_dev_null)
 		{
-			if (processio.err.win32_pipe_out_handle && *processio.err.win32_pipe_out_handle)
+			if (processio.err.win32_pipe_out_handle)
 			{
-				si.hStdError = *processio.err.win32_pipe_out_handle;
-				err_need_close = processio.err.win32_pipe_out_handle;
+				si.hStdError = processio.err.win32_pipe_out_handle;
 
-				if (!::fast_io::win32::SetHandleInformation(*processio.err.win32_pipe_in_handle, 0x00000001 /*HANDLE_FLAG_INHERIT*/, 0)) [[unlikely]]
+				if (!::fast_io::win32::SetHandleInformation(processio.err.win32_pipe_in_handle, 0x00000001 /*HANDLE_FLAG_INHERIT*/, 0)) [[unlikely]]
 				{
 					throw_win32_error();
 				}
@@ -266,33 +259,6 @@ inline win32_user_process_information win32_process_create_impl(void *__restrict
 		if (!::fast_io::win32::CreateProcessW(address_begin, const_cast<char16_t *>(args), nullptr, nullptr, 1, 0, (void *)envs, nullptr, __builtin_addressof(si), __builtin_addressof(pi)))
 		{
 			throw_win32_error();
-		}
-
-		if (in_need_close && *in_need_close)
-		{
-			if (!::fast_io::win32::CloseHandle(*in_need_close))
-			{
-				throw_win32_error();
-			}
-			*in_need_close = nullptr;
-		}
-
-		if (out_need_close && *out_need_close)
-		{
-			if (!::fast_io::win32::CloseHandle(*out_need_close))
-			{
-				throw_win32_error();
-			}
-			*out_need_close = nullptr;
-		}
-
-		if (err_need_close && *err_need_close)
-		{
-			if (!::fast_io::win32::CloseHandle(*err_need_close))
-			{
-				throw_win32_error();
-			}
-			*err_need_close = nullptr;
 		}
 
 		return {pi.hProcess, pi.hThread};
@@ -375,18 +341,13 @@ inline win32_user_process_information win32_process_create_impl(void *__restrict
 		// create process
 		::fast_io::win32::startupinfoa si{sizeof(si)};
 
-		void **in_need_close{};
-		void **out_need_close{};
-		void **err_need_close{};
-
 		if (!processio.in.is_dev_null)
 		{
-			if (processio.in.win32_pipe_in_handle && *processio.in.win32_pipe_in_handle)
+			if (processio.in.win32_pipe_in_handle)
 			{
-				si.hStdInput = *processio.in.win32_pipe_in_handle;
-				in_need_close = processio.in.win32_pipe_in_handle;
+				si.hStdInput = processio.in.win32_pipe_in_handle;
 
-				if (!::fast_io::win32::SetHandleInformation(*processio.in.win32_pipe_out_handle, 0x00000001 /*HANDLE_FLAG_INHERIT*/, 0)) [[unlikely]]
+				if (!::fast_io::win32::SetHandleInformation(processio.in.win32_pipe_out_handle, 0x00000001 /*HANDLE_FLAG_INHERIT*/, 0)) [[unlikely]]
 				{
 					throw_win32_error();
 				}
@@ -407,12 +368,11 @@ inline win32_user_process_information win32_process_create_impl(void *__restrict
 
 		if (!processio.out.is_dev_null)
 		{
-			if (processio.out.win32_pipe_out_handle && *processio.out.win32_pipe_out_handle)
+			if (processio.out.win32_pipe_out_handle)
 			{
-				si.hStdOutput = *processio.out.win32_pipe_out_handle;
-				out_need_close = processio.out.win32_pipe_out_handle;
+				si.hStdOutput = processio.out.win32_pipe_out_handle;
 
-				if (!::fast_io::win32::SetHandleInformation(*processio.out.win32_pipe_in_handle, 0x00000001 /*HANDLE_FLAG_INHERIT*/, 0)) [[unlikely]]
+				if (!::fast_io::win32::SetHandleInformation(processio.out.win32_pipe_in_handle, 0x00000001 /*HANDLE_FLAG_INHERIT*/, 0)) [[unlikely]]
 				{
 					throw_win32_error();
 				}
@@ -433,12 +393,11 @@ inline win32_user_process_information win32_process_create_impl(void *__restrict
 
 		if (!processio.err.is_dev_null)
 		{
-			if (processio.err.win32_pipe_out_handle && *processio.err.win32_pipe_out_handle)
+			if (processio.err.win32_pipe_out_handle)
 			{
-				si.hStdError = *processio.err.win32_pipe_out_handle;
-				err_need_close = processio.err.win32_pipe_out_handle;
+				si.hStdError = processio.err.win32_pipe_out_handle;
 
-				if (!::fast_io::win32::SetHandleInformation(*processio.err.win32_pipe_in_handle, 0x00000001 /*HANDLE_FLAG_INHERIT*/, 0)) [[unlikely]]
+				if (!::fast_io::win32::SetHandleInformation(processio.err.win32_pipe_in_handle, 0x00000001 /*HANDLE_FLAG_INHERIT*/, 0)) [[unlikely]]
 				{
 					throw_win32_error();
 				}
@@ -463,33 +422,6 @@ inline win32_user_process_information win32_process_create_impl(void *__restrict
 		if (!::fast_io::win32::CreateProcessA(address_begin, const_cast<char *>(args), nullptr, nullptr, 1, 0, (void *)envs, nullptr, __builtin_addressof(si), __builtin_addressof(pi)))
 		{
 			throw_win32_error();
-		}
-
-		if (in_need_close && *in_need_close)
-		{
-			if (!::fast_io::win32::CloseHandle(*in_need_close))
-			{
-				throw_win32_error();
-			}
-			*in_need_close = nullptr;
-		}
-
-		if (out_need_close && *out_need_close)
-		{
-			if (!::fast_io::win32::CloseHandle(*out_need_close))
-			{
-				throw_win32_error();
-			}
-			*out_need_close = nullptr;
-		}
-
-		if (err_need_close && *err_need_close)
-		{
-			if (!::fast_io::win32::CloseHandle(*err_need_close))
-			{
-				throw_win32_error();
-			}
-			*err_need_close = nullptr;
 		}
 
 		return {pi.hProcess, pi.hThread};


### PR DESCRIPTION
1. find_scatter_total_size_overflow_impl: Implementation error
2. on winnt:
::fast_io::io::perr(::fast_io::wwin32_box_t{}, L"hello");
```cpp
::fast_io::io::perr(::fast_io::wwin32_box_t{}, L"hello");
```

```bash
1>D:\github\fio_workplace\fio\fast_io\include\fast_io_hosted\platforms\win32_box.h(91,23): error C2672: “fast_io::details::win32_box_converter_scatter_path_impl”: 未找到匹配的重载函数
1>(编译源文件“fio.cpp”)
1>    D:\github\fio_workplace\fio\fast_io\include\fast_io_hosted\platforms\win32_box.h(65,13):
1>    可能是“void fast_io::details::win32_box_converter_scatter_path_impl(fast_io::basic_win32_family_box_t<family,ch_type>,const fast_io::basic_io_scatter_t<T> *,size_t)”
1>        D:\github\fio_workplace\fio\fast_io\include\fast_io_hosted\platforms\win32_box.h(91,23):
1>        “void fast_io::details::win32_box_converter_scatter_path_impl(fast_io::basic_win32_family_box_t<family,ch_type>,const fast_io::basic_io_scatter_t<T> *,size_t)”: 模板 参数“ch_type”不明确
1>            D:\github\fio_workplace\fio\fast_io\include\fast_io_hosted\platforms\win32_box.h(91,23):
1>            可能是“char16_t”
1>            D:\github\fio_workplace\fio\fast_io\include\fast_io_hosted\platforms\win32_box.h(91,23):
1>            或    “wchar_t”
1>        D:\github\fio_workplace\fio\fast_io\include\fast_io_hosted\platforms\win32_box.h(91,23):
1>        “void fast_io::details::win32_box_converter_scatter_path_impl(fast_io::basic_win32_family_box_t<family,ch_type>,const fast_io::basic_io_scatter_t<T> *,size_t)”: 无法从“fast_io::details::win32_box_converter_scatter_path_impl::scatter_may_alias_ptr”推导出“const fast_io::basic_io_scatter_t<T> *”的 模板 参数
1>    D:\github\fio_workplace\fio\fast_io\include\fast_io_hosted\platforms\win32_box.h(91,23):
1>    模板实例化上下文(最早的实例化上下文)为
1>        D:\github\fio_workplace\fio\fio.cpp(7,17):
1>        查看对正在编译的函数 模板 实例化“void fast_io::io::perr<fast_io::wwin32_box_t,const wchar_t(&)[6]>(T &&,const wchar_t (&)[6])”的引用
1>        with
1>        [
1>            T=fast_io::wwin32_box_t
1>        ]
1>        D:\github\fio_workplace\fio\fast_io\include\fast_io_legacy_impl\io.h(110,33):
1>        查看对正在编译的函数 模板 实例化“void fast_io::operations::decay::print_freestanding_decay_cold<false,fast_io::basic_win32_family_box_t<fast_io::win32_family::wide_nt,wchar_t>,fast_io::io_print_forward::no_cvref_t>(outputstmtype,fast_io::io_print_forward::no_cvref_t)”的引用
1>        with
1>        [
1>            outputstmtype=fast_io::basic_win32_family_box_t<fast_io::win32_family::wide_nt,wchar_t>
1>        ]
1>        D:\github\fio_workplace\fio\fast_io\include\fast_io_core_impl\operations\print_freestanding.h(1334,40):
1>        查看对正在编译的函数 模板 实例化“void fast_io::operations::decay::print_freestanding_decay<false,outputstmtype,fast_io::io_print_forward::no_cvref_t>(outputstmtype,fast_io::io_print_forward::no_cvref_t)”的引用
1>        with
1>        [
1>            outputstmtype=fast_io::basic_win32_family_box_t<fast_io::win32_family::wide_nt,wchar_t>
1>        ]
1>        D:\github\fio_workplace\fio\fast_io\include\fast_io_core_impl\operations\print_freestanding.h(1321,37):
1>        查看对正在编译的函数 模板 实例化“void fast_io::details::decay::print_controls_impl<false,outputstmtype,0,fast_io::io_print_forward::no_cvref_t,>(outputstmtype,T)”的引用
1>        with
1>        [
1>            outputstmtype=fast_io::basic_win32_family_box_t<fast_io::win32_family::wide_nt,wchar_t>,
1>            T=fast_io::io_print_forward::no_cvref_t
1>        ]
1>        D:\github\fio_workplace\fio\fast_io\include\fast_io_core_impl\operations\print_freestanding.h(1021,3):
1>        查看对正在编译的函数 模板 实例化“void fast_io::details::decay::print_control_single<false,outputstmtype,T>(output,T)”的引用
1>        with
1>        [
1>            outputstmtype=fast_io::basic_win32_family_box_t<fast_io::win32_family::wide_nt,wchar_t>,
1>            T=fast_io::io_print_forward::no_cvref_t,
1>            output=fast_io::basic_win32_family_box_t<fast_io::win32_family::wide_nt,wchar_t>
1>        ]
1>        D:\github\fio_workplace\fio\fast_io\include\fast_io_core_impl\operations\print_freestanding.h(275,34):
1>        查看对正在编译的函数 模板 实例化“void fast_io::operations::decay::write_all_decay<output>(outstmtype,const wchar_t *,const wchar_t *)”的引用
1>        with
1>        [
1>            output=fast_io::basic_win32_family_box_t<fast_io::win32_family::wide_nt,wchar_t>,
1>            outstmtype=fast_io::basic_win32_family_box_t<fast_io::win32_family::wide_nt,wchar_t>
1>        ]
1>        D:\github\fio_workplace\fio\fast_io\include\fast_io_core_impl\operations\writeimpl\decay.h(18,22):
1>        查看对正在编译的函数 模板 实例化“void fast_io::details::write_all_impl<outstmtype>(outstmtype,const wchar_t *,const wchar_t *)”的引用
1>        with
1>        [
1>            outstmtype=fast_io::basic_win32_family_box_t<fast_io::win32_family::wide_nt,wchar_t>
1>        ]
1>        D:\github\fio_workplace\fio\fast_io\include\fast_io_core_impl\operations\writeimpl\basis.h(524,22):
1>        查看对正在编译的函数 模板 实例化“void fast_io::details::write_all_cold_impl<outstmtype>(outstmtype,const wchar_t *,const wchar_t *)”的引用
1>        with
1>        [
1>            outstmtype=fast_io::basic_win32_family_box_t<fast_io::win32_family::wide_nt,wchar_t>
1>        ]
1>        D:\github\fio_workplace\fio\fast_io\include\fast_io_core_impl\operations\writeimpl\basis.h(236,3):
1>        查看对正在编译的函数 模板 实例化“void fast_io::scatter_write_all_overflow_define<fast_io::win32_family::wide_nt,wchar_t>(fast_io::basic_win32_family_box_t<fast_io::win32_family::wide_nt,wchar_t>,const fast_io::basic_io_scatter_t<wchar_t> *,size_t)”的引用
1>        D:\github\fio_workplace\fio\fast_io\include\fast_io_hosted\platforms\win32_box.h(184,22):
1>        查看对正在编译的函数 模板 实例化“void fast_io::details::win32_box_converter_scatter_path_impl<fast_io::win32_family::wide_nt,wchar_t>(fast_io::basic_win32_family_box_t<fast_io::win32_family::wide_nt,wchar_t>,const fast_io::basic_io_scatter_t<wchar_t> *,size_t)”的引用
```