### PR TITLE
support new_console option

### DIFF
--- a/include/fast_io_hosted/platforms/win32.h
+++ b/include/fast_io_hosted/platforms/win32.h
@@ -1749,7 +1749,7 @@ inline void win32_clear_screen_main(void *out_hdl)
 
 inline void win32_clear_screen_impl(void *handle)
 {
-	if (!win32_is_character_device(handle))
+	if (!win32_is_character_device(handle)) [[unlikely]]
 	{
 		return;
 	}
@@ -1774,7 +1774,7 @@ public:
 	{
 		win32::security_attributes sec_attr{sizeof(win32::security_attributes), nullptr, 1};
 		if (!::fast_io::win32::CreatePipe(__builtin_addressof(pipes[0].handle),
-										  __builtin_addressof(pipes[1].handle), __builtin_addressof(sec_attr), 0))
+										  __builtin_addressof(pipes[1].handle), __builtin_addressof(sec_attr), 0)) [[unlikely]]
 		{
 			throw_win32_error();
 		}

--- a/include/fast_io_hosted/process/process/nt.h
+++ b/include/fast_io_hosted/process/process/nt.h
@@ -557,7 +557,14 @@ inline nt_user_process_information nt_6x_process_create_impl(void *__restrict fh
 	}
 
 	// 0 == create new window, 4 == current windows, 0xfffffffffffffffd == no windows (background)
-	rtl_temp->ConsoleHandle = reinterpret_cast<void *>(0x4);
+	if ((mode & process_mode::alloc_new_console) == process_mode::alloc_new_console)
+	{
+		rtl_temp->ConsoleHandle = reinterpret_cast<void *>(0);
+	}
+	else
+	{
+		rtl_temp->ConsoleHandle = reinterpret_cast<void *>(0x4);
+	}
 
 	// Initialize the PS_CREATE_INFO structure
 	ps_create_info CreateInfo{};

--- a/include/fast_io_hosted/process/process/nt.h
+++ b/include/fast_io_hosted/process/process/nt.h
@@ -559,7 +559,7 @@ inline nt_user_process_information nt_6x_process_create_impl(void *__restrict fh
 	// 0 == create new window, 4 == current windows, 0xfffffffffffffffd == no windows (background)
 	if ((mode & process_mode::alloc_new_console) == process_mode::alloc_new_console)
 	{
-		rtl_temp->ConsoleHandle = reinterpret_cast<void *>(0);
+		rtl_temp->ConsoleHandle = nullptr;
 	}
 	else
 	{

--- a/include/fast_io_hosted/process/process/option.h
+++ b/include/fast_io_hosted/process/process/option.h
@@ -7,9 +7,11 @@ enum process_mode : ::std::uint_least64_t
 	none = 0,
 	// *indicates that the process mode has not been evaluated yet
 	new_session = static_cast<::std::uint_least64_t>(1) << 0,
-	// [POSIX] setsid(), [WINDOWS, WINNT] CREATE_NEW_PROCESS_GROUP | DETACHED_PROCESS
-	nt_absolute_path = static_cast<::std::uint_least64_t>(1) << 1
+	// [POSIX] setsid(), [WINDOWS, WINNT] CREATE_NEW_PROCESS_GROUP (Windows is currently not implemented)
+	nt_absolute_path = static_cast<::std::uint_least64_t>(1) << 1,
 	// [WINNT] Set the process path in the PEB to nt absolute path
+	alloc_new_console = static_cast<::std::uint_least64_t>(1) << 2
+	// [WINDOWS, WINNT] CREATE_NEW_CONSOLE (Automatically assign a console to new threads)
 };
 
 inline constexpr process_mode operator&(process_mode x, process_mode y) noexcept

--- a/include/fast_io_hosted/process/process/win32.h
+++ b/include/fast_io_hosted/process/process/win32.h
@@ -243,8 +243,11 @@ inline win32_user_process_information win32_winnt_process_create_from_handle_imp
 
 		if ((mode & process_mode::new_session) == process_mode::new_session)
 		{
-			dwCreationFlags &= 0x00000200; // CREATE_NEW_PROCESS_GROUP
-			dwCreationFlags &= 0x00000008; // DETACHED_PROCESS
+			dwCreationFlags |= 0x00000200; // CREATE_NEW_PROCESS_GROUP
+		}
+		if ((mode & process_mode::alloc_new_console) == process_mode::alloc_new_console)
+		{
+			dwCreationFlags |= 0x00000010; // CREATE_NEW_CONSOLE
 		}
 
 		::fast_io::win32::process_information pi{};
@@ -413,8 +416,11 @@ inline win32_user_process_information win32_winnt_process_create_from_handle_imp
 
 		if ((mode & process_mode::new_session) == process_mode::new_session)
 		{
-			dwCreationFlags &= 0x00000200; // CREATE_NEW_PROCESS_GROUP
-			dwCreationFlags &= 0x00000008; // DETACHED_PROCESS
+			dwCreationFlags |= 0x00000200; // CREATE_NEW_PROCESS_GROUP
+		}
+		if ((mode & process_mode::alloc_new_console) == process_mode::alloc_new_console)
+		{
+			dwCreationFlags |= 0x00000010; // CREATE_NEW_CONSOLE
 		}
 
 		::fast_io::win32::process_information pi{};
@@ -520,8 +526,11 @@ inline win32_user_process_information win32_9xa_win9x_process_create_from_filepa
 
 	if ((mode & process_mode::new_session) == process_mode::new_session)
 	{
-		dwCreationFlags &= 0x00000200; // CREATE_NEW_PROCESS_GROUP
-		dwCreationFlags &= 0x00000008; // DETACHED_PROCESS
+		dwCreationFlags |= 0x00000200; // CREATE_NEW_PROCESS_GROUP
+	}
+	if ((mode & process_mode::alloc_new_console) == process_mode::alloc_new_console)
+	{
+		dwCreationFlags |= 0x00000010; // CREATE_NEW_CONSOLE
 	}
 
 	::fast_io::win32::process_information pi{};


### PR DESCRIPTION
You can use process_mode::alloc_new_console creates a process using a new window on win32 and nt