### PR TITLE
Call vfork through libc only

### DIFF
--- a/include/fast_io_hosted/platforms/linux/aarch64.h
+++ b/include/fast_io_hosted/platforms/linux/aarch64.h
@@ -5,11 +5,6 @@ namespace fast_io
 
 template <::std::size_t syscall_number, ::std::signed_integral return_value_type>
 	requires(1 < sizeof(return_value_type))
-#if __has_cpp_attribute(__gnu__::__always_inline__)
-[[__gnu__::__always_inline__]]
-#else
-#error "system_call must be inlined"
-#endif
 inline return_value_type system_call() noexcept
 {
 	register ::std::uint_least64_t x8 __asm__("x8") = syscall_number;
@@ -20,11 +15,6 @@ inline return_value_type system_call() noexcept
 
 template <::std::size_t syscall_number, ::std::signed_integral return_value_type>
 	requires(1 < sizeof(return_value_type))
-#if __has_cpp_attribute(__gnu__::__always_inline__)
-[[__gnu__::__always_inline__]]
-#else
-#error "system_call must be inlined"
-#endif
 inline return_value_type system_call(auto p1) noexcept
 {
 	register ::std::uint_least64_t x8 __asm__("x8") = syscall_number;
@@ -34,11 +24,6 @@ inline return_value_type system_call(auto p1) noexcept
 }
 
 template <::std::size_t syscall_number>
-#if __has_cpp_attribute(__gnu__::__always_inline__)
-[[__gnu__::__always_inline__]]
-#else
-#error "system_call must be inlined"
-#endif
 inline void system_call_no_return(auto p1) noexcept
 {
 	register ::std::uint_least64_t x8 __asm__("x8") = syscall_number;
@@ -49,11 +34,6 @@ inline void system_call_no_return(auto p1) noexcept
 
 template <::std::size_t syscall_number, ::std::signed_integral return_value_type>
 	requires(1 < sizeof(return_value_type))
-#if __has_cpp_attribute(__gnu__::__always_inline__)
-[[__gnu__::__always_inline__]]
-#else
-#error "system_call must be inlined"
-#endif
 inline return_value_type system_call(auto p1, auto p2) noexcept
 {
 	register ::std::uint_least64_t x8 __asm__("x8") = syscall_number;
@@ -65,11 +45,6 @@ inline return_value_type system_call(auto p1, auto p2) noexcept
 
 template <::std::size_t syscall_number, ::std::signed_integral return_value_type>
 	requires(1 < sizeof(return_value_type))
-#if __has_cpp_attribute(__gnu__::__always_inline__)
-[[__gnu__::__always_inline__]]
-#else
-#error "system_call must be inlined"
-#endif
 inline return_value_type system_call(auto p1, auto p2, auto p3) noexcept
 {
 	register ::std::uint_least64_t x8 __asm__("x8") = syscall_number;
@@ -82,11 +57,6 @@ inline return_value_type system_call(auto p1, auto p2, auto p3) noexcept
 
 template <::std::size_t syscall_number, ::std::signed_integral return_value_type>
 	requires(1 < sizeof(return_value_type))
-#if __has_cpp_attribute(__gnu__::__always_inline__)
-[[__gnu__::__always_inline__]]
-#else
-#error "system_call must be inlined"
-#endif
 inline return_value_type system_call(auto p1, auto p2, auto p3, auto p4) noexcept
 {
 	register ::std::uint_least64_t x8 __asm__("x8") = syscall_number;
@@ -100,11 +70,6 @@ inline return_value_type system_call(auto p1, auto p2, auto p3, auto p4) noexcep
 
 template <::std::size_t syscall_number, ::std::signed_integral return_value_type>
 	requires(1 < sizeof(return_value_type))
-#if __has_cpp_attribute(__gnu__::__always_inline__)
-[[__gnu__::__always_inline__]]
-#else
-#error "system_call must be inlined"
-#endif
 inline return_value_type system_call(auto p1, auto p2, auto p3, auto p4, auto p5) noexcept
 {
 	register ::std::uint_least64_t x8 __asm__("x8") = syscall_number;
@@ -119,11 +84,6 @@ inline return_value_type system_call(auto p1, auto p2, auto p3, auto p4, auto p5
 
 template <::std::size_t syscall_number, ::std::signed_integral return_value_type>
 	requires(1 < sizeof(return_value_type))
-#if __has_cpp_attribute(__gnu__::__always_inline__)
-[[__gnu__::__always_inline__]]
-#else
-#error "system_call must be inlined"
-#endif
 inline return_value_type system_call(auto p1, auto p2, auto p3, auto p4, auto p5, auto p6) noexcept
 {
 	register ::std::uint_least64_t x8 __asm__("x8") = syscall_number;

--- a/include/fast_io_hosted/platforms/linux/amd64.h
+++ b/include/fast_io_hosted/platforms/linux/amd64.h
@@ -3,13 +3,9 @@
 
 namespace fast_io
 {
+
 template <::std::size_t syscall_number, ::std::signed_integral return_value_type>
 	requires(1 < sizeof(return_value_type))
-#if __has_cpp_attribute(__gnu__::__always_inline__)
-[[__gnu__::__always_inline__]]
-#else
-#error "system_call must be inlined"
-#endif
 inline return_value_type system_call() noexcept
 {
 	return_value_type ret;
@@ -23,11 +19,6 @@ inline return_value_type system_call() noexcept
 
 template <::std::size_t syscall_number, ::std::signed_integral return_value_type>
 	requires(1 < sizeof(return_value_type))
-#if __has_cpp_attribute(__gnu__::__always_inline__)
-[[__gnu__::__always_inline__]]
-#else
-#error "system_call must be inlined"
-#endif
 inline return_value_type system_call(auto p1) noexcept
 {
 	return_value_type ret;
@@ -40,11 +31,6 @@ inline return_value_type system_call(auto p1) noexcept
 }
 
 template <::std::size_t syscall_number>
-#if __has_cpp_attribute(__gnu__::__always_inline__)
-[[__gnu__::__always_inline__]]
-#else
-#error "system_call must be inlined"
-#endif
 inline void system_call_no_return(auto p1) noexcept
 {
 	::std::size_t ret;
@@ -58,11 +44,6 @@ inline void system_call_no_return(auto p1) noexcept
 
 template <::std::size_t syscall_number, ::std::signed_integral return_value_type>
 	requires(1 < sizeof(return_value_type))
-#if __has_cpp_attribute(__gnu__::__always_inline__)
-[[__gnu__::__always_inline__]]
-#else
-#error "system_call must be inlined"
-#endif
 inline return_value_type system_call(auto p1, auto p2) noexcept
 {
 	return_value_type ret;
@@ -76,11 +57,6 @@ inline return_value_type system_call(auto p1, auto p2) noexcept
 
 template <::std::size_t syscall_number, ::std::signed_integral return_value_type>
 	requires(1 < sizeof(return_value_type))
-#if __has_cpp_attribute(__gnu__::__always_inline__)
-[[__gnu__::__always_inline__]]
-#else
-#error "system_call must be inlined"
-#endif
 inline return_value_type system_call(auto p1, auto p2, auto p3) noexcept
 {
 	return_value_type ret;
@@ -94,11 +70,6 @@ inline return_value_type system_call(auto p1, auto p2, auto p3) noexcept
 
 template <::std::size_t syscall_number, ::std::signed_integral return_value_type>
 	requires(1 < sizeof(return_value_type))
-#if __has_cpp_attribute(__gnu__::__always_inline__)
-[[__gnu__::__always_inline__]]
-#else
-#error "system_call must be inlined"
-#endif
 inline return_value_type system_call(auto p1, auto p2, auto p3, auto p4) noexcept
 {
 	return_value_type ret;
@@ -113,11 +84,6 @@ inline return_value_type system_call(auto p1, auto p2, auto p3, auto p4) noexcep
 
 template <::std::size_t syscall_number, ::std::signed_integral return_value_type>
 	requires(1 < sizeof(return_value_type))
-#if __has_cpp_attribute(__gnu__::__always_inline__)
-[[__gnu__::__always_inline__]]
-#else
-#error "system_call must be inlined"
-#endif
 inline return_value_type system_call(auto p1, auto p2, auto p3, auto p4, auto p5) noexcept
 {
 	return_value_type ret;
@@ -133,11 +99,6 @@ inline return_value_type system_call(auto p1, auto p2, auto p3, auto p4, auto p5
 
 template <::std::size_t syscall_number, ::std::signed_integral return_value_type>
 	requires(1 < sizeof(return_value_type))
-#if __has_cpp_attribute(__gnu__::__always_inline__)
-[[__gnu__::__always_inline__]]
-#else
-#error "system_call must be inlined"
-#endif
 inline return_value_type system_call(auto p1, auto p2, auto p3, auto p4, auto p5, auto p6) noexcept
 {
 	return_value_type ret;

--- a/include/fast_io_hosted/platforms/linux/generic.h
+++ b/include/fast_io_hosted/platforms/linux/generic.h
@@ -7,11 +7,6 @@ namespace fast_io
 
 template <::std::size_t syscall_number, ::std::signed_integral return_value_type, typename... Args>
 	requires(::std::is_trivially_copyable_v<Args> && ...)
-#if __has_cpp_attribute(__gnu__::__always_inline__)
-[[__gnu__::__always_inline__]]
-#else
-#error "system_call must be inlined"
-#endif
 inline return_value_type system_call(Args... args) noexcept
 {
 	long ret{::syscall(syscall_number, args...)};
@@ -23,11 +18,6 @@ inline return_value_type system_call(Args... args) noexcept
 }
 
 template <::std::size_t syscall_number>
-#if __has_cpp_attribute(__gnu__::__always_inline__)
-[[__gnu__::__always_inline__]]
-#else
-#error "system_call must be inlined"
-#endif
 inline void system_call_no_return(auto p1) noexcept
 {
 	::syscall(syscall_number, p1);

--- a/include/fast_io_hosted/platforms/linux/loongarch64.h
+++ b/include/fast_io_hosted/platforms/linux/loongarch64.h
@@ -10,11 +10,6 @@ namespace fast_io
 
 template <::std::uint_least64_t syscall_number, ::std::signed_integral return_value_type>
 	requires(1 < sizeof(return_value_type))
-#if __has_cpp_attribute(__gnu__::__always_inline__)
-[[__gnu__::__always_inline__]]
-#else
-#error "system_call must be inlined"
-#endif
 inline return_value_type system_call() noexcept
 {
 	register ::std::uint_least64_t a7 __asm__("$a7") = syscall_number;
@@ -26,11 +21,6 @@ inline return_value_type system_call() noexcept
 
 template <::std::uint_least64_t syscall_number, ::std::signed_integral return_value_type>
 	requires(1 < sizeof(return_value_type))
-#if __has_cpp_attribute(__gnu__::__always_inline__)
-[[__gnu__::__always_inline__]]
-#else
-#error "system_call must be inlined"
-#endif
 inline return_value_type system_call(auto p1) noexcept
 {
 	register ::std::uint_least64_t a7 __asm__("$a7") = syscall_number;
@@ -41,11 +31,6 @@ inline return_value_type system_call(auto p1) noexcept
 }
 
 template <::std::uint_least64_t syscall_number>
-#if __has_cpp_attribute(__gnu__::__always_inline__)
-[[__gnu__::__always_inline__]]
-#else
-#error "system_call must be inlined"
-#endif
 inline void system_call_no_return(auto p1) noexcept
 {
 	register ::std::uint_least64_t a7 __asm__("$a7") = syscall_number;
@@ -57,11 +42,6 @@ inline void system_call_no_return(auto p1) noexcept
 
 template <::std::uint_least64_t syscall_number, ::std::signed_integral return_value_type>
 	requires(1 < sizeof(return_value_type))
-#if __has_cpp_attribute(__gnu__::__always_inline__)
-[[__gnu__::__always_inline__]]
-#else
-#error "system_call must be inlined"
-#endif
 inline return_value_type system_call(auto p1, auto p2) noexcept
 {
 	register ::std::uint_least64_t a7 __asm__("$a7") = syscall_number;
@@ -74,11 +54,6 @@ inline return_value_type system_call(auto p1, auto p2) noexcept
 
 template <::std::uint_least64_t syscall_number, ::std::signed_integral return_value_type>
 	requires(1 < sizeof(return_value_type))
-#if __has_cpp_attribute(__gnu__::__always_inline__)
-[[__gnu__::__always_inline__]]
-#else
-#error "system_call must be inlined"
-#endif
 inline return_value_type system_call(auto p1, auto p2, auto p3) noexcept
 {
 	register ::std::uint_least64_t a7 __asm__("$a7") = syscall_number;
@@ -92,11 +67,6 @@ inline return_value_type system_call(auto p1, auto p2, auto p3) noexcept
 
 template <::std::uint_least64_t syscall_number, ::std::signed_integral return_value_type>
 	requires(1 < sizeof(return_value_type))
-#if __has_cpp_attribute(__gnu__::__always_inline__)
-[[__gnu__::__always_inline__]]
-#else
-#error "system_call must be inlined"
-#endif
 inline return_value_type system_call(auto p1, auto p2, auto p3, auto p4) noexcept
 {
 	register ::std::uint_least64_t a7 __asm__("$a7") = syscall_number;
@@ -111,11 +81,6 @@ inline return_value_type system_call(auto p1, auto p2, auto p3, auto p4) noexcep
 
 template <::std::uint_least64_t syscall_number, ::std::signed_integral return_value_type>
 	requires(1 < sizeof(return_value_type))
-#if __has_cpp_attribute(__gnu__::__always_inline__)
-[[__gnu__::__always_inline__]]
-#else
-#error "system_call must be inlined"
-#endif
 inline return_value_type system_call(auto p1, auto p2, auto p3, auto p4, auto p5) noexcept
 {
 	register ::std::uint_least64_t a7 __asm__("$a7") = syscall_number;
@@ -131,11 +96,6 @@ inline return_value_type system_call(auto p1, auto p2, auto p3, auto p4, auto p5
 
 template <::std::uint_least64_t syscall_number, ::std::signed_integral return_value_type>
 	requires(1 < sizeof(return_value_type))
-#if __has_cpp_attribute(__gnu__::__always_inline__)
-[[__gnu__::__always_inline__]]
-#else
-#error "system_call must be inlined"
-#endif
 inline return_value_type system_call(auto p1, auto p2, auto p3, auto p4, auto p5, auto p6) noexcept
 {
 	register ::std::uint_least64_t a7 __asm__("$a7") = syscall_number;

--- a/include/fast_io_hosted/platforms/linux/riscv64.h
+++ b/include/fast_io_hosted/platforms/linux/riscv64.h
@@ -10,11 +10,6 @@ namespace fast_io
 
 template <::std::uint_least64_t syscall_number, ::std::signed_integral return_value_type>
 	requires(1 < sizeof(return_value_type))
-#if __has_cpp_attribute(__gnu__::__always_inline__)
-[[__gnu__::__always_inline__]]
-#else
-#error "system_call must be inlined"
-#endif
 inline return_value_type system_call() noexcept
 {
 	register ::std::uint_least64_t a7 __asm__("a7") = syscall_number;
@@ -25,11 +20,6 @@ inline return_value_type system_call() noexcept
 
 template <::std::uint_least64_t syscall_number, ::std::signed_integral return_value_type>
 	requires(1 < sizeof(return_value_type))
-#if __has_cpp_attribute(__gnu__::__always_inline__)
-[[__gnu__::__always_inline__]]
-#else
-#error "system_call must be inlined"
-#endif
 inline return_value_type system_call(auto p1) noexcept
 {
 	register ::std::uint_least64_t a7 __asm__("a7") = syscall_number;
@@ -39,11 +29,6 @@ inline return_value_type system_call(auto p1) noexcept
 }
 
 template <::std::uint_least64_t syscall_number>
-#if __has_cpp_attribute(__gnu__::__always_inline__)
-[[__gnu__::__always_inline__]]
-#else
-#error "system_call must be inlined"
-#endif
 inline void system_call_no_return(auto p1) noexcept
 {
 	register ::std::uint_least64_t a7 __asm__("a7") = syscall_number;
@@ -54,11 +39,6 @@ inline void system_call_no_return(auto p1) noexcept
 
 template <::std::uint_least64_t syscall_number, ::std::signed_integral return_value_type>
 	requires(1 < sizeof(return_value_type))
-#if __has_cpp_attribute(__gnu__::__always_inline__)
-[[__gnu__::__always_inline__]]
-#else
-#error "system_call must be inlined"
-#endif
 inline return_value_type system_call(auto p1, auto p2) noexcept
 {
 	register ::std::uint_least64_t a7 __asm__("a7") = syscall_number;
@@ -70,11 +50,6 @@ inline return_value_type system_call(auto p1, auto p2) noexcept
 
 template <::std::uint_least64_t syscall_number, ::std::signed_integral return_value_type>
 	requires(1 < sizeof(return_value_type))
-#if __has_cpp_attribute(__gnu__::__always_inline__)
-[[__gnu__::__always_inline__]]
-#else
-#error "system_call must be inlined"
-#endif
 inline return_value_type system_call(auto p1, auto p2, auto p3) noexcept
 {
 	register ::std::uint_least64_t a7 __asm__("a7") = syscall_number;
@@ -87,11 +62,6 @@ inline return_value_type system_call(auto p1, auto p2, auto p3) noexcept
 
 template <::std::uint_least64_t syscall_number, ::std::signed_integral return_value_type>
 	requires(1 < sizeof(return_value_type))
-#if __has_cpp_attribute(__gnu__::__always_inline__)
-[[__gnu__::__always_inline__]]
-#else
-#error "system_call must be inlined"
-#endif
 inline return_value_type system_call(auto p1, auto p2, auto p3, auto p4) noexcept
 {
 	register ::std::uint_least64_t a7 __asm__("a7") = syscall_number;
@@ -105,11 +75,6 @@ inline return_value_type system_call(auto p1, auto p2, auto p3, auto p4) noexcep
 
 template <::std::uint_least64_t syscall_number, ::std::signed_integral return_value_type>
 	requires(1 < sizeof(return_value_type))
-#if __has_cpp_attribute(__gnu__::__always_inline__)
-[[__gnu__::__always_inline__]]
-#else
-#error "system_call must be inlined"
-#endif
 inline return_value_type system_call(auto p1, auto p2, auto p3, auto p4, auto p5) noexcept
 {
 	register ::std::uint_least64_t a7 __asm__("a7") = syscall_number;
@@ -124,11 +89,6 @@ inline return_value_type system_call(auto p1, auto p2, auto p3, auto p4, auto p5
 
 template <::std::uint_least64_t syscall_number, ::std::signed_integral return_value_type>
 	requires(1 < sizeof(return_value_type))
-#if __has_cpp_attribute(__gnu__::__always_inline__)
-[[__gnu__::__always_inline__]]
-#else
-#error "system_call must be inlined"
-#endif
 inline return_value_type system_call(auto p1, auto p2, auto p3, auto p4, auto p5, auto p6) noexcept
 {
 	register ::std::uint_least64_t a7 __asm__("a7") = syscall_number;

--- a/include/fast_io_hosted/process/process/posix.h
+++ b/include/fast_io_hosted/process/process/posix.h
@@ -471,21 +471,12 @@ struct fd_remapper
 // only used in vfork_execveat_common_impl()
 inline void vfork_and_execveat(pid_t &pid, int dirfd, char const *cstr, char const *const *args, char const *const *envp, int volatile &t_errno, process_mode mode) noexcept
 {
-#if defined(__linux__) && defined(__NR_vfork)
-	// NOTE: vfork and exec must be in the same function!!!
-	// system_call can't be used here
-	__asm__ __volatile__("syscall"
-						 : "=a"(pid)
-						 : "0"(__NR_vfork)
-						 : "memory", "cc", "r11", "cx");
-	system_call_throw_error(pid);
-#else
+    // vfork can only be called through libc wrapper
 	pid = ::fast_io::posix::libc_vfork();
 	if (pid == -1) [[unlikely]]
 	{
 		throw_posix_error();
 	}
-#endif
 	if (pid != 0)
 	{
 		return;

--- a/include/fast_io_hosted/process/process/posix.h
+++ b/include/fast_io_hosted/process/process/posix.h
@@ -472,7 +472,12 @@ struct fd_remapper
 inline void vfork_and_execveat(pid_t &pid, int dirfd, char const *cstr, char const *const *args, char const *const *envp, int volatile &t_errno, process_mode mode) noexcept
 {
 #if defined(__linux__) && defined(__NR_vfork)
-    pid = system_call<__NR_vfork, pid_t>();
+	// NOTE: vfork and exec must be in the same function!!!
+	// system_call can't be used here
+	__asm__ __volatile__("syscall"
+						 : "=a"(pid)
+						 : "0"(__NR_vfork)
+						 : "memory", "cc", "r11", "cx");
 	system_call_throw_error(pid);
 #else
 	pid = ::fast_io::posix::libc_vfork();


### PR DESCRIPTION
The libc syscall() function does not handle vfork correctly
The vfork syscall is similar to fork, as it returns both in the child process and the parent process
The key difference is that the child process created by vfork shares the address space with the parent until an _exit or execve syscall is executed
This means even a simple function return in the child process can corrupt the parent's memory
The vfork api in libc is specially designed to back up and restore critical memory during a vfork syscall, which makes it irreplaceable by fast_io