### PR TITLE
fix wc_file u16c_file and u32c_file on windows

### DIFF
--- a/fuzzing/0000.write/c_file_unlocked.cc
+++ b/fuzzing/0000.write/c_file_unlocked.cc
@@ -1,6 +1,6 @@
 ﻿#include <fast_io.h>
 
-fast_io::c_file_unlocked obf("/dev/null", fast_io::open_mode::out);
+fast_io::c_file_unlocked obf("nul", fast_io::open_mode::out);
 
 extern "C" int LLVMFuzzerTestOneInput(std::uint8_t const *pptr, std::size_t n) noexcept
 {

--- a/fuzzing/0000.write/c_file_unlocked.cc
+++ b/fuzzing/0000.write/c_file_unlocked.cc
@@ -1,10 +1,17 @@
 ﻿#include <fast_io.h>
 
-fast_io::c_file_unlocked obf("nul", fast_io::open_mode::out);
+fast_io::c_file_unlocked obf(
+#if defined(_WIN32) && !defined(__WINE__)
+	"nul"
+#else
+	"/dev/null"
+#endif
+	,
+	fast_io::open_mode::out);
 
 extern "C" int LLVMFuzzerTestOneInput(std::uint8_t const *pptr, std::size_t n) noexcept
 {
-	::std::byte const* ptr{reinterpret_cast<::std::byte const*>(pptr)};
+	::std::byte const *ptr{reinterpret_cast<::std::byte const *>(pptr)};
 	::fast_io::operations::write_all_bytes(obf, ptr, ptr + n);
 	return 0;
 }

--- a/fuzzing/0000.write/c_file_unlocked.cc
+++ b/fuzzing/0000.write/c_file_unlocked.cc
@@ -2,8 +2,9 @@
 
 fast_io::c_file_unlocked obf("/dev/null", fast_io::open_mode::out);
 
-extern "C" int LLVMFuzzerTestOneInput(std::uint8_t const *ptr, std::size_t n) noexcept
+extern "C" int LLVMFuzzerTestOneInput(std::uint8_t const *pptr, std::size_t n) noexcept
 {
-	write(obf, ptr, ptr + n);
+	::std::byte const* ptr{reinterpret_cast<::std::byte const*>(pptr)};
+	::fast_io::operations::write_all_bytes(obf, ptr, ptr + n);
 	return 0;
 }

--- a/fuzzing/0000.write/u32c_file_unlocked.cc
+++ b/fuzzing/0000.write/u32c_file_unlocked.cc
@@ -1,0 +1,24 @@
+﻿#include <fast_io.h>
+
+fast_io::u32c_file_unlocked obf(
+#if defined(_WIN32) && !defined(__WINE__)
+	"nul"
+#else
+	"/dev/null"
+#endif
+	,
+	fast_io::open_mode::out);
+
+extern "C"
+	[[__gnu__::__weak__]]
+	uintptr_t __sancov_lowest_stack{};
+
+extern "C" int LLVMFuzzerTestOneInput(std::uint8_t const *pptr, std::size_t n) noexcept
+{
+	using chartype = char32_t;
+	char32_t const *ptr{reinterpret_cast<char32_t const *>(pptr)};
+	using namespace fast_io::mnp;
+	::fast_io::operations::write_all(obf, ptr, ptr + n / sizeof(char32_t));
+
+	return 0;
+}

--- a/fuzzing/0000.write/wc_file_unlocked.cc
+++ b/fuzzing/0000.write/wc_file_unlocked.cc
@@ -1,0 +1,20 @@
+﻿#include <fast_io.h>
+
+fast_io::wc_file_unlocked obf(
+#if defined(_WIN32) && !defined(__WINE__)
+	"nul"
+#else
+	"/dev/null"
+#endif
+	, fast_io::open_mode::out);
+
+extern "C"
+[[__gnu__::__weak__]]
+uintptr_t __sancov_lowest_stack{};
+
+extern "C" int LLVMFuzzerTestOneInput(std::uint8_t const *pptr, std::size_t n) noexcept
+{
+	wchar_t const* ptr{reinterpret_cast<wchar_t const*>(pptr)};
+	::fast_io::operations::write_all(obf, ptr, ptr + n/sizeof(wchar_t));
+	return 0;
+}

--- a/fuzzing/0000.write/wc_file_unlocked.cc
+++ b/fuzzing/0000.write/wc_file_unlocked.cc
@@ -6,15 +6,16 @@ fast_io::wc_file_unlocked obf(
 #else
 	"/dev/null"
 #endif
-	, fast_io::open_mode::out);
+	,
+	fast_io::open_mode::out);
 
 extern "C"
-[[__gnu__::__weak__]]
-uintptr_t __sancov_lowest_stack{};
+	[[__gnu__::__weak__]]
+	uintptr_t __sancov_lowest_stack{};
 
 extern "C" int LLVMFuzzerTestOneInput(std::uint8_t const *pptr, std::size_t n) noexcept
 {
-	wchar_t const* ptr{reinterpret_cast<wchar_t const*>(pptr)};
-	::fast_io::operations::write_all(obf, ptr, ptr + n/sizeof(wchar_t));
+	wchar_t const *ptr{reinterpret_cast<wchar_t const *>(pptr)};
+	::fast_io::operations::write_all(obf, ptr, ptr + n / sizeof(wchar_t));
 	return 0;
 }

--- a/fuzzing/0000.write/wc_file_unlocked.cc
+++ b/fuzzing/0000.write/wc_file_unlocked.cc
@@ -13,9 +13,22 @@ extern "C"
 	[[__gnu__::__weak__]]
 	uintptr_t __sancov_lowest_stack{};
 
+struct usefwide
+{
+	usefwide()
+	{
+		fwide(obf.fp, 1);
+	}
+};
+#ifdef USE_FWIDE
+usefwide t;
+#endif
+
 extern "C" int LLVMFuzzerTestOneInput(std::uint8_t const *pptr, std::size_t n) noexcept
 {
 	wchar_t const *ptr{reinterpret_cast<wchar_t const *>(pptr)};
+	using namespace fast_io::mnp;
 	::fast_io::operations::write_all(obf, ptr, ptr + n / sizeof(wchar_t));
+
 	return 0;
 }

--- a/include/fast_io_legacy_impl/c/wincrt.h
+++ b/include/fast_io_legacy_impl/c/wincrt.h
@@ -372,16 +372,15 @@ inline T *wincrt_get_buffer_ptr_impl(FILE *__restrict fpp) noexcept
 	}
 }
 
-template <typename T>
 inline void wincrt_set_buffer_curr_ptr_impl(FILE *__restrict fpp,
 #if __has_cpp_attribute(__gnu__::__may_alias__)
 											[[__gnu__::__may_alias__]]
 #endif
-											T *ptr) noexcept
+											void *ptr) noexcept
 {
 	crt_iobuf *fp{reinterpret_cast<crt_iobuf *>(fpp)};
 	fp->_cnt -= static_cast<::std::int_least32_t>(
-		static_cast<::std::uint_least32_t>(static_cast<::std::size_t>(reinterpret_cast<char *>(ptr) - fp->_ptr) / sizeof(T)));
+		static_cast<::std::uint_least32_t>(static_cast<::std::size_t>(reinterpret_cast<char *>(ptr) - fp->_ptr)));
 	fp->_ptr = reinterpret_cast<char *>(ptr);
 }
 #if defined(_MSC_VER) || defined(_UCRT)


### PR DESCRIPTION
The issue here is that i only did division not multiplication. Unfortunately it is very hard to fuzz windows but I got it work by modifying the LLVM source code. fixed.