### PR TITLE
Replace the use of if consteval with a macro, and use ::std::is_constant_evalued() instead of if consteval under msvc,

### DIFF
--- a/include/fast_io_core_impl/allocation/adapters.h
+++ b/include/fast_io_core_impl/allocation/adapters.h
@@ -104,7 +104,7 @@ public:
 						::fast_io::details::has_allocate_zero_impl<alloc> ||
 						::fast_io::details::has_allocate_aligned_zero_impl<alloc>)};
 	static inline
-
+		constexpr
 		void *
 		allocate(::std::size_t n) noexcept
 		requires(!has_status)
@@ -374,7 +374,7 @@ public:
 
 	static inline constexpr bool has_deallocate = (::fast_io::details::has_deallocate_impl<alloc> ||
 												   ::fast_io::details::has_deallocate_aligned_impl<alloc>);
-	static inline void deallocate(void *p) noexcept
+	static inline constexpr void deallocate(void *p) noexcept
 		requires(!has_status && has_deallocate)
 	{
 #if __cpp_constexpr_dynamic_alloc >= 201907L
@@ -395,7 +395,7 @@ public:
 			}
 		}
 	}
-	static inline void deallocate_n(void *p, ::std::size_t n) noexcept
+	static inline constexpr void deallocate_n(void *p, ::std::size_t n) noexcept
 		requires(!has_status)
 	{
 #if __cpp_constexpr_dynamic_alloc >= 201907L
@@ -430,7 +430,7 @@ public:
 	}
 
 	static inline
-
+		constexpr
 		void *
 		allocate_aligned(::std::size_t alignment, ::std::size_t n) noexcept
 		requires(!has_status)
@@ -446,8 +446,7 @@ public:
 			return ::fast_io::details::allocator_pointer_aligned_impl<alloc, false>(alignment, n);
 		}
 	}
-	static inline
-
+	static inline constexpr
 		void *
 		allocate_aligned_zero(::std::size_t alignment, ::std::size_t n) noexcept
 		requires(!has_status)
@@ -1132,11 +1131,9 @@ public:
 	static inline constexpr bool has_status{allocator_adaptor::has_status};
 	using handle_type = typename allocator_adaptor::handle_type;
 	static inline
-#if (__cpp_if_consteval >= 202106L || __cpp_lib_is_constant_evaluated >= 201811L) && \
-	__cpp_constexpr_dynamic_alloc >= 201907L
+#if __cpp_constexpr_dynamic_alloc >= 201907L
 		constexpr
 #endif
-
 		T *
 		allocate(::std::size_t n) noexcept
 		requires(!has_status)
@@ -1221,8 +1218,7 @@ public:
 	}
 
 	static inline
-#if (__cpp_if_consteval >= 202106L || __cpp_lib_is_constant_evaluated >= 201811L) && \
-	__cpp_constexpr_dynamic_alloc >= 201907L
+#if __cpp_constexpr_dynamic_alloc >= 201907L
 		constexpr
 #endif
 
@@ -1466,8 +1462,7 @@ public:
 
 	static inline constexpr bool has_deallocate = allocator_adaptor::has_deallocate;
 	static inline
-#if (__cpp_if_consteval >= 202106L || __cpp_lib_is_constant_evaluated >= 201811L) && \
-	__cpp_constexpr_dynamic_alloc >= 201907L
+#if __cpp_constexpr_dynamic_alloc >= 201907L
 		constexpr
 #endif
 		void
@@ -1497,8 +1492,7 @@ public:
 		}
 	}
 	static inline
-#if (__cpp_if_consteval >= 202106L || __cpp_lib_is_constant_evaluated >= 201811L) && \
-	__cpp_constexpr_dynamic_alloc >= 201907L
+#if __cpp_constexpr_dynamic_alloc >= 201907L
 		constexpr
 #endif
 		void
@@ -1529,8 +1523,7 @@ public:
 	}
 #if 0
 	static inline
-#if (__cpp_if_consteval >= 202106L || __cpp_lib_is_constant_evaluated >= 201811L) && \
-	__cpp_constexpr_dynamic_alloc >= 201907L
+#if __cpp_constexpr_dynamic_alloc >= 201907L
 		constexpr
 #endif
  
@@ -1697,8 +1690,7 @@ public:
 
 	static inline constexpr bool has_handle_deallocate = allocator_adaptor::has_handle_deallocate;
 	static inline
-#if (__cpp_if_consteval >= 202106L || __cpp_lib_is_constant_evaluated >= 201811L) && \
-	__cpp_constexpr_dynamic_alloc >= 201907L
+#if __cpp_constexpr_dynamic_alloc >= 201907L
 		constexpr
 #endif
 		void
@@ -1728,8 +1720,7 @@ public:
 		}
 	}
 	static inline
-#if (__cpp_if_consteval >= 202106L || __cpp_lib_is_constant_evaluated >= 201811L) && \
-	__cpp_constexpr_dynamic_alloc >= 201907L
+#if __cpp_constexpr_dynamic_alloc >= 201907L
 		constexpr
 #endif
 		void

--- a/include/fast_io_core_impl/allocation/adapters.h
+++ b/include/fast_io_core_impl/allocation/adapters.h
@@ -109,13 +109,8 @@ public:
 		allocate(::std::size_t n) noexcept
 		requires(!has_status)
 	{
-#if (__cpp_if_consteval >= 202106L || __cpp_lib_is_constant_evaluated >= 201811L) && \
-	__cpp_constexpr_dynamic_alloc >= 201907L
-#if __cpp_if_consteval >= 202106L
-		if consteval
-#else
-		if (__builtin_is_constant_evaluated())
-#endif
+#if defined(FAST_IO_IF_CONSTEVAL) && __cpp_constexpr_dynamic_alloc >= 201907L
+		FAST_IO_IF_CONSTEVAL
 		{
 			return ::operator new(n);
 		}
@@ -382,13 +377,8 @@ public:
 	static inline void deallocate(void *p) noexcept
 		requires(!has_status && has_deallocate)
 	{
-#if (__cpp_if_consteval >= 202106L || __cpp_lib_is_constant_evaluated >= 201811L) && \
-	__cpp_constexpr_dynamic_alloc >= 201907L
-#if __cpp_if_consteval >= 202106L
-		if consteval
-#else
-		if (__builtin_is_constant_evaluated())
-#endif
+#if defined(FAST_IO_IF_CONSTEVAL) && __cpp_constexpr_dynamic_alloc >= 201907L
+		FAST_IO_IF_CONSTEVAL
 		{
 			::operator delete(p);
 		}
@@ -408,13 +398,8 @@ public:
 	static inline void deallocate_n(void *p, ::std::size_t n) noexcept
 		requires(!has_status)
 	{
-#if (__cpp_if_consteval >= 202106L || __cpp_lib_is_constant_evaluated >= 201811L) && \
-	__cpp_constexpr_dynamic_alloc >= 201907L
-#if __cpp_if_consteval >= 202106L
-		if consteval
-#else
-		if (__builtin_is_constant_evaluated())
-#endif
+#if defined(FAST_IO_IF_CONSTEVAL) && __cpp_constexpr_dynamic_alloc >= 201907L
+		FAST_IO_IF_CONSTEVAL
 		{
 			::operator delete(p);
 		}
@@ -450,13 +435,8 @@ public:
 		allocate_aligned(::std::size_t alignment, ::std::size_t n) noexcept
 		requires(!has_status)
 	{
-#if (__cpp_if_consteval >= 202106L || __cpp_lib_is_constant_evaluated >= 201811L) && \
-	__cpp_constexpr_dynamic_alloc >= 201907L
-#if __cpp_if_consteval >= 202106L
-		if consteval
-#else
-		if (__builtin_is_constant_evaluated())
-#endif
+#if defined(FAST_IO_IF_CONSTEVAL) && __cpp_constexpr_dynamic_alloc >= 201907L
+		FAST_IO_IF_CONSTEVAL
 		{
 			return ::operator new(n);
 		}
@@ -472,13 +452,8 @@ public:
 		allocate_aligned_zero(::std::size_t alignment, ::std::size_t n) noexcept
 		requires(!has_status)
 	{
-#if (__cpp_if_consteval >= 202106L || __cpp_lib_is_constant_evaluated >= 201811L) && \
-	__cpp_constexpr_dynamic_alloc >= 201907L
-#if __cpp_if_consteval >= 202106L
-		if consteval
-#else
-		if (__builtin_is_constant_evaluated())
-#endif
+#if defined(FAST_IO_IF_CONSTEVAL) && __cpp_constexpr_dynamic_alloc >= 201907L
+		FAST_IO_IF_CONSTEVAL
 		{
 			return ::operator new(n); // this is problematic. No way to clean it up at compile time.
 		}
@@ -497,13 +472,8 @@ public:
 	allocate_at_least(::std::size_t n) noexcept
 		requires(!has_status)
 	{
-#if (__cpp_if_consteval >= 202106L || __cpp_lib_is_constant_evaluated >= 201811L) && \
-	__cpp_constexpr_dynamic_alloc >= 201907L
-#if __cpp_if_consteval >= 202106L
-		if consteval
-#else
-		if (__builtin_is_constant_evaluated())
-#endif
+#if defined(FAST_IO_IF_CONSTEVAL) && __cpp_constexpr_dynamic_alloc >= 201907L
+		FAST_IO_IF_CONSTEVAL
 		{
 			return {::operator new(n), n};
 		}
@@ -536,13 +506,8 @@ public:
 	allocate_zero_at_least(::std::size_t n) noexcept
 		requires(!has_status)
 	{
-#if (__cpp_if_consteval >= 202106L || __cpp_lib_is_constant_evaluated >= 201811L) && \
-	__cpp_constexpr_dynamic_alloc >= 201907L
-#if __cpp_if_consteval >= 202106L
-		if consteval
-#else
-		if (__builtin_is_constant_evaluated())
-#endif
+#if defined(FAST_IO_IF_CONSTEVAL) && __cpp_constexpr_dynamic_alloc >= 201907L
+		FAST_IO_IF_CONSTEVAL
 		{
 			return {::operator new(n), n};
 		}
@@ -577,13 +542,8 @@ public:
 	allocate_aligned_at_least(::std::size_t alignment, ::std::size_t n) noexcept
 		requires(!has_status)
 	{
-#if (__cpp_if_consteval >= 202106L || __cpp_lib_is_constant_evaluated >= 201811L) && \
-	__cpp_constexpr_dynamic_alloc >= 201907L
-#if __cpp_if_consteval >= 202106L
-		if consteval
-#else
-		if (__builtin_is_constant_evaluated())
-#endif
+#if defined(FAST_IO_IF_CONSTEVAL) && __cpp_constexpr_dynamic_alloc >= 201907L
+		FAST_IO_IF_CONSTEVAL
 		{
 			return {::operator new(n), n};
 		}
@@ -614,13 +574,8 @@ public:
 	allocate_aligned_zero_at_least(::std::size_t alignment, ::std::size_t n) noexcept
 		requires(!has_status)
 	{
-#if (__cpp_if_consteval >= 202106L || __cpp_lib_is_constant_evaluated >= 201811L) && \
-	__cpp_constexpr_dynamic_alloc >= 201907L
-#if __cpp_if_consteval >= 202106L
-		if consteval
-#else
-		if (__builtin_is_constant_evaluated())
-#endif
+#if defined(FAST_IO_IF_CONSTEVAL) && __cpp_constexpr_dynamic_alloc >= 201907L
+		FAST_IO_IF_CONSTEVAL
 		{
 			return {::operator new(n), n};
 		}
@@ -1186,13 +1141,8 @@ public:
 		allocate(::std::size_t n) noexcept
 		requires(!has_status)
 	{
-#if (__cpp_if_consteval >= 202106L || __cpp_lib_is_constant_evaluated >= 201811L) && \
-	__cpp_constexpr_dynamic_alloc >= 201907L
-#if __cpp_if_consteval >= 202106L
-		if consteval
-#else
-		if (__builtin_is_constant_evaluated())
-#endif
+#if defined(FAST_IO_IF_CONSTEVAL) && __cpp_constexpr_dynamic_alloc >= 201907L
+		FAST_IO_IF_CONSTEVAL
 		{
 			return ::fast_io::freestanding::allocator<T>{}.allocate(n);
 		}
@@ -1222,13 +1172,8 @@ public:
 		allocate_at_least(::std::size_t n) noexcept
 		requires(!has_status)
 	{
-#if (__cpp_if_consteval >= 202106L || __cpp_lib_is_constant_evaluated >= 201811L) && \
-	__cpp_constexpr_dynamic_alloc >= 201907L
-#if __cpp_if_consteval >= 202106L
-		if consteval
-#else
-		if (__builtin_is_constant_evaluated())
-#endif
+#if defined(FAST_IO_IF_CONSTEVAL) && __cpp_constexpr_dynamic_alloc >= 201907L
+		FAST_IO_IF_CONSTEVAL
 		{
 			return {::fast_io::freestanding::allocator<T>{}.allocate(n), n};
 		}
@@ -1285,13 +1230,8 @@ public:
 		allocate_zero_at_least(::std::size_t n) noexcept
 		requires(!has_status)
 	{
-#if (__cpp_if_consteval >= 202106L || __cpp_lib_is_constant_evaluated >= 201811L) && \
-	__cpp_constexpr_dynamic_alloc >= 201907L
-#if __cpp_if_consteval >= 202106L
-		if consteval
-#else
-		if (__builtin_is_constant_evaluated())
-#endif
+#if defined(FAST_IO_IF_CONSTEVAL) && __cpp_constexpr_dynamic_alloc >= 201907L
+		FAST_IO_IF_CONSTEVAL
 		{
 			return {::fast_io::freestanding::allocator<T>{}.allocate(n), n};
 		}
@@ -1534,13 +1474,8 @@ public:
 		deallocate(T *ptr) noexcept
 		requires(!has_status && has_deallocate)
 	{
-#if (__cpp_if_consteval >= 202106L || __cpp_lib_is_constant_evaluated >= 201811L) && \
-	__cpp_constexpr_dynamic_alloc >= 201907L
-#if __cpp_if_consteval >= 202106L
-		if consteval
-#else
-		if (__builtin_is_constant_evaluated())
-#endif
+#if defined(FAST_IO_IF_CONSTEVAL) && __cpp_constexpr_dynamic_alloc >= 201907L
+		FAST_IO_IF_CONSTEVAL
 		{
 			if (ptr)
 			{
@@ -1570,13 +1505,8 @@ public:
 		deallocate_n(T *ptr, ::std::size_t n) noexcept
 		requires(!has_status)
 	{
-#if (__cpp_if_consteval >= 202106L || __cpp_lib_is_constant_evaluated >= 201811L) && \
-	__cpp_constexpr_dynamic_alloc >= 201907L
-#if __cpp_if_consteval >= 202106L
-		if consteval
-#else
-		if (__builtin_is_constant_evaluated())
-#endif
+#if defined(FAST_IO_IF_CONSTEVAL) && __cpp_constexpr_dynamic_alloc >= 201907L
+		FAST_IO_IF_CONSTEVAL
 		{
 			if (ptr)
 			{
@@ -1609,13 +1539,8 @@ public:
 		handle_allocate(handle_type handle, ::std::size_t n) noexcept
 		requires(has_status)
 	{
-#if (__cpp_if_consteval >= 202106L || __cpp_lib_is_constant_evaluated >= 201811L) && \
-	__cpp_constexpr_dynamic_alloc >= 201907L
-#if __cpp_if_consteval >= 202106L
-		if consteval
-#else
-		if (__builtin_is_constant_evaluated())
-#endif
+#if defined(FAST_IO_IF_CONSTEVAL) && __cpp_constexpr_dynamic_alloc >= 201907L
+		FAST_IO_IF_CONSTEVAL
 		{
 			if (n)
 			{
@@ -1780,13 +1705,8 @@ public:
 		handle_deallocate(handle_type handle, T *ptr) noexcept
 		requires(has_status && has_handle_deallocate)
 	{
-#if (__cpp_if_consteval >= 202106L || __cpp_lib_is_constant_evaluated >= 201811L) && \
-	__cpp_constexpr_dynamic_alloc >= 201907L
-#if __cpp_if_consteval >= 202106L
-		if consteval
-#else
-		if (__builtin_is_constant_evaluated())
-#endif
+#if defined(FAST_IO_IF_CONSTEVAL) && __cpp_constexpr_dynamic_alloc >= 201907L
+		FAST_IO_IF_CONSTEVAL
 		{
 			if (ptr)
 			{
@@ -1816,13 +1736,8 @@ public:
 		handle_deallocate_n(handle_type handle, T *ptr, ::std::size_t n) noexcept
 		requires(has_status)
 	{
-#if (__cpp_if_consteval >= 202106L || __cpp_lib_is_constant_evaluated >= 201811L) && \
-	__cpp_constexpr_dynamic_alloc >= 201907L
-#if __cpp_if_consteval >= 202106L
-		if consteval
-#else
-		if (__builtin_is_constant_evaluated())
-#endif
+#if defined(FAST_IO_IF_CONSTEVAL) && __cpp_constexpr_dynamic_alloc >= 201907L
+		FAST_IO_IF_CONSTEVAL
 		{
 			if (ptr)
 			{

--- a/include/fast_io_core_impl/allocation/adapters.h
+++ b/include/fast_io_core_impl/allocation/adapters.h
@@ -109,8 +109,8 @@ public:
 		allocate(::std::size_t n) noexcept
 		requires(!has_status)
 	{
-#if defined(FAST_IO_IF_CONSTEVAL) && __cpp_constexpr_dynamic_alloc >= 201907L
-		FAST_IO_IF_CONSTEVAL
+#if __cpp_constexpr_dynamic_alloc >= 201907L
+		if (__builtin_is_constant_evaluated())
 		{
 			return ::operator new(n);
 		}
@@ -377,8 +377,8 @@ public:
 	static inline void deallocate(void *p) noexcept
 		requires(!has_status && has_deallocate)
 	{
-#if defined(FAST_IO_IF_CONSTEVAL) && __cpp_constexpr_dynamic_alloc >= 201907L
-		FAST_IO_IF_CONSTEVAL
+#if __cpp_constexpr_dynamic_alloc >= 201907L
+		if (__builtin_is_constant_evaluated())
 		{
 			::operator delete(p);
 		}
@@ -398,8 +398,8 @@ public:
 	static inline void deallocate_n(void *p, ::std::size_t n) noexcept
 		requires(!has_status)
 	{
-#if defined(FAST_IO_IF_CONSTEVAL) && __cpp_constexpr_dynamic_alloc >= 201907L
-		FAST_IO_IF_CONSTEVAL
+#if __cpp_constexpr_dynamic_alloc >= 201907L
+		if (__builtin_is_constant_evaluated())
 		{
 			::operator delete(p);
 		}
@@ -435,8 +435,8 @@ public:
 		allocate_aligned(::std::size_t alignment, ::std::size_t n) noexcept
 		requires(!has_status)
 	{
-#if defined(FAST_IO_IF_CONSTEVAL) && __cpp_constexpr_dynamic_alloc >= 201907L
-		FAST_IO_IF_CONSTEVAL
+#if __cpp_constexpr_dynamic_alloc >= 201907L
+		if (__builtin_is_constant_evaluated())
 		{
 			return ::operator new(n);
 		}
@@ -452,8 +452,8 @@ public:
 		allocate_aligned_zero(::std::size_t alignment, ::std::size_t n) noexcept
 		requires(!has_status)
 	{
-#if defined(FAST_IO_IF_CONSTEVAL) && __cpp_constexpr_dynamic_alloc >= 201907L
-		FAST_IO_IF_CONSTEVAL
+#if __cpp_constexpr_dynamic_alloc >= 201907L
+		if (__builtin_is_constant_evaluated())
 		{
 			return ::operator new(n); // this is problematic. No way to clean it up at compile time.
 		}
@@ -472,8 +472,8 @@ public:
 	allocate_at_least(::std::size_t n) noexcept
 		requires(!has_status)
 	{
-#if defined(FAST_IO_IF_CONSTEVAL) && __cpp_constexpr_dynamic_alloc >= 201907L
-		FAST_IO_IF_CONSTEVAL
+#if __cpp_constexpr_dynamic_alloc >= 201907L
+		if (__builtin_is_constant_evaluated())
 		{
 			return {::operator new(n), n};
 		}
@@ -506,8 +506,8 @@ public:
 	allocate_zero_at_least(::std::size_t n) noexcept
 		requires(!has_status)
 	{
-#if defined(FAST_IO_IF_CONSTEVAL) && __cpp_constexpr_dynamic_alloc >= 201907L
-		FAST_IO_IF_CONSTEVAL
+#if __cpp_constexpr_dynamic_alloc >= 201907L
+		if (__builtin_is_constant_evaluated())
 		{
 			return {::operator new(n), n};
 		}
@@ -542,8 +542,8 @@ public:
 	allocate_aligned_at_least(::std::size_t alignment, ::std::size_t n) noexcept
 		requires(!has_status)
 	{
-#if defined(FAST_IO_IF_CONSTEVAL) && __cpp_constexpr_dynamic_alloc >= 201907L
-		FAST_IO_IF_CONSTEVAL
+#if __cpp_constexpr_dynamic_alloc >= 201907L
+		if (__builtin_is_constant_evaluated())
 		{
 			return {::operator new(n), n};
 		}
@@ -574,8 +574,8 @@ public:
 	allocate_aligned_zero_at_least(::std::size_t alignment, ::std::size_t n) noexcept
 		requires(!has_status)
 	{
-#if defined(FAST_IO_IF_CONSTEVAL) && __cpp_constexpr_dynamic_alloc >= 201907L
-		FAST_IO_IF_CONSTEVAL
+#if __cpp_constexpr_dynamic_alloc >= 201907L
+		if (__builtin_is_constant_evaluated())
 		{
 			return {::operator new(n), n};
 		}
@@ -1141,8 +1141,8 @@ public:
 		allocate(::std::size_t n) noexcept
 		requires(!has_status)
 	{
-#if defined(FAST_IO_IF_CONSTEVAL) && __cpp_constexpr_dynamic_alloc >= 201907L
-		FAST_IO_IF_CONSTEVAL
+#if __cpp_constexpr_dynamic_alloc >= 201907L
+		if (__builtin_is_constant_evaluated())
 		{
 			return ::fast_io::freestanding::allocator<T>{}.allocate(n);
 		}
@@ -1172,8 +1172,8 @@ public:
 		allocate_at_least(::std::size_t n) noexcept
 		requires(!has_status)
 	{
-#if defined(FAST_IO_IF_CONSTEVAL) && __cpp_constexpr_dynamic_alloc >= 201907L
-		FAST_IO_IF_CONSTEVAL
+#if __cpp_constexpr_dynamic_alloc >= 201907L
+		if (__builtin_is_constant_evaluated())
 		{
 			return {::fast_io::freestanding::allocator<T>{}.allocate(n), n};
 		}
@@ -1230,8 +1230,8 @@ public:
 		allocate_zero_at_least(::std::size_t n) noexcept
 		requires(!has_status)
 	{
-#if defined(FAST_IO_IF_CONSTEVAL) && __cpp_constexpr_dynamic_alloc >= 201907L
-		FAST_IO_IF_CONSTEVAL
+#if __cpp_constexpr_dynamic_alloc >= 201907L
+		if (__builtin_is_constant_evaluated())
 		{
 			return {::fast_io::freestanding::allocator<T>{}.allocate(n), n};
 		}
@@ -1474,8 +1474,8 @@ public:
 		deallocate(T *ptr) noexcept
 		requires(!has_status && has_deallocate)
 	{
-#if defined(FAST_IO_IF_CONSTEVAL) && __cpp_constexpr_dynamic_alloc >= 201907L
-		FAST_IO_IF_CONSTEVAL
+#if __cpp_constexpr_dynamic_alloc >= 201907L
+		if (__builtin_is_constant_evaluated())
 		{
 			if (ptr)
 			{
@@ -1505,8 +1505,8 @@ public:
 		deallocate_n(T *ptr, ::std::size_t n) noexcept
 		requires(!has_status)
 	{
-#if defined(FAST_IO_IF_CONSTEVAL) && __cpp_constexpr_dynamic_alloc >= 201907L
-		FAST_IO_IF_CONSTEVAL
+#if __cpp_constexpr_dynamic_alloc >= 201907L
+		if (__builtin_is_constant_evaluated())
 		{
 			if (ptr)
 			{
@@ -1539,8 +1539,8 @@ public:
 		handle_allocate(handle_type handle, ::std::size_t n) noexcept
 		requires(has_status)
 	{
-#if defined(FAST_IO_IF_CONSTEVAL) && __cpp_constexpr_dynamic_alloc >= 201907L
-		FAST_IO_IF_CONSTEVAL
+#if __cpp_constexpr_dynamic_alloc >= 201907L
+		if (__builtin_is_constant_evaluated())
 		{
 			if (n)
 			{
@@ -1705,8 +1705,8 @@ public:
 		handle_deallocate(handle_type handle, T *ptr) noexcept
 		requires(has_status && has_handle_deallocate)
 	{
-#if defined(FAST_IO_IF_CONSTEVAL) && __cpp_constexpr_dynamic_alloc >= 201907L
-		FAST_IO_IF_CONSTEVAL
+#if __cpp_constexpr_dynamic_alloc >= 201907L
+		if (__builtin_is_constant_evaluated())
 		{
 			if (ptr)
 			{
@@ -1736,8 +1736,8 @@ public:
 		handle_deallocate_n(handle_type handle, T *ptr, ::std::size_t n) noexcept
 		requires(has_status)
 	{
-#if defined(FAST_IO_IF_CONSTEVAL) && __cpp_constexpr_dynamic_alloc >= 201907L
-		FAST_IO_IF_CONSTEVAL
+#if __cpp_constexpr_dynamic_alloc >= 201907L
+		if (__builtin_is_constant_evaluated())
 		{
 			if (ptr)
 			{

--- a/include/fast_io_core_impl/freestanding/algorithm.h
+++ b/include/fast_io_core_impl/freestanding/algorithm.h
@@ -326,12 +326,9 @@ inline
 template <::std::input_iterator input_iter, ::std::input_or_output_iterator output_iter>
 inline constexpr output_iter non_overlapped_copy_n(input_iter first, ::std::size_t count, output_iter result)
 {
-#if __cpp_if_consteval >= 202106L || __cpp_lib_is_constant_evaluated >= 201811L
-#if __cpp_if_consteval >= 202106L
-	if consteval
-#else
-	if (__builtin_is_constant_evaluated())
-#endif
+
+#if defined(FAST_IO_IF_CONSTEVAL)
+	FAST_IO_IF_CONSTEVAL
 	{
 		return ::fast_io::freestanding::copy_n(first, count, result);
 	}
@@ -363,12 +360,8 @@ inline constexpr output_iter non_overlapped_copy_n(input_iter first, ::std::size
 template <::std::input_iterator input_iter, ::std::input_or_output_iterator output_iter>
 inline constexpr output_iter non_overlapped_copy(input_iter first, input_iter last, output_iter result)
 {
-#if __cpp_if_consteval >= 202106L || __cpp_lib_is_constant_evaluated >= 201811L
-#if __cpp_if_consteval >= 202106L
-	if consteval
-#else
-	if (__builtin_is_constant_evaluated())
-#endif
+#if defined(FAST_IO_IF_CONSTEVAL)
+	FAST_IO_IF_CONSTEVAL
 	{
 		return ::fast_io::freestanding::copy(first, last, result);
 	}
@@ -401,12 +394,8 @@ inline constexpr output_iter non_overlapped_copy(input_iter first, input_iter la
 template <::std::input_iterator input_iter, ::std::input_or_output_iterator output_iter>
 inline constexpr output_iter my_copy_n(input_iter first, ::std::size_t count, output_iter result)
 {
-#if __cpp_if_consteval >= 202106L || __cpp_lib_is_constant_evaluated >= 201811L
-#if __cpp_if_consteval >= 202106L
-	if consteval
-#else
-	if (__builtin_is_constant_evaluated())
-#endif
+#if defined(FAST_IO_IF_CONSTEVAL)
+	FAST_IO_IF_CONSTEVAL
 	{
 		return ::fast_io::freestanding::copy_n(first, count, result);
 	}
@@ -461,12 +450,8 @@ inline constexpr output_iter my_copy(input_iter first, input_iter second, output
 template <::std::bidirectional_iterator input_iter, ::std::bidirectional_iterator output_iter>
 inline constexpr output_iter my_copy_backward(input_iter first, input_iter last, output_iter d_last)
 {
-#if __cpp_if_consteval >= 202106L || __cpp_lib_is_constant_evaluated >= 201811L
-#if __cpp_if_consteval >= 202106L
-	if consteval
-#else
-	if (__builtin_is_constant_evaluated())
-#endif
+#if defined(FAST_IO_IF_CONSTEVAL)
+	FAST_IO_IF_CONSTEVAL
 	{
 		return ::fast_io::freestanding::copy_backward(first, last, d_last);
 	}
@@ -500,12 +485,8 @@ inline constexpr output_iter my_copy_backward(input_iter first, input_iter last,
 template <::std::random_access_iterator input_iter, ::std::random_access_iterator output_iter>
 inline constexpr bool my_compare_iter_n(input_iter first, ::std::size_t n, output_iter outier) noexcept
 {
-#if __cpp_if_consteval >= 202106L || __cpp_lib_is_constant_evaluated >= 201811L
-#if __cpp_if_consteval >= 202106L
-	if consteval
-#else
-	if (__builtin_is_constant_evaluated())
-#endif
+#if defined(FAST_IO_IF_CONSTEVAL)
+	FAST_IO_IF_CONSTEVAL
 	{
 		for (auto last{first + n}; first != last; ++first)
 		{

--- a/include/fast_io_core_impl/freestanding/algorithm.h
+++ b/include/fast_io_core_impl/freestanding/algorithm.h
@@ -327,13 +327,11 @@ template <::std::input_iterator input_iter, ::std::input_or_output_iterator outp
 inline constexpr output_iter non_overlapped_copy_n(input_iter first, ::std::size_t count, output_iter result)
 {
 
-#if defined(FAST_IO_IF_CONSTEVAL)
-	FAST_IO_IF_CONSTEVAL
+	if (__builtin_is_constant_evaluated())
 	{
 		return ::fast_io::freestanding::copy_n(first, count, result);
 	}
 	else
-#endif
 	{
 		using input_value_type = ::std::iter_value_t<input_iter>;
 		using output_value_type = ::std::iter_value_t<output_iter>;
@@ -360,13 +358,11 @@ inline constexpr output_iter non_overlapped_copy_n(input_iter first, ::std::size
 template <::std::input_iterator input_iter, ::std::input_or_output_iterator output_iter>
 inline constexpr output_iter non_overlapped_copy(input_iter first, input_iter last, output_iter result)
 {
-#if defined(FAST_IO_IF_CONSTEVAL)
-	FAST_IO_IF_CONSTEVAL
+	if (__builtin_is_constant_evaluated())
 	{
 		return ::fast_io::freestanding::copy(first, last, result);
 	}
 	else
-#endif
 	{
 		using input_value_type = ::std::iter_value_t<input_iter>;
 		using output_value_type = ::std::iter_value_t<output_iter>;
@@ -394,13 +390,11 @@ inline constexpr output_iter non_overlapped_copy(input_iter first, input_iter la
 template <::std::input_iterator input_iter, ::std::input_or_output_iterator output_iter>
 inline constexpr output_iter my_copy_n(input_iter first, ::std::size_t count, output_iter result)
 {
-#if defined(FAST_IO_IF_CONSTEVAL)
-	FAST_IO_IF_CONSTEVAL
+	if (__builtin_is_constant_evaluated())
 	{
 		return ::fast_io::freestanding::copy_n(first, count, result);
 	}
 	else
-#endif
 	{
 		using input_value_type = ::std::iter_value_t<input_iter>;
 		using output_value_type = ::std::iter_value_t<output_iter>;
@@ -450,13 +444,11 @@ inline constexpr output_iter my_copy(input_iter first, input_iter second, output
 template <::std::bidirectional_iterator input_iter, ::std::bidirectional_iterator output_iter>
 inline constexpr output_iter my_copy_backward(input_iter first, input_iter last, output_iter d_last)
 {
-#if defined(FAST_IO_IF_CONSTEVAL)
-	FAST_IO_IF_CONSTEVAL
+	if (__builtin_is_constant_evaluated())
 	{
 		return ::fast_io::freestanding::copy_backward(first, last, d_last);
 	}
 	else
-#endif
 	{
 		using input_value_type = typename ::std::iter_value_t<input_iter>;
 		using output_value_type = typename ::std::iter_value_t<output_iter>;
@@ -485,8 +477,7 @@ inline constexpr output_iter my_copy_backward(input_iter first, input_iter last,
 template <::std::random_access_iterator input_iter, ::std::random_access_iterator output_iter>
 inline constexpr bool my_compare_iter_n(input_iter first, ::std::size_t n, output_iter outier) noexcept
 {
-#if defined(FAST_IO_IF_CONSTEVAL)
-	FAST_IO_IF_CONSTEVAL
+	if (__builtin_is_constant_evaluated())
 	{
 		for (auto last{first + n}; first != last; ++first)
 		{
@@ -499,7 +490,6 @@ inline constexpr bool my_compare_iter_n(input_iter first, ::std::size_t n, outpu
 		return true;
 	}
 	else
-#endif
 	{
 		using input_value_type = typename ::std::iter_value_t<input_iter>;
 		using output_value_type = typename ::std::iter_value_t<output_iter>;

--- a/include/fast_io_core_impl/freestanding/bytes.h
+++ b/include/fast_io_core_impl/freestanding/bytes.h
@@ -26,8 +26,7 @@ struct overlapped_copy_buffer_ptr
 inline constexpr ::std::byte *bytes_copy_naive_n_impl(::std::byte const *first, ::std::size_t n,
 													  ::std::byte *dest) noexcept
 {
-#if defined(FAST_IO_IF_CONSTEVAL)
-	FAST_IO_IF_CONSTEVAL
+	if (__builtin_is_constant_evaluated())
 	{
 		::fast_io::details::overlapped_copy_buffer_ptr<::std::byte> tempbuffer(n);
 		auto tempbufferptr{tempbuffer.ptr};
@@ -42,7 +41,6 @@ inline constexpr ::std::byte *bytes_copy_naive_n_impl(::std::byte const *first, 
 		return dest + n;
 	}
 	else
-#endif
 	{
 		auto ed{first + n};
 		auto dested{dest + n};
@@ -79,13 +77,11 @@ namespace fast_io::freestanding
 #endif
 inline constexpr ::std::byte *bytes_copy_n(::std::byte const *first, ::std::size_t n, ::std::byte *dest) noexcept
 {
-#if defined(FAST_IO_IF_CONSTEVAL)
-	FAST_IO_IF_CONSTEVAL
+	if (__builtin_is_constant_evaluated())
 	{
 		return ::fast_io::details::bytes_copy_naive_n_impl(first, n, dest);
 	}
 	else
-#endif
 	{
 		if (n)
 #if __has_cpp_attribute(likely)
@@ -115,13 +111,11 @@ inline constexpr ::std::byte *bytes_copy(::std::byte const *first, ::std::byte c
 inline constexpr ::std::byte *nonoverlapped_bytes_copy_n(::std::byte const *first, ::std::size_t n,
 														 ::std::byte *dest) noexcept
 {
-#if defined(FAST_IO_IF_CONSTEVAL)
-	FAST_IO_IF_CONSTEVAL
+	if (__builtin_is_constant_evaluated())
 	{
 		return ::fast_io::details::bytes_copy_naive_n_impl(first, n, dest);
 	}
 	else
-#endif
 	{
 		if (n)
 #if __has_cpp_attribute(likely)
@@ -153,8 +147,8 @@ inline constexpr ::std::byte const *type_punning_from_bytes(::std::byte const *_
 	constexpr ::std::size_t n{sizeof(T)};
 	if constexpr (n != 0)
 	{
-#if __cpp_lib_bit_cast >= 201806L && defined(FAST_IO_IF_CONSTEVAL)
-		FAST_IO_IF_CONSTEVAL
+#if __cpp_lib_bit_cast >= 201806L
+		if (__builtin_is_constant_evaluated())
 		{
 			::std::byte buffer[n];
 			nonoverlapped_bytes_copy_n(first, n, buffer);
@@ -181,8 +175,8 @@ inline constexpr ::std::byte *type_punning_to_bytes_n(T const &__restrict first,
 {
 	if constexpr (n != 0)
 	{
-#if __cpp_lib_bit_cast >= 201806L && defined(FAST_IO_IF_CONSTEVAL)
-		FAST_IO_IF_CONSTEVAL
+#if __cpp_lib_bit_cast >= 201806L
+		if (__builtin_is_constant_evaluated())
 		{
 			auto buffer{::std::bit_cast<::fast_io::freestanding::array<::std::byte, sizeof(T)>>(first)};
 			nonoverlapped_bytes_copy_n(buffer.data(), n, dest);
@@ -211,8 +205,7 @@ inline constexpr ::std::byte *type_punning_to_bytes(T const &__restrict first, :
 
 inline constexpr ::std::byte *bytes_clear_n(::std::byte *data, ::std::size_t size) noexcept
 {
-#if defined(FAST_IO_IF_CONSTEVAL)
-	FAST_IO_IF_CONSTEVAL
+	if (__builtin_is_constant_evaluated())
 	{
 		for (::std::size_t i{}; i != size; ++i)
 		{
@@ -220,7 +213,6 @@ inline constexpr ::std::byte *bytes_clear_n(::std::byte *data, ::std::size_t siz
 		}
 	}
 	else
-#endif
 	{
 #if defined(__has_builtin)
 #if __has_builtin(__builtin_memset)
@@ -242,8 +234,7 @@ inline constexpr ::std::byte *bytes_clear(::std::byte *first, ::std::byte *last)
 
 inline constexpr ::std::byte *bytes_fill_n(::std::byte *data, ::std::size_t size, ::std::byte val) noexcept
 {
-#if defined(FAST_IO_IF_CONSTEVAL)
-	FAST_IO_IF_CONSTEVAL
+	if (__builtin_is_constant_evaluated())
 	{
 		for (::std::size_t i{}; i != size; ++i)
 		{
@@ -251,7 +242,6 @@ inline constexpr ::std::byte *bytes_fill_n(::std::byte *data, ::std::size_t size
 		}
 	}
 	else
-#endif
 	{
 #if defined(__has_builtin)
 #if __has_builtin(__builtin_memset)

--- a/include/fast_io_core_impl/freestanding/bytes.h
+++ b/include/fast_io_core_impl/freestanding/bytes.h
@@ -26,12 +26,8 @@ struct overlapped_copy_buffer_ptr
 inline constexpr ::std::byte *bytes_copy_naive_n_impl(::std::byte const *first, ::std::size_t n,
 													  ::std::byte *dest) noexcept
 {
-#if __cpp_if_consteval >= 202106L || __cpp_lib_is_constant_evaluated >= 201811L
-#if __cpp_if_consteval >= 202106L
-	if consteval
-#elif __cpp_lib_is_constant_evaluated >= 201811L
-	if (__builtin_is_constant_evaluated())
-#endif
+#if defined(FAST_IO_IF_CONSTEVAL)
+	FAST_IO_IF_CONSTEVAL
 	{
 		::fast_io::details::overlapped_copy_buffer_ptr<::std::byte> tempbuffer(n);
 		auto tempbufferptr{tempbuffer.ptr};
@@ -83,12 +79,8 @@ namespace fast_io::freestanding
 #endif
 inline constexpr ::std::byte *bytes_copy_n(::std::byte const *first, ::std::size_t n, ::std::byte *dest) noexcept
 {
-#if __cpp_if_consteval >= 202106L || __cpp_lib_is_constant_evaluated >= 201811L
-#if __cpp_if_consteval >= 202106L
-	if consteval
-#elif __cpp_lib_is_constant_evaluated >= 201811L
-	if (__builtin_is_constant_evaluated())
-#endif
+#if defined(FAST_IO_IF_CONSTEVAL)
+	FAST_IO_IF_CONSTEVAL
 	{
 		return ::fast_io::details::bytes_copy_naive_n_impl(first, n, dest);
 	}
@@ -123,12 +115,8 @@ inline constexpr ::std::byte *bytes_copy(::std::byte const *first, ::std::byte c
 inline constexpr ::std::byte *nonoverlapped_bytes_copy_n(::std::byte const *first, ::std::size_t n,
 														 ::std::byte *dest) noexcept
 {
-#if __cpp_if_consteval >= 202106L || __cpp_lib_is_constant_evaluated >= 201811L
-#if __cpp_if_consteval >= 202106L
-	if consteval
-#elif __cpp_lib_is_constant_evaluated >= 201811L
-	if (__builtin_is_constant_evaluated())
-#endif
+#if defined(FAST_IO_IF_CONSTEVAL)
+	FAST_IO_IF_CONSTEVAL
 	{
 		return ::fast_io::details::bytes_copy_naive_n_impl(first, n, dest);
 	}
@@ -165,12 +153,8 @@ inline constexpr ::std::byte const *type_punning_from_bytes(::std::byte const *_
 	constexpr ::std::size_t n{sizeof(T)};
 	if constexpr (n != 0)
 	{
-#if __cpp_lib_bit_cast >= 201806L && (__cpp_if_consteval >= 202106L || __cpp_lib_is_constant_evaluated >= 201811L)
-#if __cpp_if_consteval >= 202106L
-		if consteval
-#elif __cpp_lib_is_constant_evaluated >= 201811L
-		if (__builtin_is_constant_evaluated())
-#endif
+#if __cpp_lib_bit_cast >= 201806L && defined(FAST_IO_IF_CONSTEVAL)
+		FAST_IO_IF_CONSTEVAL
 		{
 			::std::byte buffer[n];
 			nonoverlapped_bytes_copy_n(first, n, buffer);
@@ -197,12 +181,8 @@ inline constexpr ::std::byte *type_punning_to_bytes_n(T const &__restrict first,
 {
 	if constexpr (n != 0)
 	{
-#if __cpp_lib_bit_cast >= 201806L && (__cpp_if_consteval >= 202106L || __cpp_lib_is_constant_evaluated >= 201811L)
-#if __cpp_if_consteval >= 202106L
-		if consteval
-#elif __cpp_lib_is_constant_evaluated >= 201811L
-		if (__builtin_is_constant_evaluated())
-#endif
+#if __cpp_lib_bit_cast >= 201806L && defined(FAST_IO_IF_CONSTEVAL)
+		FAST_IO_IF_CONSTEVAL
 		{
 			auto buffer{::std::bit_cast<::fast_io::freestanding::array<::std::byte, sizeof(T)>>(first)};
 			nonoverlapped_bytes_copy_n(buffer.data(), n, dest);
@@ -231,12 +211,8 @@ inline constexpr ::std::byte *type_punning_to_bytes(T const &__restrict first, :
 
 inline constexpr ::std::byte *bytes_clear_n(::std::byte *data, ::std::size_t size) noexcept
 {
-#if __cpp_if_consteval >= 202106L || __cpp_lib_is_constant_evaluated >= 201811L
-#if __cpp_if_consteval >= 202106L
-	if consteval
-#elif __cpp_lib_is_constant_evaluated >= 201811L
-	if (__builtin_is_constant_evaluated())
-#endif
+#if defined(FAST_IO_IF_CONSTEVAL)
+	FAST_IO_IF_CONSTEVAL
 	{
 		for (::std::size_t i{}; i != size; ++i)
 		{
@@ -266,12 +242,8 @@ inline constexpr ::std::byte *bytes_clear(::std::byte *first, ::std::byte *last)
 
 inline constexpr ::std::byte *bytes_fill_n(::std::byte *data, ::std::size_t size, ::std::byte val) noexcept
 {
-#if __cpp_if_consteval >= 202106L || __cpp_lib_is_constant_evaluated >= 201811L
-#if __cpp_if_consteval >= 202106L
-	if consteval
-#elif __cpp_lib_is_constant_evaluated >= 201811L
-	if (__builtin_is_constant_evaluated())
-#endif
+#if defined(FAST_IO_IF_CONSTEVAL)
+	FAST_IO_IF_CONSTEVAL
 	{
 		for (::std::size_t i{}; i != size; ++i)
 		{

--- a/include/fast_io_core_impl/freestanding/cstr_len.h
+++ b/include/fast_io_core_impl/freestanding/cstr_len.h
@@ -31,13 +31,11 @@ inline constexpr ::std::size_t dummy_cstr_nlen(char_type const *cstr, ::std::siz
 template <::std::integral char_type>
 inline constexpr ::std::size_t cstr_len(char_type const *cstr) noexcept
 {
-#if defined(FAST_IO_IF_CONSTEVAL)
-	FAST_IO_IF_CONSTEVAL
+	if (__builtin_is_constant_evaluated())
 	{
 		return details::dummy_cstr_len(cstr);
 	}
 	else
-#endif
 	{
 		if constexpr (::std::same_as<char_type, char>)
 		{
@@ -61,13 +59,11 @@ inline constexpr ::std::size_t cstr_len(char_type const *cstr) noexcept
 template <::std::integral char_type>
 inline constexpr ::std::size_t cstr_nlen(char_type const *cstr, ::std::size_t n) noexcept
 {
-#if defined(FAST_IO_IF_CONSTEVAL)
-	FAST_IO_IF_CONSTEVAL
+	if (__builtin_is_constant_evaluated())
 	{
 		return details::dummy_cstr_nlen(cstr, n);
 	}
 	else
-#endif
 	{
 		if constexpr (::std::same_as<char_type, char>)
 		{

--- a/include/fast_io_core_impl/freestanding/cstr_len.h
+++ b/include/fast_io_core_impl/freestanding/cstr_len.h
@@ -31,18 +31,13 @@ inline constexpr ::std::size_t dummy_cstr_nlen(char_type const *cstr, ::std::siz
 template <::std::integral char_type>
 inline constexpr ::std::size_t cstr_len(char_type const *cstr) noexcept
 {
-#if __cpp_if_consteval >= 202106L
-	if consteval
+#if defined(FAST_IO_IF_CONSTEVAL)
+	FAST_IO_IF_CONSTEVAL
 	{
 		return details::dummy_cstr_len(cstr);
 	}
-#else
-	if (__builtin_is_constant_evaluated())
-	{
-		return details::dummy_cstr_len(cstr);
-	}
-#endif
 	else
+#endif
 	{
 		if constexpr (::std::same_as<char_type, char>)
 		{
@@ -66,18 +61,13 @@ inline constexpr ::std::size_t cstr_len(char_type const *cstr) noexcept
 template <::std::integral char_type>
 inline constexpr ::std::size_t cstr_nlen(char_type const *cstr, ::std::size_t n) noexcept
 {
-#if __cpp_if_consteval >= 202106L
-	if consteval
+#if defined(FAST_IO_IF_CONSTEVAL)
+	FAST_IO_IF_CONSTEVAL
 	{
 		return details::dummy_cstr_nlen(cstr, n);
 	}
-#else
-	if (__builtin_is_constant_evaluated())
-	{
-		return details::dummy_cstr_nlen(cstr, n);
-	}
-#endif
 	else
+#endif
 	{
 		if constexpr (::std::same_as<char_type, char>)
 		{

--- a/include/fast_io_core_impl/freestanding/noexcept_call.h
+++ b/include/fast_io_core_impl/freestanding/noexcept_call.h
@@ -55,13 +55,11 @@ inline
 #endif
 	decltype(auto) noexcept_call(F *f, Args &&...args) noexcept
 {
-#if defined(FAST_IO_IF_CONSTEVAL)
-	FAST_IO_IF_CONSTEVAL
+	if (__builtin_is_constant_evaluated())
 	{
 		return f(::std::forward<Args>(args)...); // EH unwinding does not matter here
 	}
 	else
-#endif
 	{
 		return noexcept_cast(f)(::std::forward<Args>(args)...);
 	}

--- a/include/fast_io_core_impl/freestanding/noexcept_call.h
+++ b/include/fast_io_core_impl/freestanding/noexcept_call.h
@@ -55,25 +55,16 @@ inline
 #endif
 	decltype(auto) noexcept_call(F *f, Args &&...args) noexcept
 {
-#if __cpp_if_consteval >= 202106L
-	if consteval
-	{
-		return f(::std::forward<Args>(args)...); // EH unwinding does not matter here
-	}
-	else
-	{
-		return noexcept_cast(f)(::std::forward<Args>(args)...);
-	}
-#else
-#if __cpp_lib_is_constant_evaluated >= 201811
-	if (__builtin_is_constant_evaluated())
+#if defined(FAST_IO_IF_CONSTEVAL)
+	FAST_IO_IF_CONSTEVAL
 	{
 		return f(::std::forward<Args>(args)...); // EH unwinding does not matter here
 	}
 	else
 #endif
+	{
 		return noexcept_cast(f)(::std::forward<Args>(args)...);
-#endif
+	}
 }
 
 } // namespace freestanding

--- a/include/fast_io_core_impl/integers/crypto_hash.h
+++ b/include/fast_io_core_impl/integers/crypto_hash.h
@@ -333,12 +333,8 @@ inline constexpr char_type *copy_to_hash_df_commom_impl(char_type *iter, ::std::
 {
 	if constexpr (d == ::fast_io::manipulators::digest_format::raw_bytes)
 	{
-#if (__cpp_if_consteval >= 202106L || __cpp_lib_is_constant_evaluated >= 201811L) && __cpp_lib_bit_cast >= 201806L
-#if __cpp_if_consteval >= 202106L
-		if consteval
-#else
-		if (__builtin_is_constant_evaluated())
-#endif
+#if defined(FAST_IO_IF_CONSTEVAL) && __cpp_lib_bit_cast >= 201806L
+		FAST_IO_IF_CONSTEVAL
 		{
 			for (::std::size_t i{}; i != digest_size; ++i)
 			{
@@ -417,12 +413,8 @@ inline constexpr Iter prv_srv_hash_df_impl(Iter iter, T const &t) noexcept
 		using char_type = ::std::iter_value_t<Iter>;
 		if constexpr (d == ::fast_io::manipulators::digest_format::raw_bytes)
 		{
-#if __cpp_if_consteval >= 202106L || __cpp_lib_is_constant_evaluated >= 201811L
-#if __cpp_if_consteval >= 202106L
-			if consteval
-#else
-			if (__builtin_is_constant_evaluated())
-#endif
+#if defined(FAST_IO_IF_CONSTEVAL)
+			FAST_IO_IF_CONSTEVAL
 			{
 				return ::fast_io::details::prv_srv_hash_df_common_impl<d>(iter, t);
 			}
@@ -483,12 +475,8 @@ inline constexpr char_type *prv_srv_hash_compress_df_impl(char_type *iter, ::std
 	{
 		if constexpr (d == ::fast_io::manipulators::digest_format::raw_bytes)
 		{
-#if __cpp_if_consteval >= 202106L || __cpp_lib_is_constant_evaluated >= 201811L
-#if __cpp_if_consteval >= 202106L
-			if consteval
-#else
-			if (__builtin_is_constant_evaluated())
-#endif
+#if defined(FAST_IO_IF_CONSTEVAL)
+			FAST_IO_IF_CONSTEVAL
 			{
 				::std::byte buffer[digest_size];
 				auto ret{cal_hash_internal_impl<T>(base, len, buffer)};
@@ -523,12 +511,8 @@ inline constexpr char_type *prv_srv_hash_compress_df_impl(char_type *iter, ::std
 	{
 		if constexpr (d == ::fast_io::manipulators::digest_format::raw_bytes)
 		{
-#if __cpp_if_consteval >= 202106L || __cpp_lib_is_constant_evaluated >= 201811L
-#if __cpp_if_consteval >= 202106L
-			if consteval
-#else
-			if (__builtin_is_constant_evaluated())
-#endif
+#if defined(FAST_IO_IF_CONSTEVAL)
+			FAST_IO_IF_CONSTEVAL
 			{
 				::std::byte buffer[digest_size];
 				cal_hash_internal<T>(base, len, buffer);

--- a/include/fast_io_core_impl/integers/crypto_hash.h
+++ b/include/fast_io_core_impl/integers/crypto_hash.h
@@ -333,8 +333,8 @@ inline constexpr char_type *copy_to_hash_df_commom_impl(char_type *iter, ::std::
 {
 	if constexpr (d == ::fast_io::manipulators::digest_format::raw_bytes)
 	{
-#if defined(FAST_IO_IF_CONSTEVAL) && __cpp_lib_bit_cast >= 201806L
-		FAST_IO_IF_CONSTEVAL
+#if __cpp_lib_bit_cast >= 201806L
+		if (__builtin_is_constant_evaluated())
 		{
 			for (::std::size_t i{}; i != digest_size; ++i)
 			{
@@ -413,13 +413,11 @@ inline constexpr Iter prv_srv_hash_df_impl(Iter iter, T const &t) noexcept
 		using char_type = ::std::iter_value_t<Iter>;
 		if constexpr (d == ::fast_io::manipulators::digest_format::raw_bytes)
 		{
-#if defined(FAST_IO_IF_CONSTEVAL)
-			FAST_IO_IF_CONSTEVAL
+			if (__builtin_is_constant_evaluated())
 			{
 				return ::fast_io::details::prv_srv_hash_df_common_impl<d>(iter, t);
 			}
 			else
-#endif
 			{
 				if constexpr (sizeof(char_type) == 1 && ::std::is_pointer_v<Iter>)
 				{
@@ -475,8 +473,7 @@ inline constexpr char_type *prv_srv_hash_compress_df_impl(char_type *iter, ::std
 	{
 		if constexpr (d == ::fast_io::manipulators::digest_format::raw_bytes)
 		{
-#if defined(FAST_IO_IF_CONSTEVAL)
-			FAST_IO_IF_CONSTEVAL
+			if (__builtin_is_constant_evaluated())
 			{
 				::std::byte buffer[digest_size];
 				auto ret{cal_hash_internal_impl<T>(base, len, buffer)};
@@ -484,7 +481,6 @@ inline constexpr char_type *prv_srv_hash_compress_df_impl(char_type *iter, ::std
 					   ::fast_io::manipulators::digest_format::upper > (buffer, iter, static_cast<::std::size_t>(ret - buffer));
 			}
 			else
-#endif
 			{
 				if constexpr (sizeof(char_type) == 1)
 				{
@@ -511,8 +507,7 @@ inline constexpr char_type *prv_srv_hash_compress_df_impl(char_type *iter, ::std
 	{
 		if constexpr (d == ::fast_io::manipulators::digest_format::raw_bytes)
 		{
-#if defined(FAST_IO_IF_CONSTEVAL)
-			FAST_IO_IF_CONSTEVAL
+			if (__builtin_is_constant_evaluated())
 			{
 				::std::byte buffer[digest_size];
 				cal_hash_internal<T>(base, len, buffer);
@@ -520,7 +515,6 @@ inline constexpr char_type *prv_srv_hash_compress_df_impl(char_type *iter, ::std
 					   ::fast_io::manipulators::digest_format::upper > (buffer, iter, digest_size);
 			}
 			else
-#endif
 			{
 				if constexpr (sizeof(char_type) == 1)
 				{

--- a/include/fast_io_core_impl/intrinsics.h
+++ b/include/fast_io_core_impl/intrinsics.h
@@ -19,12 +19,8 @@ inline
 #endif
 	void typed_memcpy(T1 *dest, T2 const *src, ::std::size_t bytes) noexcept
 {
-#if (__cpp_if_consteval >= 202106L || __cpp_lib_is_constant_evaluated >= 201811L) && __cpp_lib_bit_cast >= 201806L
-#if __cpp_if_consteval >= 202106L
-	if consteval
-#else
-	if (__builtin_is_constant_evaluated())
-#endif
+#if defined(FAST_IO_IF_CONSTEVAL) && __cpp_lib_bit_cast >= 201806L
+	FAST_IO_IF_CONSTEVAL
 	{
 		if (dest == nullptr || src == nullptr || sizeof(T1) != sizeof(T2) || bytes % sizeof(T1) != 0)
 		{
@@ -202,14 +198,8 @@ inline constexpr bool add_carry(bool carry, T a, T b, T &out) noexcept
 	}
 	else
 	{
-#if __cpp_if_consteval >= 202106L
-		if consteval
-		{
-			return add_carry_naive(carry, a, b, out);
-		}
-		else
-#elif __cpp_lib_is_constant_evaluated >= 201811L
-		if (__builtin_is_constant_evaluated())
+#if defined(FAST_IO_IF_CONSTEVAL)
+		FAST_IO_IF_CONSTEVAL
 		{
 			return add_carry_naive(carry, a, b, out);
 		}
@@ -396,13 +386,8 @@ inline constexpr bool sub_borrow(bool borrow, T a, T b, T &out) noexcept
 	}
 	else
 	{
-#if __cpp_if_consteval >= 202106L
-		if consteval
-		{
-			return sub_borrow_naive(borrow, a, b, out);
-		}
-#elif __cpp_lib_is_constant_evaluated >= 201811L
-		if (__builtin_is_constant_evaluated())
+#if defined(FAST_IO_IF_CONSTEVAL)
+		FAST_IO_IF_CONSTEVAL
 		{
 			return sub_borrow_naive(borrow, a, b, out);
 		}
@@ -622,23 +607,14 @@ inline
 	umul(::std::uint_least64_t a, ::std::uint_least64_t b, ::std::uint_least64_t &high) noexcept
 {
 #ifdef __SIZEOF_INT128__
-#if __cpp_if_consteval >= 202106L
-	if consteval
+#if defined(FAST_IO_IF_CONSTEVAL)
+	FAST_IO_IF_CONSTEVAL
 	{
 		__uint128_t res{static_cast<__uint128_t>(a) * b};
 		high = static_cast<::std::uint_least64_t>(res >> 64u);
 		return static_cast<::std::uint_least64_t>(res);
 	}
 	else
-#elif __cpp_lib_is_constant_evaluated >= 201811L
-	if (__builtin_is_constant_evaluated())
-	{
-		__uint128_t res{static_cast<__uint128_t>(a) * b};
-		high = static_cast<::std::uint_least64_t>(res >> 64u);
-		return static_cast<::std::uint_least64_t>(res);
-	}
-	else
-
 #endif
 	{
 #if defined(__has_builtin)
@@ -743,14 +719,8 @@ inline
 	};
 	return static_cast<::std::uint_least64_t>((static_cast<__uint128_t>(a) * b) >> ul64bits);
 #elif defined(_MSC_VER) && defined(_M_X64) && !defined(_M_ARM64EC)
-#if __cpp_if_consteval >= 202106L && 0
-	if consteval
-	{
-		return umul_least64_high_emulated(a, b);
-	}
-	else
-#elif __cpp_lib_is_constant_evaluated >= 201811L
-	if (__builtin_is_constant_evaluated())
+#if defined(FAST_IO_IF_CONSTEVAL)
+	FAST_IO_IF_CONSTEVAL
 	{
 		return umul_least64_high_emulated(a, b);
 	}

--- a/include/fast_io_core_impl/intrinsics.h
+++ b/include/fast_io_core_impl/intrinsics.h
@@ -19,8 +19,8 @@ inline
 #endif
 	void typed_memcpy(T1 *dest, T2 const *src, ::std::size_t bytes) noexcept
 {
-#if defined(FAST_IO_IF_CONSTEVAL) && __cpp_lib_bit_cast >= 201806L
-	FAST_IO_IF_CONSTEVAL
+#if __cpp_lib_bit_cast >= 201806L
+	if (__builtin_is_constant_evaluated())
 	{
 		if (dest == nullptr || src == nullptr || sizeof(T1) != sizeof(T2) || bytes % sizeof(T1) != 0)
 		{
@@ -198,13 +198,11 @@ inline constexpr bool add_carry(bool carry, T a, T b, T &out) noexcept
 	}
 	else
 	{
-#if defined(FAST_IO_IF_CONSTEVAL)
-		FAST_IO_IF_CONSTEVAL
+		if (__builtin_is_constant_evaluated())
 		{
 			return add_carry_naive(carry, a, b, out);
 		}
 		else
-#endif
 		{
 #if defined(_MSC_VER) && !defined(__clang__)
 #if (defined(_M_IX86) || defined(_M_AMD64))
@@ -386,13 +384,11 @@ inline constexpr bool sub_borrow(bool borrow, T a, T b, T &out) noexcept
 	}
 	else
 	{
-#if defined(FAST_IO_IF_CONSTEVAL)
-		FAST_IO_IF_CONSTEVAL
+		if (__builtin_is_constant_evaluated())
 		{
 			return sub_borrow_naive(borrow, a, b, out);
 		}
 		else
-#endif
 		{
 #if defined(_MSC_VER) && !defined(__clang__)
 #if (defined(_M_IX86) || defined(_M_AMD64))
@@ -607,15 +603,13 @@ inline
 	umul(::std::uint_least64_t a, ::std::uint_least64_t b, ::std::uint_least64_t &high) noexcept
 {
 #ifdef __SIZEOF_INT128__
-#if defined(FAST_IO_IF_CONSTEVAL)
-	FAST_IO_IF_CONSTEVAL
+	if (__builtin_is_constant_evaluated())
 	{
 		__uint128_t res{static_cast<__uint128_t>(a) * b};
 		high = static_cast<::std::uint_least64_t>(res >> 64u);
 		return static_cast<::std::uint_least64_t>(res);
 	}
 	else
-#endif
 	{
 #if defined(__has_builtin)
 		if constexpr (::std::endian::native == ::std::endian::little || ::std::endian::native == ::std::endian::big)
@@ -719,13 +713,11 @@ inline
 	};
 	return static_cast<::std::uint_least64_t>((static_cast<__uint128_t>(a) * b) >> ul64bits);
 #elif defined(_MSC_VER) && defined(_M_X64) && !defined(_M_ARM64EC)
-#if defined(FAST_IO_IF_CONSTEVAL)
-	FAST_IO_IF_CONSTEVAL
+	if (__builtin_is_constant_evaluated())
 	{
 		return umul_least64_high_emulated(a, b);
 	}
 	else
-#endif
 	{
 		return __umulh(a, b);
 	}

--- a/include/fast_io_core_impl/intrinsics/umul.h
+++ b/include/fast_io_core_impl/intrinsics/umul.h
@@ -389,15 +389,13 @@ inline constexpr T umul(U a, T b, U &high) noexcept
 	else if constexpr (sizeof(T) == sizeof(::std::uint_least64_t))
 	{
 #ifdef __SIZEOF_INT128__
-#if defined(FAST_IO_IF_CONSTEVAL)
-		FAST_IO_IF_CONSTEVAL
+		if (__builtin_is_constant_evaluated())
 		{
 			__uint128_t res{a * static_cast<__uint128_t>(b)};
 			high = static_cast<U>(res >> 64u);
 			return static_cast<T>(res);
 		}
 		else
-#endif
 		{
 #if defined(__cpp_lib_bit_cast)
 			if constexpr (::std::endian::native == ::std::endian::little || ::std::endian::native == ::std::endian::big)
@@ -415,13 +413,11 @@ inline constexpr T umul(U a, T b, U &high) noexcept
 			}
 		}
 #elif defined(_MSC_VER) && defined(_M_X64) && !defined(__arm64ec__) && !defined(_M_ARM64EC)
-#if defined(FAST_IO_IF_CONSTEVAL)
-		FAST_IO_IF_CONSTEVAL
+		if (__builtin_is_constant_evaluated())
 		{
 			return ::fast_io::intrinsics::details::umul_least64_generic_emulated(a, b, high);
 		}
 		else
-#endif
 		{
 			if constexpr (sizeof(U) == sizeof(::std::uint_least64_t))
 			{
@@ -492,14 +488,12 @@ inline constexpr U umulh(U a, T b) noexcept
 	else if constexpr (sizeof(T) == sizeof(::std::uint_least64_t))
 	{
 #ifdef __SIZEOF_INT128__
-#if defined(FAST_IO_IF_CONSTEVAL)
-		FAST_IO_IF_CONSTEVAL
+		if (__builtin_is_constant_evaluated())
 		{
 			__uint128_t res{a * static_cast<__uint128_t>(b)};
 			return static_cast<U>(res >> 64u);
 		}
 		else
-#endif
 		{
 #if defined(__cpp_lib_bit_cast)
 			if constexpr (::std::endian::native == ::std::endian::little || ::std::endian::native == ::std::endian::big)
@@ -515,13 +509,11 @@ inline constexpr U umulh(U a, T b) noexcept
 			}
 		}
 #elif defined(_MSC_VER) && defined(_M_X64) && !defined(__arm64ec__) && !defined(_M_ARM64EC)
-#if defined(FAST_IO_IF_CONSTEVAL)
-		FAST_IO_IF_CONSTEVAL
+		if (__builtin_is_constant_evaluated())
 		{
 			return ::fast_io::intrinsics::details::umulh_least64_generic_emulated(a, b);
 		}
 		else
-#endif
 		{
 			return static_cast<U>(::fast_io::intrinsics::msvc::x86::__umulh(a, b));
 		}

--- a/include/fast_io_core_impl/intrinsics/umul.h
+++ b/include/fast_io_core_impl/intrinsics/umul.h
@@ -389,12 +389,8 @@ inline constexpr T umul(U a, T b, U &high) noexcept
 	else if constexpr (sizeof(T) == sizeof(::std::uint_least64_t))
 	{
 #ifdef __SIZEOF_INT128__
-#if defined(__cpp_lib_is_constant_evaluated) || defined(__cpp_if_consteval)
-#if defined(__cpp_if_consteval)
-		if consteval
-#else
-		if (__builtin_is_constant_evaluated())
-#endif
+#if defined(FAST_IO_IF_CONSTEVAL)
+		FAST_IO_IF_CONSTEVAL
 		{
 			__uint128_t res{a * static_cast<__uint128_t>(b)};
 			high = static_cast<U>(res >> 64u);
@@ -419,12 +415,8 @@ inline constexpr T umul(U a, T b, U &high) noexcept
 			}
 		}
 #elif defined(_MSC_VER) && defined(_M_X64) && !defined(__arm64ec__) && !defined(_M_ARM64EC)
-#if defined(__cpp_lib_is_constant_evaluated) || defined(__cpp_if_consteval)
-#if defined(__cpp_if_consteval)
-		if consteval
-#else
-		if (__builtin_is_constant_evaluated())
-#endif
+#if defined(FAST_IO_IF_CONSTEVAL)
+		FAST_IO_IF_CONSTEVAL
 		{
 			return ::fast_io::intrinsics::details::umul_least64_generic_emulated(a, b, high);
 		}
@@ -500,12 +492,8 @@ inline constexpr U umulh(U a, T b) noexcept
 	else if constexpr (sizeof(T) == sizeof(::std::uint_least64_t))
 	{
 #ifdef __SIZEOF_INT128__
-#if defined(__cpp_lib_is_constant_evaluated) || defined(__cpp_if_consteval)
-#if defined(__cpp_if_consteval)
-		if consteval
-#else
-		if (__builtin_is_constant_evaluated())
-#endif
+#if defined(FAST_IO_IF_CONSTEVAL)
+		FAST_IO_IF_CONSTEVAL
 		{
 			__uint128_t res{a * static_cast<__uint128_t>(b)};
 			return static_cast<U>(res >> 64u);
@@ -527,12 +515,8 @@ inline constexpr U umulh(U a, T b) noexcept
 			}
 		}
 #elif defined(_MSC_VER) && defined(_M_X64) && !defined(__arm64ec__) && !defined(_M_ARM64EC)
-#if defined(__cpp_lib_is_constant_evaluated) || defined(__cpp_if_consteval)
-#if defined(__cpp_if_consteval)
-		if consteval
-#else
-		if (__builtin_is_constant_evaluated())
-#endif
+#if defined(FAST_IO_IF_CONSTEVAL)
+		FAST_IO_IF_CONSTEVAL
 		{
 			return ::fast_io::intrinsics::details::umulh_least64_generic_emulated(a, b);
 		}

--- a/include/fast_io_core_impl/local_new_array_ptr.h
+++ b/include/fast_io_core_impl/local_new_array_ptr.h
@@ -5,13 +5,8 @@ namespace fast_io::details
 template <typename char_type, typename allocator = ::fast_io::native_thread_local_allocator>
 inline constexpr char_type *allocate_iobuf_space(::std::size_t buffer_size) noexcept
 {
-#if __cpp_constexpr >= 201907L && __cpp_constexpr_dynamic_alloc >= 201907L && \
-	(__cpp_lib_is_constant_evaluated >= 201811L || __cpp_if_consteval >= 202106L)
-#if __cpp_if_consteval >= 202106L
-	if consteval
-#else
-	if (__builtin_is_constant_evaluated())
-#endif
+#if __cpp_constexpr >= 201907L && __cpp_constexpr_dynamic_alloc >= 201907L && defined(FAST_IO_IF_CONSTEVAL)
+	FAST_IO_IF_CONSTEVAL
 	{
 		return new char_type[buffer_size];
 	}
@@ -42,13 +37,8 @@ inline void deallocate_with_secure_clear(void *ptr, [[maybe_unused]] ::std::size
 template <bool nsecure_clear, typename char_type, typename allocator = ::fast_io::native_thread_local_allocator>
 inline constexpr void deallocate_iobuf_space(char_type *ptr, [[maybe_unused]] ::std::size_t buffer_size) noexcept
 {
-#if __cpp_constexpr >= 201907L && __cpp_constexpr_dynamic_alloc >= 201907L && \
-	(__cpp_lib_is_constant_evaluated >= 201811L || __cpp_if_consteval >= 202106L)
-#if __cpp_if_consteval >= 202106L
-	if consteval
-#else
-	if (__builtin_is_constant_evaluated())
-#endif
+#if __cpp_constexpr >= 201907L && __cpp_constexpr_dynamic_alloc >= 201907L && defined(FAST_IO_IF_CONSTEVAL)
+	FAST_IO_IF_CONSTEVAL
 	{
 		delete[] ptr;
 	}

--- a/include/fast_io_core_impl/local_new_array_ptr.h
+++ b/include/fast_io_core_impl/local_new_array_ptr.h
@@ -5,8 +5,8 @@ namespace fast_io::details
 template <typename char_type, typename allocator = ::fast_io::native_thread_local_allocator>
 inline constexpr char_type *allocate_iobuf_space(::std::size_t buffer_size) noexcept
 {
-#if __cpp_constexpr >= 201907L && __cpp_constexpr_dynamic_alloc >= 201907L && defined(FAST_IO_IF_CONSTEVAL)
-	FAST_IO_IF_CONSTEVAL
+#if __cpp_constexpr >= 201907L && __cpp_constexpr_dynamic_alloc >= 201907L
+	if (__builtin_is_constant_evaluated())
 	{
 		return new char_type[buffer_size];
 	}
@@ -37,8 +37,8 @@ inline void deallocate_with_secure_clear(void *ptr, [[maybe_unused]] ::std::size
 template <bool nsecure_clear, typename char_type, typename allocator = ::fast_io::native_thread_local_allocator>
 inline constexpr void deallocate_iobuf_space(char_type *ptr, [[maybe_unused]] ::std::size_t buffer_size) noexcept
 {
-#if __cpp_constexpr >= 201907L && __cpp_constexpr_dynamic_alloc >= 201907L && defined(FAST_IO_IF_CONSTEVAL)
-	FAST_IO_IF_CONSTEVAL
+#if __cpp_constexpr >= 201907L && __cpp_constexpr_dynamic_alloc >= 201907L
+	if (__builtin_is_constant_evaluated())
 	{
 		delete[] ptr;
 	}

--- a/include/fast_io_core_impl/operations/common.h
+++ b/include/fast_io_core_impl/operations/common.h
@@ -58,13 +58,11 @@ template <typename T>
 inline constexpr scatter_total_size_overflow_result find_scatter_total_size_overflow(basic_io_scatter_t<T> const *base,
 																					 ::std::size_t len) noexcept
 {
-#if defined(FAST_IO_IF_CONSTEVAL)
-	FAST_IO_IF_CONSTEVAL
+	if (__builtin_is_constant_evaluated())
 	{
 		return ::fast_io::details::find_scatter_total_size_overflow_impl<::std::size_t>(base, len);
 	}
 	else
-#endif
 	{
 		using io_scatter_alias_ptr
 
@@ -193,13 +191,11 @@ template <typename T>
 inline constexpr ::fast_io::intfpos_t fposoffadd_scatters(::fast_io::intfpos_t off, basic_io_scatter_t<T> const *base,
 														  io_scatter_status_t status) noexcept
 {
-#if defined(FAST_IO_IF_CONSTEVAL)
-	FAST_IO_IF_CONSTEVAL
+	if (__builtin_is_constant_evaluated())
 	{
 		return ::fast_io::details::fposoffadd_scatters_impl(off, base, status.position, status.position_in_scatter);
 	}
 	else
-#endif
 	{
 		using io_scatter_alias_ptr
 

--- a/include/fast_io_core_impl/operations/common.h
+++ b/include/fast_io_core_impl/operations/common.h
@@ -58,15 +58,13 @@ template <typename T>
 inline constexpr scatter_total_size_overflow_result find_scatter_total_size_overflow(basic_io_scatter_t<T> const *base,
 																					 ::std::size_t len) noexcept
 {
-#if __cpp_if_consteval >= 202106L
-	if consteval
-#else
-	if (__builtin_is_constant_evaluated())
-#endif
+#if defined(FAST_IO_IF_CONSTEVAL)
+	FAST_IO_IF_CONSTEVAL
 	{
 		return ::fast_io::details::find_scatter_total_size_overflow_impl<::std::size_t>(base, len);
 	}
 	else
+#endif
 	{
 		using io_scatter_alias_ptr
 
@@ -195,15 +193,13 @@ template <typename T>
 inline constexpr ::fast_io::intfpos_t fposoffadd_scatters(::fast_io::intfpos_t off, basic_io_scatter_t<T> const *base,
 														  io_scatter_status_t status) noexcept
 {
-#if __cpp_if_consteval >= 202106L
-	if consteval
-#else
-	if (__builtin_is_constant_evaluated())
-#endif
+#if defined(FAST_IO_IF_CONSTEVAL)
+	FAST_IO_IF_CONSTEVAL
 	{
 		return ::fast_io::details::fposoffadd_scatters_impl(off, base, status.position, status.position_in_scatter);
 	}
 	else
+#endif
 	{
 		using io_scatter_alias_ptr
 

--- a/include/fast_io_core_impl/operations/writeimpl/range.h
+++ b/include/fast_io_core_impl/operations/writeimpl/range.h
@@ -29,12 +29,8 @@ bytes_copy_punning_impl(FromItbg fromfirst, FromIted fromlast, ToIter tofirst, T
 		else
 		{
 			constexpr ::std::size_t quoti{sizeof(fromvaluetype) / sizeof(tovaluetype)};
-#if __cpp_if_consteval >= 202106L || __cpp_lib_is_constant_evaluated >= 201811L
-#if __cpp_if_consteval >= 202106L
-			if consteval
-#elif __cpp_lib_is_constant_evaluated >= 201811L
-			if (__builtin_is_constant_evaluated())
-#endif
+#if defined(FAST_IO_IF_CONSTEVAL)
+			FAST_IO_IF_CONSTEVAL
 			{
 				auto arr{::std::bit_cast<::fast_io::freestanding::array<fromvaluetype, quoti>>(*fromfirst)};
 				::fast_io::details::non_overlapped_copy(arr.data(), arr.data() + arr.size(), tofirst);

--- a/include/fast_io_core_impl/operations/writeimpl/range.h
+++ b/include/fast_io_core_impl/operations/writeimpl/range.h
@@ -29,14 +29,12 @@ bytes_copy_punning_impl(FromItbg fromfirst, FromIted fromlast, ToIter tofirst, T
 		else
 		{
 			constexpr ::std::size_t quoti{sizeof(fromvaluetype) / sizeof(tovaluetype)};
-#if defined(FAST_IO_IF_CONSTEVAL)
-			FAST_IO_IF_CONSTEVAL
+			if (__builtin_is_constant_evaluated())
 			{
 				auto arr{::std::bit_cast<::fast_io::freestanding::array<fromvaluetype, quoti>>(*fromfirst)};
 				::fast_io::details::non_overlapped_copy(arr.data(), arr.data() + arr.size(), tofirst);
 			}
 			else
-#endif
 			{
 				::fast_io::freestanding::bytes_copy_n(reinterpret_cast<::std::byte const *>(fromfirst),
 													  sizeof(fromvaluetype), reinterpret_cast<::std::byte *>(tofirst));

--- a/include/fast_io_core_impl/secure_clear_guard.h
+++ b/include/fast_io_core_impl/secure_clear_guard.h
@@ -43,8 +43,7 @@ inline
 	void
 	none_secure_clear(::std::byte *data, ::std::size_t size) noexcept
 {
-#if defined(FAST_IO_IF_CONSTEVAL)
-	FAST_IO_IF_CONSTEVAL
+	if (__builtin_is_constant_evaluated())
 	{
 		for (::std::size_t i{}; i != size; ++i)
 		{
@@ -52,7 +51,6 @@ inline
 		}
 	}
 	else
-#endif
 	{
 #if defined(__has_builtin)
 #if __has_builtin(__builtin_memset)
@@ -105,8 +103,7 @@ namespace freestanding
 
 inline constexpr ::std::byte *bytes_secure_clear_n(::std::byte *data, ::std::size_t size) noexcept
 {
-#if defined(FAST_IO_IF_CONSTEVAL)
-	FAST_IO_IF_CONSTEVAL
+	if (__builtin_is_constant_evaluated())
 	{
 		for (::std::size_t i{}; i != size; ++i)
 		{
@@ -114,7 +111,6 @@ inline constexpr ::std::byte *bytes_secure_clear_n(::std::byte *data, ::std::siz
 		}
 	}
 	else
-#endif
 	{
 #if defined(_MSC_VER) && !defined(__clang__)
 		/*

--- a/include/fast_io_core_impl/secure_clear_guard.h
+++ b/include/fast_io_core_impl/secure_clear_guard.h
@@ -43,12 +43,8 @@ inline
 	void
 	none_secure_clear(::std::byte *data, ::std::size_t size) noexcept
 {
-#if __cpp_if_consteval >= 202106L || __cpp_lib_is_constant_evaluated >= 201811L
-#if __cpp_if_consteval >= 202106L
-	if consteval
-#elif __cpp_lib_is_constant_evaluated >= 201811L
-	if (__builtin_is_constant_evaluated())
-#endif
+#if defined(FAST_IO_IF_CONSTEVAL)
+	FAST_IO_IF_CONSTEVAL
 	{
 		for (::std::size_t i{}; i != size; ++i)
 		{
@@ -109,12 +105,8 @@ namespace freestanding
 
 inline constexpr ::std::byte *bytes_secure_clear_n(::std::byte *data, ::std::size_t size) noexcept
 {
-#if __cpp_if_consteval >= 202106L || __cpp_lib_is_constant_evaluated >= 201811L
-#if __cpp_if_consteval >= 202106L && (!defined(_MSC_VER) || defined(__clang__))
-	if consteval
-#elif __cpp_lib_is_constant_evaluated >= 201811L
-	if (__builtin_is_constant_evaluated())
-#endif
+#if defined(FAST_IO_IF_CONSTEVAL)
+	FAST_IO_IF_CONSTEVAL
 	{
 		for (::std::size_t i{}; i != size; ++i)
 		{

--- a/include/fast_io_core_impl/simd/mask_countr.h
+++ b/include/fast_io_core_impl/simd/mask_countr.h
@@ -97,12 +97,8 @@ inline
 	unsigned
 	vector_mask_countr_common_intrinsics_impl(::fast_io::intrinsics::simd_vector<T, n> const &vec) noexcept
 {
-#if __cpp_if_consteval >= 202106L || __cpp_lib_is_constant_evaluated >= 201811L
-#if __cpp_if_consteval >= 202106L
-	if consteval
-#elif __cpp_lib_is_constant_evaluated >= 201811L
-	if (__builtin_is_constant_evaluated())
-#endif
+#if defined(FAST_IO_IF_CONSTEVAL)
+	FAST_IO_IF_CONSTEVAL
 	{
 		return vector_mask_countr_common_no_intrinsics_impl<ctzero>(vec);
 	}

--- a/include/fast_io_core_impl/simd/mask_countr.h
+++ b/include/fast_io_core_impl/simd/mask_countr.h
@@ -97,12 +97,10 @@ inline
 	unsigned
 	vector_mask_countr_common_intrinsics_impl(::fast_io::intrinsics::simd_vector<T, n> const &vec) noexcept
 {
-#if defined(FAST_IO_IF_CONSTEVAL)
-	FAST_IO_IF_CONSTEVAL
+	if (__builtin_is_constant_evaluated())
 	{
 		return vector_mask_countr_common_no_intrinsics_impl<ctzero>(vec);
 	}
-#endif
 	unsigned d{};
 	if constexpr (sizeof(::fast_io::intrinsics::simd_vector<T, n>) == 16)
 	{

--- a/include/fast_io_core_impl/utils.h
+++ b/include/fast_io_core_impl/utils.h
@@ -346,8 +346,8 @@ inline
 	void
 	compile_time_type_punning_copy_n(range_type const *first, ::std::size_t bytes, ::std::byte *out)
 {
-#if defined(FAST_IO_IF_CONSTEVAL) && __cpp_lib_bit_cast >= 201806L
-	FAST_IO_IF_CONSTEVAL
+#if __cpp_lib_bit_cast >= 201806L
+	if (__builtin_is_constant_evaluated())
 	{
 		if constexpr (::std::same_as<range_type, ::std::byte>)
 		{
@@ -383,13 +383,11 @@ template <::std::input_or_output_iterator output_iter, typename T>
 	requires(::std::is_trivially_copyable_v<T> && sizeof(T) <= sizeof(::std::uintmax_t))
 inline constexpr output_iter my_fill_n(output_iter first, ::std::size_t count, T value)
 {
-#if defined(FAST_IO_IF_CONSTEVAL)
-	FAST_IO_IF_CONSTEVAL
+	if (__builtin_is_constant_evaluated())
 	{
 		::fast_io::freestanding::fill_n(first, count, value);
 	}
 	else
-#endif
 	{
 		using output_value_type = ::std::iter_value_t<output_iter>;
 		if constexpr (::std::contiguous_iterator<output_iter> && ::std::is_trivially_copyable_v<output_value_type> &&

--- a/include/fast_io_core_impl/utils.h
+++ b/include/fast_io_core_impl/utils.h
@@ -346,12 +346,8 @@ inline
 	void
 	compile_time_type_punning_copy_n(range_type const *first, ::std::size_t bytes, ::std::byte *out)
 {
-#if (__cpp_if_consteval >= 202106L || __cpp_lib_is_constant_evaluated >= 201811L) && __cpp_lib_bit_cast >= 201806L
-#if __cpp_if_consteval >= 202106L
-	if consteval
-#else
-	if (__builtin_is_constant_evaluated())
-#endif
+#if defined(FAST_IO_IF_CONSTEVAL) && __cpp_lib_bit_cast >= 201806L
+	FAST_IO_IF_CONSTEVAL
 	{
 		if constexpr (::std::same_as<range_type, ::std::byte>)
 		{
@@ -387,12 +383,8 @@ template <::std::input_or_output_iterator output_iter, typename T>
 	requires(::std::is_trivially_copyable_v<T> && sizeof(T) <= sizeof(::std::uintmax_t))
 inline constexpr output_iter my_fill_n(output_iter first, ::std::size_t count, T value)
 {
-#if __cpp_if_consteval >= 202106L || __cpp_lib_is_constant_evaluated >= 201811L
-#if __cpp_if_consteval >= 202106L
-	if consteval
-#else
-	if (__builtin_is_constant_evaluated())
-#endif
+#if defined(FAST_IO_IF_CONSTEVAL)
+	FAST_IO_IF_CONSTEVAL
 	{
 		::fast_io::freestanding::fill_n(first, count, value);
 	}

--- a/include/fast_io_crypto.h
+++ b/include/fast_io_crypto.h
@@ -13,11 +13,13 @@
 #include "fast_io_core.h"
 
 #include "fast_io_dsal/impl/misc/push_warnings.h"
+#include "fast_io_dsal/impl/misc/push_macros.h"
 
 // #include"fast_io_crypto/symmetric_crypto.h"
 // #include"fast_io_crypto/hash/intrin_include.h"
 #include "fast_io_crypto/hash/impl.h"
 
+#include "fast_io_dsal/impl/misc/pop_macros.h"
 #include "fast_io_dsal/impl/misc/pop_warnings.h"
 
 #endif

--- a/include/fast_io_crypto/hash/crc32.h
+++ b/include/fast_io_crypto/hash/crc32.h
@@ -19,8 +19,8 @@ inline constexpr void crc32_to_byte_ptr_commom_impl(::std::uint_least32_t crc, :
 	{
 		crc = ::fast_io::byte_swap(crc);
 	}
-#if defined(FAST_IO_IF_CONSTEVAL) && __cpp_lib_bit_cast >= 201806L
-	FAST_IO_IF_CONSTEVAL
+#if __cpp_lib_bit_cast >= 201806L
+	if (__builtin_is_constant_evaluated())
 	{
 		auto a{::std::bit_cast<::fast_io::freestanding::array<::std::byte, sizeof(::std::uint_least32_t)>>(crc)};
 		::fast_io::freestanding::nonoverlapped_bytes_copy_n(a.data(), a.size(), ptr);

--- a/include/fast_io_crypto/hash/crc32.h
+++ b/include/fast_io_crypto/hash/crc32.h
@@ -19,12 +19,8 @@ inline constexpr void crc32_to_byte_ptr_commom_impl(::std::uint_least32_t crc, :
 	{
 		crc = ::fast_io::byte_swap(crc);
 	}
-#if (__cpp_if_consteval >= 202106L || __cpp_lib_is_constant_evaluated >= 201811L) && __cpp_lib_bit_cast >= 201806L
-#if __cpp_if_consteval >= 202106L
-	if consteval
-#elif __cpp_lib_is_constant_evaluated >= 201811L
-	if (__builtin_is_constant_evaluated())
-#endif
+#if defined(FAST_IO_IF_CONSTEVAL) && __cpp_lib_bit_cast >= 201806L
+	FAST_IO_IF_CONSTEVAL
 	{
 		auto a{::std::bit_cast<::fast_io::freestanding::array<::std::byte, sizeof(::std::uint_least32_t)>>(crc)};
 		::fast_io::freestanding::nonoverlapped_bytes_copy_n(a.data(), a.size(), ptr);

--- a/include/fast_io_crypto/hash/md5.h
+++ b/include/fast_io_crypto/hash/md5.h
@@ -98,12 +98,8 @@ inline
 	::std::uint_least32_t tmp;
 	for (; block != ed; block += block_size)
 	{
-#if __cpp_lib_is_constant_evaluated >= 201811L
-#if __cpp_if_consteval >= 202106L
-		if consteval
-#else
-		if (__builtin_is_constant_evaluated())
-#endif
+#if defined(FAST_IO_IF_CONSTEVAL)
+		FAST_IO_IF_CONSTEVAL
 		{
 			for (::std::size_t j{}; j != 16; ++j)
 			{
@@ -375,12 +371,8 @@ public:
 		void
 		update_blocks(::std::byte const *block_start, ::std::byte const *block_last) noexcept
 	{
-#if __cpp_lib_is_constant_evaluated >= 201811L
-#if __cpp_if_consteval >= 202106L
-		if consteval
-#else
-		if (__builtin_is_constant_evaluated())
-#endif
+#if defined(FAST_IO_IF_CONSTEVAL)
+		FAST_IO_IF_CONSTEVAL
 		{
 			::fast_io::details::md5::md5_main(this->state, block_start, block_last);
 		}

--- a/include/fast_io_crypto/hash/md5.h
+++ b/include/fast_io_crypto/hash/md5.h
@@ -98,8 +98,7 @@ inline
 	::std::uint_least32_t tmp;
 	for (; block != ed; block += block_size)
 	{
-#if defined(FAST_IO_IF_CONSTEVAL)
-		FAST_IO_IF_CONSTEVAL
+		if (__builtin_is_constant_evaluated())
 		{
 			for (::std::size_t j{}; j != 16; ++j)
 			{
@@ -127,7 +126,6 @@ inline
 			uu<operation::F>(b, c, d, a, x[15], 22, 0x49b40821u);
 		}
 		else
-#endif
 		{
 			ul32_may_alias const *w{reinterpret_cast<ul32_may_alias const *>(block)};
 			uu<operation::F>(a, b, c, d, x[0] = little_endian(w[0]), 7, 0xd76aa478u);
@@ -371,13 +369,11 @@ public:
 		void
 		update_blocks(::std::byte const *block_start, ::std::byte const *block_last) noexcept
 	{
-#if defined(FAST_IO_IF_CONSTEVAL)
-		FAST_IO_IF_CONSTEVAL
+		if (__builtin_is_constant_evaluated())
 		{
 			::fast_io::details::md5::md5_main(this->state, block_start, block_last);
 		}
 		else
-#endif
 		{
 			if constexpr (::std::endian::native == ::std::endian::little)
 			{

--- a/include/fast_io_crypto/hash/md5_sha_hash_context.h
+++ b/include/fast_io_crypto/hash/md5_sha_hash_context.h
@@ -215,12 +215,8 @@ inline
 	hash_digest_to_byte_ptr_common_impl(U const *digest, ::std::size_t n, ::std::byte *ptr) noexcept
 {
 	constexpr ::std::size_t usz{sizeof(U)};
-#if __cpp_if_consteval >= 202106L || __cpp_lib_is_constant_evaluated >= 201811L
-#if __cpp_if_consteval >= 202106L
-	if consteval
-#else
-	if (__builtin_is_constant_evaluated())
-#endif
+#if defined(FAST_IO_IF_CONSTEVAL)
+	FAST_IO_IF_CONSTEVAL
 	{
 		for (::std::size_t i{}; i != n; ++i)
 		{
@@ -259,12 +255,8 @@ template <::std::endian end, ::std::unsigned_integral U>
 inline constexpr void hash_digest_to_byte_ptr_simd16_impl(U const *digest, ::std::size_t n, ::std::byte *ptr) noexcept
 {
 	constexpr ::std::size_t usz{sizeof(U)};
-#if __cpp_if_consteval >= 202106L || __cpp_lib_is_constant_evaluated >= 201811L
-#if __cpp_if_consteval >= 202106L
-	if consteval
-#else
-	if (__builtin_is_constant_evaluated())
-#endif
+#if defined(FAST_IO_IF_CONSTEVAL)
+	FAST_IO_IF_CONSTEVAL
 	{
 		hash_digest_to_byte_ptr_common_impl(digest, n, ptr);
 	}

--- a/include/fast_io_crypto/hash/md5_sha_hash_context.h
+++ b/include/fast_io_crypto/hash/md5_sha_hash_context.h
@@ -215,8 +215,7 @@ inline
 	hash_digest_to_byte_ptr_common_impl(U const *digest, ::std::size_t n, ::std::byte *ptr) noexcept
 {
 	constexpr ::std::size_t usz{sizeof(U)};
-#if defined(FAST_IO_IF_CONSTEVAL)
-	FAST_IO_IF_CONSTEVAL
+	if (__builtin_is_constant_evaluated())
 	{
 		for (::std::size_t i{}; i != n; ++i)
 		{
@@ -231,7 +230,6 @@ inline
 		}
 	}
 	else
-#endif
 	{
 		if constexpr (::std::endian::native == end)
 		{
@@ -255,13 +253,11 @@ template <::std::endian end, ::std::unsigned_integral U>
 inline constexpr void hash_digest_to_byte_ptr_simd16_impl(U const *digest, ::std::size_t n, ::std::byte *ptr) noexcept
 {
 	constexpr ::std::size_t usz{sizeof(U)};
-#if defined(FAST_IO_IF_CONSTEVAL)
-	FAST_IO_IF_CONSTEVAL
+	if (__builtin_is_constant_evaluated())
 	{
 		hash_digest_to_byte_ptr_common_impl(digest, n, ptr);
 	}
 	else
-#endif
 	{
 		if constexpr (::std::endian::native == end)
 		{

--- a/include/fast_io_crypto/hash/sha1.h
+++ b/include/fast_io_crypto/hash/sha1.h
@@ -746,15 +746,11 @@ public:
 		update_blocks(::std::byte const *__restrict blocks_start, ::std::byte const *__restrict blocks_last) noexcept
 	{
 		::std::size_t const blocks_bytes{static_cast<::std::size_t>(blocks_last - blocks_start)};
-#if defined(FAST_IO_IF_CONSTEVAL)
-		FAST_IO_IF_CONSTEVAL
+		if (__builtin_is_constant_evaluated())
 		{
 			::fast_io::details::sha1::sha1_do_constexpr_function(this->state, blocks_start, blocks_bytes);
 		}
 		else
-#else
-#error "fuck you"
-#endif
 		{
 			::fast_io::details::sha1::sha1_do_function(this->state, blocks_start, blocks_bytes);
 		}

--- a/include/fast_io_crypto/hash/sha1.h
+++ b/include/fast_io_crypto/hash/sha1.h
@@ -746,12 +746,8 @@ public:
 		update_blocks(::std::byte const *__restrict blocks_start, ::std::byte const *__restrict blocks_last) noexcept
 	{
 		::std::size_t const blocks_bytes{static_cast<::std::size_t>(blocks_last - blocks_start)};
-#if __cpp_if_consteval >= 202106L || __cpp_lib_is_constant_evaluated >= 201811L
-#if __cpp_if_consteval >= 202106L
-		if consteval
-#else
-		if (__builtin_is_constant_evaluated())
-#endif
+#if defined(FAST_IO_IF_CONSTEVAL)
+		FAST_IO_IF_CONSTEVAL
 		{
 			::fast_io::details::sha1::sha1_do_constexpr_function(this->state, blocks_start, blocks_bytes);
 		}

--- a/include/fast_io_crypto/hash/sha1.h
+++ b/include/fast_io_crypto/hash/sha1.h
@@ -752,6 +752,8 @@ public:
 			::fast_io::details::sha1::sha1_do_constexpr_function(this->state, blocks_start, blocks_bytes);
 		}
 		else
+#else
+#error "fuck you"
 #endif
 		{
 			::fast_io::details::sha1::sha1_do_function(this->state, blocks_start, blocks_bytes);

--- a/include/fast_io_crypto/hash/sha256.h
+++ b/include/fast_io_crypto/hash/sha256.h
@@ -184,12 +184,8 @@ public:
 		void
 		update_blocks(::std::byte const *blocks_start, ::std::byte const *blocks_last) noexcept
 	{
-#if __cpp_if_consteval >= 202106L || __cpp_lib_is_constant_evaluated >= 201811L
-#if __cpp_if_consteval >= 202106L
-		if consteval
-#else
-		if (__builtin_is_constant_evaluated())
-#endif
+#if defined(FAST_IO_IF_CONSTEVAL)
+		FAST_IO_IF_CONSTEVAL
 		{
 			::fast_io::details::sha256::sha256_do_constexpr_function(this->state, blocks_start, blocks_last);
 		}

--- a/include/fast_io_crypto/hash/sha256.h
+++ b/include/fast_io_crypto/hash/sha256.h
@@ -184,13 +184,11 @@ public:
 		void
 		update_blocks(::std::byte const *blocks_start, ::std::byte const *blocks_last) noexcept
 	{
-#if defined(FAST_IO_IF_CONSTEVAL)
-		FAST_IO_IF_CONSTEVAL
+		if (__builtin_is_constant_evaluated())
 		{
 			::fast_io::details::sha256::sha256_do_constexpr_function(this->state, blocks_start, blocks_last);
 		}
 		else
-#endif
 		{
 			::fast_io::details::sha256::sha256_runtime_routine(this->state, blocks_start, blocks_last);
 		}

--- a/include/fast_io_crypto/hash/sha512.h
+++ b/include/fast_io_crypto/hash/sha512.h
@@ -208,12 +208,8 @@ public:
 		void
 		update_blocks(::std::byte const *blocks_start, ::std::byte const *blocks_last) noexcept
 	{
-#if __cpp_if_consteval >= 202106L || __cpp_lib_is_constant_evaluated >= 201811L
-#if __cpp_if_consteval >= 202106L
-		if consteval
-#else
-		if (__builtin_is_constant_evaluated())
-#endif
+#if defined(FAST_IO_IF_CONSTEVAL)
+		FAST_IO_IF_CONSTEVAL
 		{
 			::fast_io::details::sha512::sha512_do_constexpr_function(state, blocks_start, blocks_last);
 		}

--- a/include/fast_io_crypto/hash/sha512.h
+++ b/include/fast_io_crypto/hash/sha512.h
@@ -208,13 +208,11 @@ public:
 		void
 		update_blocks(::std::byte const *blocks_start, ::std::byte const *blocks_last) noexcept
 	{
-#if defined(FAST_IO_IF_CONSTEVAL)
-		FAST_IO_IF_CONSTEVAL
+		if (__builtin_is_constant_evaluated())
 		{
 			::fast_io::details::sha512::sha512_do_constexpr_function(state, blocks_start, blocks_last);
 		}
 		else
-#endif
 		{
 			::fast_io::details::sha512::sha512_runtime_routine(state, blocks_start, blocks_last);
 		}

--- a/include/fast_io_crypto/streamcipher/chacha/scalar.h
+++ b/include/fast_io_crypto/streamcipher/chacha/scalar.h
@@ -39,8 +39,7 @@ inline
 {
 	constexpr ::std::size_t n{16};
 	::std::uint_least32_t x[n];
-#if defined(FAST_IO_IF_CONSTEVAL)
-	FAST_IO_IF_CONSTEVAL
+	if (__builtin_is_constant_evaluated())
 	{
 		for (::std::size_t i{}; i != n; ++i)
 		{
@@ -48,7 +47,6 @@ inline
 		}
 	}
 	else
-#endif
 	{
 		__builtin_memcpy(x, indata, sizeof(x));
 	}
@@ -75,8 +73,7 @@ inline
 		{
 			res = ::fast_io::byte_swap(res);
 		}
-#if defined(FAST_IO_IF_CONSTEVAL)
-		FAST_IO_IF_CONSTEVAL
+		if (__builtin_is_constant_evaluated())
 		{
 			auto v{::std::bit_cast<::fast_io::freestanding::array<::std::byte, sizeof(::std::uint_least32_t)>>(res)};
 			for (::std::size_t j{}; j != sizeof(::std::uint_least32_t); ++j)
@@ -85,7 +82,6 @@ inline
 			}
 		}
 		else
-#endif
 		{
 			__builtin_memcpy(outdata + i * sizeof(::std::uint_least32_t), __builtin_addressof(res),
 							 sizeof(::std::uint_least32_t));

--- a/include/fast_io_crypto/streamcipher/chacha/scalar.h
+++ b/include/fast_io_crypto/streamcipher/chacha/scalar.h
@@ -39,12 +39,8 @@ inline
 {
 	constexpr ::std::size_t n{16};
 	::std::uint_least32_t x[n];
-#if __cpp_lib_is_constant_evaluated >= 201811L || __cpp_if_consteval >= 202106L
-#if __cpp_if_consteval >= 202106L
-	if consteval
-#else
-	if (__builtin_is_constant_evaluated())
-#endif
+#if defined(FAST_IO_IF_CONSTEVAL)
+	FAST_IO_IF_CONSTEVAL
 	{
 		for (::std::size_t i{}; i != n; ++i)
 		{
@@ -79,12 +75,8 @@ inline
 		{
 			res = ::fast_io::byte_swap(res);
 		}
-#if __cpp_lib_is_constant_evaluated >= 201811L || __cpp_if_consteval >= 202106L
-#if __cpp_if_consteval >= 202106L
-		if consteval
-#else
-		if (__builtin_is_constant_evaluated())
-#endif
+#if defined(FAST_IO_IF_CONSTEVAL)
+		FAST_IO_IF_CONSTEVAL
 		{
 			auto v{::std::bit_cast<::fast_io::freestanding::array<::std::byte, sizeof(::std::uint_least32_t)>>(res)};
 			for (::std::size_t j{}; j != sizeof(::std::uint_least32_t); ++j)

--- a/include/fast_io_driver/boost/uuid.h
+++ b/include/fast_io_driver/boost/uuid.h
@@ -22,11 +22,8 @@ inline constexpr char_type *pr_rsv_boost_uuid(char_type *iter, boost::uuids::uui
 {
 	static_assert(::std::contiguous_iterator<boost::uuids::uuid::const_iterator>);
 	auto first{::std::to_address(u.begin())};
-#if __cpp_if_consteval >= 202106L
-	if consteval
-#else
-	if (__builtin_is_constant_evaluated())
-#endif
+#if defined(FAST_IO_IF_CONSTEVAL)
+	FAST_IO_IF_CONSTEVAL
 	{
 		::std::byte buffer[16];
 		for (::std::size_t i{}; i != 16; ++i)
@@ -36,6 +33,7 @@ inline constexpr char_type *pr_rsv_boost_uuid(char_type *iter, boost::uuids::uui
 		return pr_rsv_uuid<uppercase>(iter, buffer);
 	}
 	else
+#endif
 	{
 		return pr_rsv_uuid<uppercase>(iter, reinterpret_cast<::std::byte const *>(first));
 	}

--- a/include/fast_io_driver/boost/uuid.h
+++ b/include/fast_io_driver/boost/uuid.h
@@ -22,8 +22,7 @@ inline constexpr char_type *pr_rsv_boost_uuid(char_type *iter, boost::uuids::uui
 {
 	static_assert(::std::contiguous_iterator<boost::uuids::uuid::const_iterator>);
 	auto first{::std::to_address(u.begin())};
-#if defined(FAST_IO_IF_CONSTEVAL)
-	FAST_IO_IF_CONSTEVAL
+	if (__builtin_is_constant_evaluated())
 	{
 		::std::byte buffer[16];
 		for (::std::size_t i{}; i != 16; ++i)
@@ -33,7 +32,6 @@ inline constexpr char_type *pr_rsv_boost_uuid(char_type *iter, boost::uuids::uui
 		return pr_rsv_uuid<uppercase>(iter, buffer);
 	}
 	else
-#endif
 	{
 		return pr_rsv_uuid<uppercase>(iter, reinterpret_cast<::std::byte const *>(first));
 	}

--- a/include/fast_io_dsal/impl/deque.h
+++ b/include/fast_io_dsal/impl/deque.h
@@ -326,13 +326,11 @@ inline constexpr void deque_destroy_trivial_common_impl(controllerblocktype *con
 template <typename allocator, ::std::size_t align, ::std::size_t sz, typename controllerblocktype>
 inline constexpr void deque_destroy_trivial_common(controllerblocktype &controller) noexcept
 {
-#if defined(FAST_IO_IF_CONSTEVAL)
-	FAST_IO_IF_CONSTEVAL
+	if (__builtin_is_constant_evaluated())
 	{
 		::fast_io::containers::details::deque_destroy_trivial_common_impl<allocator, align, sz, controllerblocktype>(__builtin_addressof(controller));
 	}
 	else
-#endif
 	{
 		::fast_io::containers::details::deque_destroy_trivial_common_impl<allocator, align, sz, ::fast_io::containers::details::deque_controller_block_common>(
 			reinterpret_cast<::fast_io::containers::details::deque_controller_block_common *>(__builtin_addressof(controller)));
@@ -677,13 +675,11 @@ private:
 	[[deprecated]] inline constexpr void init_grow() noexcept
 	{
 		constexpr size_type mid{block_size >> 1u};
-#if defined(FAST_IO_IF_CONSTEVAL)
-		FAST_IO_IF_CONSTEVAL
+		if (__builtin_is_constant_evaluated())
 		{
 			::fast_io::containers::details::deque_init_grow_common<allocator, alignof(value_type), block_size, mid>(controller);
 		}
 		else
-#endif
 		{
 			::fast_io::containers::details::deque_init_grow_common<allocator, alignof(value_type), sizeof(value_type) * block_size, sizeof(value_type) * mid>(*reinterpret_cast<::fast_io::containers::details::deque_controller_common *>(__builtin_addressof(controller)));
 		}
@@ -694,13 +690,11 @@ private:
 #endif
 	inline constexpr void grow_front() noexcept
 	{
-#if defined(FAST_IO_IF_CONSTEVAL)
-		FAST_IO_IF_CONSTEVAL
+		if (__builtin_is_constant_evaluated())
 		{
 			::fast_io::containers::details::deque_grow_front_common<allocator, alignof(value_type), sizeof(value_type), block_size>(controller);
 		}
 		else
-#endif
 		{
 			::fast_io::containers::details::deque_grow_front_common<allocator, alignof(value_type), sizeof(value_type), sizeof(value_type) * block_size>(*reinterpret_cast<::fast_io::containers::details::deque_controller_common *>(__builtin_addressof(controller)));
 		}
@@ -711,13 +705,11 @@ private:
 #endif
 	inline constexpr void grow_back() noexcept
 	{
-#if defined(FAST_IO_IF_CONSTEVAL)
-		FAST_IO_IF_CONSTEVAL
+		if (__builtin_is_constant_evaluated())
 		{
 			::fast_io::containers::details::deque_grow_back_common<allocator, alignof(value_type), sizeof(value_type), block_size>(controller);
 		}
 		else
-#endif
 		{
 			::fast_io::containers::details::deque_grow_back_common<allocator, alignof(value_type), sizeof(value_type), sizeof(value_type) * block_size>(*reinterpret_cast<::fast_io::containers::details::deque_controller_common *>(__builtin_addressof(controller)));
 		}

--- a/include/fast_io_dsal/impl/deque.h
+++ b/include/fast_io_dsal/impl/deque.h
@@ -326,15 +326,13 @@ inline constexpr void deque_destroy_trivial_common_impl(controllerblocktype *con
 template <typename allocator, ::std::size_t align, ::std::size_t sz, typename controllerblocktype>
 inline constexpr void deque_destroy_trivial_common(controllerblocktype &controller) noexcept
 {
-#if __cpp_if_consteval >= 202106L
-	if consteval
-#else
-	if (__builtin_is_constant_evaluated())
-#endif
+#if defined(FAST_IO_IF_CONSTEVAL)
+	FAST_IO_IF_CONSTEVAL
 	{
 		::fast_io::containers::details::deque_destroy_trivial_common_impl<allocator, align, sz, controllerblocktype>(__builtin_addressof(controller));
 	}
 	else
+#endif
 	{
 		::fast_io::containers::details::deque_destroy_trivial_common_impl<allocator, align, sz, ::fast_io::containers::details::deque_controller_block_common>(
 			reinterpret_cast<::fast_io::containers::details::deque_controller_block_common *>(__builtin_addressof(controller)));
@@ -679,15 +677,13 @@ private:
 	[[deprecated]] inline constexpr void init_grow() noexcept
 	{
 		constexpr size_type mid{block_size >> 1u};
-#if __cpp_if_consteval >= 202106L
-		if consteval
-#else
-		if (__builtin_is_constant_evaluated())
-#endif
+#if defined(FAST_IO_IF_CONSTEVAL)
+		FAST_IO_IF_CONSTEVAL
 		{
 			::fast_io::containers::details::deque_init_grow_common<allocator, alignof(value_type), block_size, mid>(controller);
 		}
 		else
+#endif
 		{
 			::fast_io::containers::details::deque_init_grow_common<allocator, alignof(value_type), sizeof(value_type) * block_size, sizeof(value_type) * mid>(*reinterpret_cast<::fast_io::containers::details::deque_controller_common *>(__builtin_addressof(controller)));
 		}
@@ -698,15 +694,13 @@ private:
 #endif
 	inline constexpr void grow_front() noexcept
 	{
-#if __cpp_if_consteval >= 202106L
-		if consteval
-#else
-		if (__builtin_is_constant_evaluated())
-#endif
+#if defined(FAST_IO_IF_CONSTEVAL)
+		FAST_IO_IF_CONSTEVAL
 		{
 			::fast_io::containers::details::deque_grow_front_common<allocator, alignof(value_type), sizeof(value_type), block_size>(controller);
 		}
 		else
+#endif
 		{
 			::fast_io::containers::details::deque_grow_front_common<allocator, alignof(value_type), sizeof(value_type), sizeof(value_type) * block_size>(*reinterpret_cast<::fast_io::containers::details::deque_controller_common *>(__builtin_addressof(controller)));
 		}
@@ -717,15 +711,13 @@ private:
 #endif
 	inline constexpr void grow_back() noexcept
 	{
-#if __cpp_if_consteval >= 202106L
-		if consteval
-#else
-		if (__builtin_is_constant_evaluated())
-#endif
+#if defined(FAST_IO_IF_CONSTEVAL)
+		FAST_IO_IF_CONSTEVAL
 		{
 			::fast_io::containers::details::deque_grow_back_common<allocator, alignof(value_type), sizeof(value_type), block_size>(controller);
 		}
 		else
+#endif
 		{
 			::fast_io::containers::details::deque_grow_back_common<allocator, alignof(value_type), sizeof(value_type), sizeof(value_type) * block_size>(*reinterpret_cast<::fast_io::containers::details::deque_controller_common *>(__builtin_addressof(controller)));
 		}

--- a/include/fast_io_dsal/impl/freestanding.h
+++ b/include/fast_io_dsal/impl/freestanding.h
@@ -64,15 +64,13 @@ inline constexpr Iter2 overlapped_copy(Iter1 first, Iter1 last, Iter2 dest) noex
 			}
 		}
 
-#if defined(FAST_IO_IF_CONSTEVAL)
-		FAST_IO_IF_CONSTEVAL
+	if (__builtin_is_constant_evaluated())
 		{
 			::fast_io::details::overlapped_copy_buffer_ptr<iter2valuetype> tempbuffer(static_cast<::std::size_t>(::std::distance(first, last)));
 			auto buffered{::std::copy(first, last, tempbuffer.ptr)};
 			return ::std::move(tempbuffer.ptr, buffered, dest);
 		}
 		else
-#endif
 		{
 			// we do not allow move constructor to throw EH.
 			if (first <= dest && dest < last)

--- a/include/fast_io_dsal/impl/freestanding.h
+++ b/include/fast_io_dsal/impl/freestanding.h
@@ -64,12 +64,8 @@ inline constexpr Iter2 overlapped_copy(Iter1 first, Iter1 last, Iter2 dest) noex
 			}
 		}
 
-#if __cpp_if_consteval >= 202106L || __cpp_lib_is_constant_evaluated >= 201811L
-#if __cpp_if_consteval >= 202106L
-		if consteval
-#else
-		if (__builtin_is_constant_evaluated())
-#endif
+#if defined(FAST_IO_IF_CONSTEVAL)
+		FAST_IO_IF_CONSTEVAL
 		{
 			::fast_io::details::overlapped_copy_buffer_ptr<iter2valuetype> tempbuffer(static_cast<::std::size_t>(::std::distance(first, last)));
 			auto buffered{::std::copy(first, last, tempbuffer.ptr)};

--- a/include/fast_io_dsal/impl/misc/pop_macros.h
+++ b/include/fast_io_dsal/impl/misc/pop_macros.h
@@ -1,4 +1,6 @@
 ﻿// Please keep it in reverse order with the macros in push_macros.h
+
+#pragma pop_macro("FAST_IO_IF_CONSTEVAL")
 #pragma pop_macro("FAST_IO_GNU_RETURNS_NONNULL")
 #pragma pop_macro("FAST_IO_GNU_MALLOC")
 #pragma pop_macro("FAST_IO_GNU_ALWAYS_INLINE_ARTIFICIAL_CONST")
@@ -6,11 +8,14 @@
 #pragma pop_macro("FAST_IO_GNU_ARTIFICIAL")
 #pragma pop_macro("FAST_IO_GNU_ALWAYS_INLINE")
 #pragma pop_macro("FAST_IO_GNU_CONST")
+#pragma pop_macro("FAST_IO_WINFASTCALL_RENAME")
+#pragma pop_macro("FAST_IO_WINFASTCALL")
 #pragma pop_macro("FAST_IO_WINCDECL_RENAME")
 #pragma pop_macro("FAST_IO_WINCDECL")
 #pragma pop_macro("FAST_IO_WINSTDCALL_RENAME")
 #pragma pop_macro("FAST_IO_WINSTDCALL")
 #pragma pop_macro("FAST_IO_STDCALL")
+#pragma pop_macro("FAST_IO_DLL_DLLIMPORT")
 #pragma pop_macro("FAST_IO_DLLIMPORT")
 #pragma pop_macro("refresh")
 #pragma pop_macro("new")

--- a/include/fast_io_dsal/impl/misc/pop_macros.h
+++ b/include/fast_io_dsal/impl/misc/pop_macros.h
@@ -1,6 +1,5 @@
 ﻿// Please keep it in reverse order with the macros in push_macros.h
 
-#pragma pop_macro("FAST_IO_IF_CONSTEVAL")
 #pragma pop_macro("FAST_IO_GNU_RETURNS_NONNULL")
 #pragma pop_macro("FAST_IO_GNU_MALLOC")
 #pragma pop_macro("FAST_IO_GNU_ALWAYS_INLINE_ARTIFICIAL_CONST")

--- a/include/fast_io_dsal/impl/misc/push_macros.h
+++ b/include/fast_io_dsal/impl/misc/push_macros.h
@@ -19,37 +19,9 @@
 #pragma push_macro("refresh")
 #undef refresh
 
+
 #pragma push_macro("FAST_IO_DLLIMPORT")
 #undef FAST_IO_DLLIMPORT
-#pragma push_macro("FAST_IO_STDCALL")
-#undef FAST_IO_STDCALL
-#pragma push_macro("FAST_IO_WINSTDCALL")
-#undef FAST_IO_WINSTDCALL
-#pragma push_macro("FAST_IO_WINSTDCALL_RENAME")
-#undef FAST_IO_WINSTDCALL_RENAME
-#pragma push_macro("FAST_IO_WINCDECL")
-#undef FAST_IO_WINCDECL
-#pragma push_macro("FAST_IO_WINCDECL_RENAME")
-#undef FAST_IO_WINCDECL_RENAME
-#pragma push_macro("FAST_IO_WINFASTCALL")
-#undef FAST_IO_WINFASTCALL
-#pragma push_macro("FAST_IO_WINFASTCALL_RENAME")
-#undef FAST_IO_WINFASTCALL_RENAME
-#pragma push_macro("FAST_IO_GNU_CONST")
-#undef FAST_IO_GNU_CONST
-#pragma push_macro("FAST_IO_GNU_ALWAYS_INLINE")
-#undef FAST_IO_GNU_ALWAYS_INLINE
-#pragma push_macro("FAST_IO_GNU_ARTIFICIAL")
-#undef FAST_IO_GNU_ARTIFICIAL
-#pragma push_macro("FAST_IO_GNU_ALWAYS_INLINE_ARTIFICIAL")
-#undef FAST_IO_GNU_ALWAYS_INLINE_ARTIFICIAL
-#pragma push_macro("FAST_IO_GNU_ALWAYS_INLINE_ARTIFICIAL_CONST")
-#undef FAST_IO_GNU_ALWAYS_INLINE_ARTIFICIAL_CONST
-#pragma push_macro("FAST_IO_GNU_MALLOC")
-#undef FAST_IO_GNU_MALLOC
-#pragma push_macro("FAST_IO_GNU_RETURNS_NONNULL")
-#undef FAST_IO_GNU_RETURNS_NONNULL
-
 #if defined(_MSC_VER) && !defined(__clang__)
 #define FAST_IO_DLLIMPORT __declspec(dllimport)
 #elif __has_cpp_attribute(__gnu__::__dllimport__) && !defined(__WINE__) && !defined(__arm64ec__)
@@ -58,12 +30,16 @@
 #define FAST_IO_DLLIMPORT
 #endif
 
+#pragma push_macro("FAST_IO_DLL_DLLIMPORT")
+#undef FAST_IO_DLL_DLLIMPORT
 #if defined(_DLL) && !defined(__WINE__)
 #define FAST_IO_DLL_DLLIMPORT FAST_IO_DLLIMPORT
 #else
 #define FAST_IO_DLL_DLLIMPORT
 #endif
 
+#pragma push_macro("FAST_IO_STDCALL")
+#undef FAST_IO_STDCALL
 #if defined(_MSC_VER) && (!__has_cpp_attribute(__gnu__::__stdcall__) && !defined(__WINE__))
 #define FAST_IO_STDCALL __stdcall
 #elif (__has_cpp_attribute(__gnu__::__stdcall__) && !defined(__WINE__))
@@ -72,6 +48,8 @@
 #define FAST_IO_STDCALL
 #endif
 
+#pragma push_macro("FAST_IO_WINSTDCALL")
+#undef FAST_IO_WINSTDCALL
 #if defined(_MSC_VER) && (!__has_cpp_attribute(__gnu__::__stdcall__) && !defined(__WINE__))
 #define FAST_IO_WINSTDCALL __stdcall
 #elif (__has_cpp_attribute(__gnu__::__stdcall__) && !defined(__WINE__))
@@ -80,6 +58,8 @@
 #define FAST_IO_WINSTDCALL
 #endif
 
+#pragma push_macro("FAST_IO_WINSTDCALL_RENAME")
+#undef FAST_IO_WINSTDCALL_RENAME
 #if defined(__clang__) || defined(__GNUC__)
 #if defined(_M_HYBRID)
 #define FAST_IO_WINSTDCALL_RENAME(name, count) __asm__("#" #name "@" #count)
@@ -98,6 +78,8 @@
 #define FAST_IO_WINSTDCALL_RENAME(name, count)
 #endif
 
+#pragma push_macro("FAST_IO_WINCDECL")
+#undef FAST_IO_WINCDECL
 #if defined(_MSC_VER) && (!__has_cpp_attribute(__gnu__::__cdecl__) && !defined(__WINE__))
 #define FAST_IO_WINCDECL __cdecl
 #elif (__has_cpp_attribute(__gnu__::__cdecl__) && !defined(__WINE__))
@@ -106,6 +88,8 @@
 #define FAST_IO_WINCDECL
 #endif
 
+#pragma push_macro("FAST_IO_WINCDECL_RENAME")
+#undef FAST_IO_WINCDECL_RENAME
 #if defined(__clang__) || defined(__GNUC__)
 #if defined(_M_HYBRID)
 #define FAST_IO_WINCDECL_RENAME(name, count) __asm__("#" #name "@" #count)
@@ -124,6 +108,8 @@
 #define FAST_IO_WINCDECL_RENAME(name, count)
 #endif
 
+#pragma push_macro("FAST_IO_WINFASTCALL")
+#undef FAST_IO_WINFASTCALL
 #if defined(_MSC_VER) && (!__has_cpp_attribute(__gnu__::__fastcall__) && !defined(__WINE__))
 #define FAST_IO_WINFASTCALL __fastcall
 #elif (__has_cpp_attribute(__gnu__::__fastcall__) && !defined(__WINE__))
@@ -132,6 +118,8 @@
 #define FAST_IO_WINFASTCALL
 #endif
 
+#pragma push_macro("FAST_IO_WINFASTCALL_RENAME")
+#undef FAST_IO_WINFASTCALL_RENAME
 #if defined(__clang__) || defined(__GNUC__)
 #if defined(_M_HYBRID)
 #define FAST_IO_WINFASTCALL_RENAME(name, count) __asm__("#" #name "@" #count)
@@ -150,12 +138,16 @@
 #define FAST_IO_WINFASTCALL_RENAME(name, count)
 #endif
 
+#pragma push_macro("FAST_IO_GNU_CONST")
+#undef FAST_IO_GNU_CONST
 #if __has_cpp_attribute(__gnu__::__const__)
 #define FAST_IO_GNU_CONST [[__gnu__::__const__]]
 #else
 #define FAST_IO_GNU_CONST
 #endif
 
+#pragma push_macro("FAST_IO_GNU_ALWAYS_INLINE")
+#undef FAST_IO_GNU_ALWAYS_INLINE
 #if __has_cpp_attribute(__gnu__::__always_inline__)
 #define FAST_IO_GNU_ALWAYS_INLINE [[__gnu__::__always_inline__]]
 #elif __has_cpp_attribute(msvc::forceinline)
@@ -164,25 +156,48 @@
 #define FAST_IO_GNU_ALWAYS_INLINE
 #endif
 
+#pragma push_macro("FAST_IO_GNU_ARTIFICIAL")
+#undef FAST_IO_GNU_ARTIFICIAL
 #if __has_cpp_attribute(__gnu__::__artificial__)
 #define FAST_IO_GNU_ARTIFICIAL [[__gnu__::__artificial__]]
 #else
 #define FAST_IO_GNU_ARTIFICIAL
 #endif
 
+
+#pragma push_macro("FAST_IO_GNU_ALWAYS_INLINE_ARTIFICIAL")
+#undef FAST_IO_GNU_ALWAYS_INLINE_ARTIFICIAL
 #define FAST_IO_GNU_ALWAYS_INLINE_ARTIFICIAL FAST_IO_GNU_ALWAYS_INLINE FAST_IO_GNU_ARTIFICIAL
 
+#pragma push_macro("FAST_IO_GNU_ALWAYS_INLINE_ARTIFICIAL_CONST")
+#undef FAST_IO_GNU_ALWAYS_INLINE_ARTIFICIAL_CONST
 #define FAST_IO_GNU_ALWAYS_INLINE_ARTIFICIAL_CONST \
 	FAST_IO_GNU_ALWAYS_INLINE [[nodiscard]] FAST_IO_GNU_ARTIFICIAL FAST_IO_GNU_CONST
 
+#pragma push_macro("FAST_IO_GNU_MALLOC")
+#undef FAST_IO_GNU_MALLOC
 #if __has_cpp_attribute(__gnu__::__malloc__)
 #define FAST_IO_GNU_MALLOC [[__gnu__::__malloc__]]
 #else
 #define FAST_IO_GNU_MALLOC
 #endif
 
+#pragma push_macro("FAST_IO_GNU_RETURNS_NONNULL")
+#undef FAST_IO_GNU_RETURNS_NONNULL
 #if __has_cpp_attribute(__gnu__::__returns_nonnull__)
 #define FAST_IO_GNU_RETURNS_NONNULL [[__gnu__::__returns_nonnull__]]
 #else
 #define FAST_IO_GNU_RETURNS_NONNULL
+#endif
+
+#pragma push_macro("FAST_IO_IF_CONSTEVAL")
+#undef FAST_IO_IF_CONSTEVAL
+#if __cpp_if_consteval >= 202106L || __cpp_lib_is_constant_evaluated >= 201811L
+#if __cpp_if_consteval >= 202106L && (!defined(_MSC_VER) || defined(__clang__))
+#define FAST_IO_IF_CONSTEVAL if consteval
+#elif __cpp_lib_is_constant_evaluated >= 201811L
+#define FAST_IO_IF_CONSTEVAL if (__builtin_is_constant_evaluated())
+#endif
+#else
+// #define FAST_IO_IF_CONSTEVAL 
 #endif

--- a/include/fast_io_dsal/impl/misc/push_macros.h
+++ b/include/fast_io_dsal/impl/misc/push_macros.h
@@ -189,15 +189,3 @@
 #else
 #define FAST_IO_GNU_RETURNS_NONNULL
 #endif
-
-#pragma push_macro("FAST_IO_IF_CONSTEVAL")
-#undef FAST_IO_IF_CONSTEVAL
-#if __cpp_if_consteval >= 202106L || __cpp_lib_is_constant_evaluated >= 201811L
-#if __cpp_if_consteval >= 202106L && (!defined(_MSC_VER) || defined(__clang__))
-#define FAST_IO_IF_CONSTEVAL if consteval
-#elif __cpp_lib_is_constant_evaluated >= 201811L
-#define FAST_IO_IF_CONSTEVAL if (__builtin_is_constant_evaluated())
-#endif
-#else
-// #define FAST_IO_IF_CONSTEVAL 
-#endif

--- a/include/fast_io_dsal/impl/string.h
+++ b/include/fast_io_dsal/impl/string.h
@@ -112,13 +112,8 @@ public:
 private:
 	constexpr void reset_imp() noexcept
 	{
-
-#if (__cpp_if_consteval >= 202106L || __cpp_lib_is_constant_evaluated >= 201811L) && __cpp_constexpr_dynamic_alloc >= 201907L
-#if __cpp_if_consteval >= 202106L
-		if consteval
-#else
-		if (__builtin_is_constant_evaluated())
-#endif
+#if defined(FAST_IO_IF_CONSTEVAL) && __cpp_constexpr_dynamic_alloc >= 201907L
+		FAST_IO_IF_CONSTEVAL
 		{
 			using untyped_allocator_type = generic_allocator_adapter<allocator_type>;
 			using typed_allocator_type = typed_generic_allocator_adapter<untyped_allocator_type, chtype>;
@@ -838,15 +833,13 @@ public:
 	}
 	inline constexpr iterator insert(const_iterator ptr, string_view_type vw) noexcept
 	{
-#ifdef __cpp_if_consteval
-		if consteval
-#else
-		if (__builtin_is_constant_evaluated())
-#endif
+#if defined(FAST_IO_IF_CONSTEVAL)
+		FAST_IO_IF_CONSTEVAL
 		{
 			return this->insert_impl(this->imp.begin_ptr + (ptr - this->imp.begin_ptr), vw.data(), vw.size());
 		}
 		else
+#endif
 		{
 			return this->insert_impl(const_cast<pointer>(ptr), vw.data(), vw.size());
 		}
@@ -874,16 +867,14 @@ private:
 public:
 	inline constexpr iterator erase(const_iterator first, const_iterator last) noexcept
 	{
-#ifdef __cpp_if_consteval
-		if consteval
-#else
-		if (__builtin_is_constant_evaluated())
-#endif
+#if defined(FAST_IO_IF_CONSTEVAL)
+		FAST_IO_IF_CONSTEVAL
 		{
 			auto beginptr{this->imp.begin_ptr};
 			return this->erase_impl(beginptr + (first - beginptr), beginptr + (last - beginptr));
 		}
 		else
+#endif
 		{
 			return this->erase_impl(const_cast<pointer>(first), const_cast<pointer>(last));
 		}
@@ -901,16 +892,14 @@ public:
 	}
 	inline constexpr iterator erase(const_iterator it) noexcept
 	{
-#ifdef __cpp_if_consteval
-		if consteval
-#else
-		if (__builtin_is_constant_evaluated())
-#endif
+#if defined(FAST_IO_IF_CONSTEVAL)
+		FAST_IO_IF_CONSTEVAL
 		{
 			auto beginptr{this->imp.begin_ptr};
 			return this->erase_impl(beginptr + (it - beginptr));
 		}
 		else
+#endif
 		{
 			return this->erase_impl(const_cast<pointer>(it));
 		}
@@ -932,15 +921,13 @@ public:
 	}
 	inline constexpr iterator insert(const_iterator ptr, basic_string const &other) noexcept
 	{
-#ifdef __cpp_if_consteval
-		if consteval
-#else
-		if (__builtin_is_constant_evaluated())
-#endif
+#if defined(FAST_IO_IF_CONSTEVAL)
+		FAST_IO_IF_CONSTEVAL
 		{
 			return this->insert_impl(this->imp.begin_ptr + (ptr - this->imp.begin_ptr), other.data(), other.size());
 		}
 		else
+#endif
 		{
 			return this->insert_impl(const_cast<pointer>(ptr), other.data(), other.size());
 		}
@@ -1036,16 +1023,14 @@ public:
 #endif
 	inline constexpr iterator replace(const_iterator first, const_iterator last, string_view_type view) noexcept
 	{
-#ifdef __cpp_if_consteval
-		if consteval
-#else
-		if (__builtin_is_constant_evaluated())
-#endif
+#if defined(FAST_IO_IF_CONSTEVAL)
+		FAST_IO_IF_CONSTEVAL
 		{
 			auto beginptr{this->imp.begin_ptr};
 			return this->replace_impl(beginptr + (first - beginptr), beginptr + (last - beginptr), view.data(), view.size());
 		}
 		else
+#endif
 		{
 			return this->replace_impl(const_cast<pointer>(first), const_cast<pointer>(last), view.data(), view.size());
 		}
@@ -1057,16 +1042,14 @@ public:
 #endif
 	inline constexpr iterator replace(const_iterator first, const_iterator last, basic_string const &view) noexcept
 	{
-#ifdef __cpp_if_consteval
-		if consteval
-#else
-		if (__builtin_is_constant_evaluated())
-#endif
+#if defined(FAST_IO_IF_CONSTEVAL)
+		FAST_IO_IF_CONSTEVAL
 		{
 			auto beginptr{this->imp.begin_ptr};
 			return this->replace_impl(beginptr + (first - beginptr), beginptr + (last - beginptr), view.data(), view.size());
 		}
 		else
+#endif
 		{
 			return this->replace_impl(const_cast<pointer>(first), const_cast<pointer>(last), view.data(), view.size());
 		}

--- a/include/fast_io_dsal/impl/string.h
+++ b/include/fast_io_dsal/impl/string.h
@@ -112,8 +112,8 @@ public:
 private:
 	constexpr void reset_imp() noexcept
 	{
-#if defined(FAST_IO_IF_CONSTEVAL) && __cpp_constexpr_dynamic_alloc >= 201907L
-		FAST_IO_IF_CONSTEVAL
+#if __cpp_constexpr_dynamic_alloc >= 201907L
+		if (__builtin_is_constant_evaluated())
 		{
 			using untyped_allocator_type = generic_allocator_adapter<allocator_type>;
 			using typed_allocator_type = typed_generic_allocator_adapter<untyped_allocator_type, chtype>;
@@ -833,13 +833,11 @@ public:
 	}
 	inline constexpr iterator insert(const_iterator ptr, string_view_type vw) noexcept
 	{
-#if defined(FAST_IO_IF_CONSTEVAL)
-		FAST_IO_IF_CONSTEVAL
+		if (__builtin_is_constant_evaluated())
 		{
 			return this->insert_impl(this->imp.begin_ptr + (ptr - this->imp.begin_ptr), vw.data(), vw.size());
 		}
 		else
-#endif
 		{
 			return this->insert_impl(const_cast<pointer>(ptr), vw.data(), vw.size());
 		}
@@ -867,14 +865,12 @@ private:
 public:
 	inline constexpr iterator erase(const_iterator first, const_iterator last) noexcept
 	{
-#if defined(FAST_IO_IF_CONSTEVAL)
-		FAST_IO_IF_CONSTEVAL
+		if (__builtin_is_constant_evaluated())
 		{
 			auto beginptr{this->imp.begin_ptr};
 			return this->erase_impl(beginptr + (first - beginptr), beginptr + (last - beginptr));
 		}
 		else
-#endif
 		{
 			return this->erase_impl(const_cast<pointer>(first), const_cast<pointer>(last));
 		}
@@ -892,14 +888,12 @@ public:
 	}
 	inline constexpr iterator erase(const_iterator it) noexcept
 	{
-#if defined(FAST_IO_IF_CONSTEVAL)
-		FAST_IO_IF_CONSTEVAL
+		if (__builtin_is_constant_evaluated())
 		{
 			auto beginptr{this->imp.begin_ptr};
 			return this->erase_impl(beginptr + (it - beginptr));
 		}
 		else
-#endif
 		{
 			return this->erase_impl(const_cast<pointer>(it));
 		}
@@ -921,13 +915,11 @@ public:
 	}
 	inline constexpr iterator insert(const_iterator ptr, basic_string const &other) noexcept
 	{
-#if defined(FAST_IO_IF_CONSTEVAL)
-		FAST_IO_IF_CONSTEVAL
+		if (__builtin_is_constant_evaluated())
 		{
 			return this->insert_impl(this->imp.begin_ptr + (ptr - this->imp.begin_ptr), other.data(), other.size());
 		}
 		else
-#endif
 		{
 			return this->insert_impl(const_cast<pointer>(ptr), other.data(), other.size());
 		}
@@ -1023,14 +1015,12 @@ public:
 #endif
 	inline constexpr iterator replace(const_iterator first, const_iterator last, string_view_type view) noexcept
 	{
-#if defined(FAST_IO_IF_CONSTEVAL)
-		FAST_IO_IF_CONSTEVAL
+		if (__builtin_is_constant_evaluated())
 		{
 			auto beginptr{this->imp.begin_ptr};
 			return this->replace_impl(beginptr + (first - beginptr), beginptr + (last - beginptr), view.data(), view.size());
 		}
 		else
-#endif
 		{
 			return this->replace_impl(const_cast<pointer>(first), const_cast<pointer>(last), view.data(), view.size());
 		}
@@ -1042,14 +1032,12 @@ public:
 #endif
 	inline constexpr iterator replace(const_iterator first, const_iterator last, basic_string const &view) noexcept
 	{
-#if defined(FAST_IO_IF_CONSTEVAL)
-		FAST_IO_IF_CONSTEVAL
+		if (__builtin_is_constant_evaluated())
 		{
 			auto beginptr{this->imp.begin_ptr};
 			return this->replace_impl(beginptr + (first - beginptr), beginptr + (last - beginptr), view.data(), view.size());
 		}
 		else
-#endif
 		{
 			return this->replace_impl(const_cast<pointer>(first), const_cast<pointer>(last), view.data(), view.size());
 		}

--- a/include/fast_io_dsal/impl/vector.h
+++ b/include/fast_io_dsal/impl/vector.h
@@ -915,14 +915,12 @@ public:
 		if constexpr (::std::is_nothrow_constructible_v<value_type, Args...>)
 		{
 			pointer ret;
-#if defined(FAST_IO_IF_CONSTEVAL)
-			FAST_IO_IF_CONSTEVAL
+			if (__builtin_is_constant_evaluated())
 			{
 				auto beginptr{imp.begin_ptr};
 				ret = ::std::construct_at(this->move_backward_common_impl(iter - beginptr + beginptr), ::std::forward<Args>(args)...);
 			}
 			else
-#endif
 			{
 				ret = ::std::construct_at(this->move_backward_common_impl(const_cast<pointer>(iter)), ::std::forward<Args>(args)...);
 			}
@@ -931,14 +929,12 @@ public:
 		}
 		else
 		{
-#if defined(FAST_IO_IF_CONSTEVAL)
-			FAST_IO_IF_CONSTEVAL
+			if (__builtin_is_constant_evaluated())
 			{
 				auto beginptr{imp.begin_ptr};
 				return this->insert_impl(iter - beginptr + beginptr, value_type(::std::forward<Args>(args)...));
 			}
 			else
-#endif
 			{
 				return this->insert_impl(const_cast<pointer>(iter), value_type(::std::forward<Args>(args)...));
 			}
@@ -1005,13 +1001,11 @@ private:
 public:
 	inline constexpr iterator erase(const_iterator it) noexcept
 	{
-#if defined(FAST_IO_IF_CONSTEVAL)
-		FAST_IO_IF_CONSTEVAL
+		if (__builtin_is_constant_evaluated())
 		{
 			return this->erase_common(it - imp.begin_ptr + imp.begin_ptr);
 		}
 		else
-#endif
 		{
 			return this->erase_common(const_cast<pointer>(it));
 		}
@@ -1031,13 +1025,11 @@ public:
 
 	inline constexpr iterator erase(const_iterator first, const_iterator last) noexcept
 	{
-#if defined(FAST_IO_IF_CONSTEVAL)
-		FAST_IO_IF_CONSTEVAL
+		if (__builtin_is_constant_evaluated())
 		{
 			return this->erase_iters_common(first - imp.begin_ptr + imp.begin_ptr, last - imp.begin_ptr + imp.begin_ptr);
 		}
 		else
-#endif
 		{
 			return this->erase_iters_common(const_cast<pointer>(first), const_cast<pointer>(last));
 		}

--- a/include/fast_io_dsal/impl/vector.h
+++ b/include/fast_io_dsal/impl/vector.h
@@ -915,16 +915,14 @@ public:
 		if constexpr (::std::is_nothrow_constructible_v<value_type, Args...>)
 		{
 			pointer ret;
-#ifdef __cpp_if_consteval
-			if consteval
-#else
-			if (__builtin_is_constant_evaluated())
-#endif
+#if defined(FAST_IO_IF_CONSTEVAL)
+			FAST_IO_IF_CONSTEVAL
 			{
 				auto beginptr{imp.begin_ptr};
 				ret = ::std::construct_at(this->move_backward_common_impl(iter - beginptr + beginptr), ::std::forward<Args>(args)...);
 			}
 			else
+#endif
 			{
 				ret = ::std::construct_at(this->move_backward_common_impl(const_cast<pointer>(iter)), ::std::forward<Args>(args)...);
 			}
@@ -933,16 +931,14 @@ public:
 		}
 		else
 		{
-#ifdef __cpp_if_consteval
-			if consteval
-#else
-			if (__builtin_is_constant_evaluated())
-#endif
+#if defined(FAST_IO_IF_CONSTEVAL)
+			FAST_IO_IF_CONSTEVAL
 			{
 				auto beginptr{imp.begin_ptr};
 				return this->insert_impl(iter - beginptr + beginptr, value_type(::std::forward<Args>(args)...));
 			}
 			else
+#endif
 			{
 				return this->insert_impl(const_cast<pointer>(iter), value_type(::std::forward<Args>(args)...));
 			}
@@ -1009,15 +1005,13 @@ private:
 public:
 	inline constexpr iterator erase(const_iterator it) noexcept
 	{
-#ifdef __cpp_if_consteval
-		if consteval
-#else
-		if (__builtin_is_constant_evaluated())
-#endif
+#if defined(FAST_IO_IF_CONSTEVAL)
+		FAST_IO_IF_CONSTEVAL
 		{
 			return this->erase_common(it - imp.begin_ptr + imp.begin_ptr);
 		}
 		else
+#endif
 		{
 			return this->erase_common(const_cast<pointer>(it));
 		}
@@ -1037,15 +1031,13 @@ public:
 
 	inline constexpr iterator erase(const_iterator first, const_iterator last) noexcept
 	{
-#ifdef __cpp_if_consteval
-		if consteval
-#else
-		if (__builtin_is_constant_evaluated())
-#endif
+#if defined(FAST_IO_IF_CONSTEVAL)
+		FAST_IO_IF_CONSTEVAL
 		{
 			return this->erase_iters_common(first - imp.begin_ptr + imp.begin_ptr, last - imp.begin_ptr + imp.begin_ptr);
 		}
 		else
+#endif
 		{
 			return this->erase_iters_common(const_cast<pointer>(first), const_cast<pointer>(last));
 		}

--- a/include/fast_io_freestanding_impl/decorators/deco_partial_adapter.h
+++ b/include/fast_io_freestanding_impl/decorators/deco_partial_adapter.h
@@ -27,8 +27,7 @@ struct deco_partial_adapter
 	{
 		if constexpr (!::std::same_as<char_type, input_char_type>)
 		{
-#if defined(FAST_IO_IF_CONSTEVAL)
-			FAST_IO_IF_CONSTEVAL
+			if (__builtin_is_constant_evaluated())
 			{
 				::std::size_t fromdiff{static_cast<::std::size_t>(fromlast - fromfirst)};
 				::fast_io::details::local_operator_new_array_ptr<input_char_type> fromptr(fromdiff);
@@ -47,7 +46,6 @@ struct deco_partial_adapter
 			return {(fromit - reinterpret_cast<may_alias_input_char_ptr>(fromfirst)) + fromfirst, toit};
 		}
 		else
-#endif
 		{
 			::std::size_t fromdiff{static_cast<::std::size_t>(fromlast - fromfirst)};
 			::std::size_t diff{remained_max - remained};

--- a/include/fast_io_freestanding_impl/decorators/deco_partial_adapter.h
+++ b/include/fast_io_freestanding_impl/decorators/deco_partial_adapter.h
@@ -27,12 +27,8 @@ struct deco_partial_adapter
 	{
 		if constexpr (!::std::same_as<char_type, input_char_type>)
 		{
-#if defined(__cpp_if_consteval)
-			if consteval
-
-#else
-			if (__builtin_is_constant_evaluated())
-#endif
+#if defined(FAST_IO_IF_CONSTEVAL)
+			FAST_IO_IF_CONSTEVAL
 			{
 				::std::size_t fromdiff{static_cast<::std::size_t>(fromlast - fromfirst)};
 				::fast_io::details::local_operator_new_array_ptr<input_char_type> fromptr(fromdiff);
@@ -51,6 +47,7 @@ struct deco_partial_adapter
 			return {(fromit - reinterpret_cast<may_alias_input_char_ptr>(fromfirst)) + fromfirst, toit};
 		}
 		else
+#endif
 		{
 			::std::size_t fromdiff{static_cast<::std::size_t>(fromlast - fromfirst)};
 			::std::size_t diff{remained_max - remained};

--- a/include/fast_io_freestanding_impl/serializations/lebe.h
+++ b/include/fast_io_freestanding_impl/serializations/lebe.h
@@ -365,8 +365,8 @@ inline
 	static_assert(n != 0);
 	int_type t;
 
-#if __cpp_lib_bit_cast >= 201806L && defined(FAST_IO_IF_CONSTEVAL)
-	FAST_IO_IF_CONSTEVAL
+#if __cpp_lib_bit_cast >= 201806L
+	if (__builtin_is_constant_evaluated())
 	{
 		char_type buffer[n];
 		non_overlapped_copy_n(iter, n, buffer);
@@ -549,8 +549,8 @@ inline
 			u.high = ::fast_io::byte_swap(low);
 		}
 	}
-#if __cpp_lib_bit_cast >= 201806L && defined(FAST_IO_IF_CONSTEVAL)
-	FAST_IO_IF_CONSTEVAL
+#if __cpp_lib_bit_cast >= 201806L
+	if (__builtin_is_constant_evaluated())
 	{
 		::fast_io::freestanding::array<char unsigned, n> buffer{
 			::std::bit_cast<::fast_io::freestanding::array<char unsigned, n>>(u)};

--- a/include/fast_io_freestanding_impl/serializations/lebe.h
+++ b/include/fast_io_freestanding_impl/serializations/lebe.h
@@ -365,12 +365,8 @@ inline
 	static_assert(n != 0);
 	int_type t;
 
-#if __cpp_lib_bit_cast >= 201806L && (__cpp_if_consteval >= 202106L || __cpp_lib_is_constant_evaluated >= 201811L)
-#if __cpp_if_consteval >= 202106L
-	if consteval
-#elif __cpp_lib_is_constant_evaluated >= 201811L
-	if (__builtin_is_constant_evaluated())
-#endif
+#if __cpp_lib_bit_cast >= 201806L && defined(FAST_IO_IF_CONSTEVAL)
+	FAST_IO_IF_CONSTEVAL
 	{
 		char_type buffer[n];
 		non_overlapped_copy_n(iter, n, buffer);
@@ -553,12 +549,8 @@ inline
 			u.high = ::fast_io::byte_swap(low);
 		}
 	}
-#if __cpp_lib_bit_cast >= 201806L && (__cpp_if_consteval >= 202106L || __cpp_lib_is_constant_evaluated >= 201811L)
-#if __cpp_if_consteval >= 202106L
-	if consteval
-#elif __cpp_lib_is_constant_evaluated >= 201811L
-	if (__builtin_is_constant_evaluated())
-#endif
+#if __cpp_lib_bit_cast >= 201806L && defined(FAST_IO_IF_CONSTEVAL)
+	FAST_IO_IF_CONSTEVAL
 	{
 		::fast_io::freestanding::array<char unsigned, n> buffer{
 			::std::bit_cast<::fast_io::freestanding::array<char unsigned, n>>(u)};

--- a/include/fast_io_hosted/filesystem/nt.h
+++ b/include/fast_io_hosted/filesystem/nt.h
@@ -62,12 +62,8 @@ inline
 	nt_dirent *
 	new_nt_dirent() noexcept
 {
-#if __cpp_if_consteval >= 202106L || __cpp_lib_is_constant_evaluated >= 201811L
-#if __cpp_if_consteval >= 202106L
-	if consteval
-#else
-	if (__builtin_is_constant_evaluated())
-#endif
+#if defined(FAST_IO_IF_CONSTEVAL)
+	FAST_IO_IF_CONSTEVAL
 	{
 		return new nt_dirent;
 	}
@@ -89,12 +85,8 @@ inline
 	void
 	delete_nt_dirent(nt_dirent *ptr) noexcept
 {
-#if __cpp_if_consteval >= 202106L || __cpp_lib_is_constant_evaluated >= 201811L
-#if __cpp_if_consteval >= 202106L
-	if consteval
-#else
-	if (__builtin_is_constant_evaluated())
-#endif
+#if defined(FAST_IO_IF_CONSTEVAL)
+	FAST_IO_IF_CONSTEVAL
 	{
 		delete ptr;
 	}

--- a/include/fast_io_hosted/filesystem/nt.h
+++ b/include/fast_io_hosted/filesystem/nt.h
@@ -62,13 +62,11 @@ inline
 	nt_dirent *
 	new_nt_dirent() noexcept
 {
-#if defined(FAST_IO_IF_CONSTEVAL)
-	FAST_IO_IF_CONSTEVAL
+	if (__builtin_is_constant_evaluated())
 	{
 		return new nt_dirent;
 	}
 	else
-#endif
 	{
 		nt_dirent_space_guard<Allocator, nt_dirent> guard;
 		guard.ptr = typed_generic_allocator_adapter<Allocator, nt_dirent>::allocate(1);
@@ -85,13 +83,11 @@ inline
 	void
 	delete_nt_dirent(nt_dirent *ptr) noexcept
 {
-#if defined(FAST_IO_IF_CONSTEVAL)
-	FAST_IO_IF_CONSTEVAL
+	if (__builtin_is_constant_evaluated())
 	{
 		delete ptr;
 	}
 	else
-#endif
 	{
 		if (ptr == nullptr)
 		{

--- a/include/fast_io_unit/string_impl/ostring_ref.h
+++ b/include/fast_io_unit/string_impl/ostring_ref.h
@@ -75,13 +75,9 @@ inline constexpr void
 strlike_set_curr(io_strlike_type_t<char_type, ::std::basic_string<char_type, traits_type, allocator_type>>,
 				 ::std::basic_string<char_type, traits_type, allocator_type> &str, char_type *p)
 {
-#if (__cpp_lib_is_constant_evaluated >= 201811L || __cpp_if_consteval >= 202106L) && \
+#if defined(FAST_IO_IF_CONSTEVAL)\
 	(__cpp_lib_string_resize_and_overwrite >= 202110L || __cpp_constexpr_dynamic_alloc >= 201907L)
-#if __cpp_if_consteval >= 202106L
-	if consteval
-#else
-	if (::std::is_constant_evaluated())
-#endif
+	FAST_IO_IF_CONSTEVAL
 	{
 		auto old_ptr{str.data()};
 		::std::size_t const sz{static_cast<::std::size_t>(p - str.data())};

--- a/include/fast_io_unit/string_impl/ostring_ref.h
+++ b/include/fast_io_unit/string_impl/ostring_ref.h
@@ -75,9 +75,8 @@ inline constexpr void
 strlike_set_curr(io_strlike_type_t<char_type, ::std::basic_string<char_type, traits_type, allocator_type>>,
 				 ::std::basic_string<char_type, traits_type, allocator_type> &str, char_type *p)
 {
-#if defined(FAST_IO_IF_CONSTEVAL)\
-	(__cpp_lib_string_resize_and_overwrite >= 202110L || __cpp_constexpr_dynamic_alloc >= 201907L)
-	FAST_IO_IF_CONSTEVAL
+#if (__cpp_lib_string_resize_and_overwrite >= 202110L || __cpp_constexpr_dynamic_alloc >= 201907L)
+	if (__builtin_is_constant_evaluated())
 	{
 		auto old_ptr{str.data()};
 		::std::size_t const sz{static_cast<::std::size_t>(p - str.data())};


### PR DESCRIPTION
Replace the use of if consteval with a macro, and use ::std::is_constant_evalued() instead of if consteval under msvc, Because msvc has a bug in its implementation of if consteval (which doesn't behave the same as ::std::is_constant_evalued())