### PR TITLE
add missing constexpr in win32_9xa_dirent

### DIFF
--- a/include/fast_io_hosted/filesystem/win32_9xa.h
+++ b/include/fast_io_hosted/filesystem/win32_9xa.h
@@ -12,7 +12,7 @@ struct win32_9xa_dirent
 	[[maybe_unused]] ::std::uint_least64_t d_ino{};
 	::fast_io::win32::details::win32_9xa_dir_handle_path_str filename{};
 
-	inline ~win32_9xa_dirent()
+	inline constexpr ~win32_9xa_dirent()
 	{
 		if (file_struct) [[likely]]
 		{


### PR DESCRIPTION
there is the traceback before this patch:
D:/projects/Phy-Engine/test/../include/fast_io/fast_io_hosted/filesystem/win32_9xa.h:273:19: error: destructor cannot be declared constexpr because data member 'entry' does not have a constexpr destructor
  273 |         inline constexpr ~basic_win32_9xa_recursive_directory_generator()
      |                          ^
D:/projects/Phy-Engine/test/../include/fast_io/fast_io_hosted/filesystem/win32_9xa.h:250:19: note: data member 'entry' declared here
  250 |         win32_9xa_dirent entry{};
      |                          ^