### PR TITLE
Suggesting for using is_copy_constructible_v in copy constructor

### DIFF
--- a/examples/0039.gen_win32_mangling/arm-windows-msvc.cc
+++ b/examples/0039.gen_win32_mangling/arm-windows-msvc.cc
@@ -6,7 +6,7 @@ inline auto gen_pragmas(char8_t const *asmpath, ::fast_io::vector<::fast_io::u8s
 	bool is_win32_symbols{true};
 	::std::size_t symbols_index{};
 	auto asmfile = ::fast_io::native_file_loader{::fast_io::mnp::os_c_str(asmpath)};
-	auto const &&asmfile_size = asmfile.size();
+	auto const asmfile_size = asmfile.size();
 	for (::std::size_t i{}; i < asmfile_size; ++i)
 	{
 		if (asmfile[i + 0] == u8'm' && asmfile[i + 1] == u8'o' && asmfile[i + 2] == u8'v' && asmfile[i + 3] == u8'w')

--- a/examples/0039.gen_win32_mangling/arm64ec-windows-msvc.cc
+++ b/examples/0039.gen_win32_mangling/arm64ec-windows-msvc.cc
@@ -6,7 +6,7 @@ inline auto gen_pragmas(char8_t const *asmpath, ::fast_io::vector<::fast_io::u8s
 	bool is_win32_symbols{true};
 	::std::size_t symbols_index{};
 	auto asmfile = ::fast_io::native_file_loader{::fast_io::mnp::os_c_str(asmpath)};
-	auto const &&asmfile_size = asmfile.size();
+	auto const asmfile_size = asmfile.size();
 	for (::std::size_t i{}; i < asmfile_size; ++i)
 	{
 		while (asmfile[i] == u8'\t' || asmfile[i] == u8' ' || asmfile[i] == u8'\n')

--- a/examples/0039.gen_win32_mangling/common.h
+++ b/examples/0039.gen_win32_mangling/common.h
@@ -12,7 +12,7 @@ inline ::fast_io::vector<::fast_io::u8string> parse_symbols(char8_t const *path)
 	::fast_io::vector<::fast_io::u8string> result;
 	// TODO native_file_loader do not suppport ::fast_io::string_view
 	::fast_io::native_file_loader symbols_loader{::fast_io::mnp::os_c_str(path)};
-	auto const &&symbols_loader_size = symbols_loader.size();
+	auto const symbols_loader_size = symbols_loader.size();
 	for (::std::size_t i{}; i < symbols_loader_size; ++i)
 	{
 		::fast_io::u8string tmp{};

--- a/examples/0039.gen_win32_mangling/i686-windows-msvc.cc
+++ b/examples/0039.gen_win32_mangling/i686-windows-msvc.cc
@@ -9,7 +9,7 @@ inline auto parse_symbols(char8_t const *path)
 	::fast_io::vector<::fast_io::u8string> result;
 	// TODO native_file_loader do not suppport ::fast_io::string_view
 	::fast_io::native_file_loader symbols_loader{::fast_io::mnp::os_c_str(path)};
-	auto const &&symbols_loader_size = symbols_loader.size();
+	auto const symbols_loader_size = symbols_loader.size();
 	for (::std::size_t i{}; i < symbols_loader_size; ++i)
 	{
 		::fast_io::u8string tmp{};
@@ -35,7 +35,7 @@ inline auto gen_pragmas(char8_t const *asmpath, ::fast_io::vector<::fast_io::u8s
 	bool is_win32_symbols{true};
 	::std::size_t symbols_index{};
 	auto asmfile = ::fast_io::native_file_loader{::fast_io::mnp::os_c_str(asmpath)};
-	auto const &&asmfile_size = asmfile.size();
+	auto const asmfile_size = asmfile.size();
 	for (::std::size_t i{}; i < asmfile_size; ++i)
 	{
 		if (asmfile[i] == u8'c' && asmfile[i + 1] == u8'a' && asmfile[i + 2] == u8'l' && asmfile[i + 3] == u8'l' && asmfile[i + 4] == u8'l')

--- a/examples/0039.gen_win32_mangling/prebuild.cc
+++ b/examples/0039.gen_win32_mangling/prebuild.cc
@@ -28,7 +28,7 @@ inline auto gen_apis(
 {
 	::fast_io::u8string main_body{};
 	function_declaration.append(::fast_io::u8concat_fast_io(u8"namespace ", prefix, u8" {\n"));
-	auto const &&header_size = context.size();
+	auto const header_size = context.size();
 	for (::std::size_t i{}; i < header_size; ++i)
 	{
 		// FAST_IO_DLLIMPORT
@@ -189,8 +189,8 @@ int main(int argc, char *const *const argv)
 
 	::fast_io::native_mkdirat(::fast_io::at_fdcwd(), "build");
 
-	auto const &&nt_header = ::fast_io::native_file_loader{"../../include/fast_io_hosted/platforms/nt/nt_api.h"};
-	auto const &&win32_header = ::fast_io::native_file_loader{"../../include/fast_io_hosted/platforms/win32/apis.h"};
+	auto const nt_header = ::fast_io::native_file_loader{"../../include/fast_io_hosted/platforms/nt/nt_api.h"};
+	auto const win32_header = ::fast_io::native_file_loader{"../../include/fast_io_hosted/platforms/win32/apis.h"};
 
 	::fast_io::u8string win32_declaration{}, nt_declaration{}, win32_symbols{}, nt_symbols{};
 	// process win32 apis.h

--- a/examples/0039.gen_win32_mangling/x86_64-windows-msvc.cc
+++ b/examples/0039.gen_win32_mangling/x86_64-windows-msvc.cc
@@ -6,7 +6,7 @@ inline auto gen_pragmas(char8_t const *asmpath, ::fast_io::vector<::fast_io::u8s
 	bool is_win32_symbols{true};
 	::std::size_t symbols_index{};
 	auto asmfile = ::fast_io::native_file_loader{::fast_io::mnp::os_c_str(asmpath)};
-	auto const &&asmfile_size = asmfile.size();
+	auto const asmfile_size = asmfile.size();
 	for (::std::size_t i{}; i < asmfile_size; ++i)
 	{
 		if (asmfile[i] == u8'c' && asmfile[i + 1] == u8'a' && asmfile[i + 2] == u8'l' && asmfile[i + 3] == u8'l' && asmfile[i + 4] == u8'q')

--- a/include/fast_io_dsal/impl/vector.h
+++ b/include/fast_io_dsal/impl/vector.h
@@ -397,7 +397,7 @@ public:
 	}
 
 	inline constexpr vector(vector const &vec)
-		requires(::std::copyable<value_type>)
+		requires(::std::is_copy_constructible_v<value_type>)
 	{
 		std::size_t const vecsize{static_cast<std::size_t>(vec.imp.curr_ptr - vec.imp.begin_ptr)};
 		if (vecsize == 0)

--- a/include/fast_io_dsal/impl/vector.h
+++ b/include/fast_io_dsal/impl/vector.h
@@ -201,7 +201,7 @@ struct vector_internal
 
 } // namespace details
 
-template <::std::movable T, typename allocator>
+template <typename T, typename allocator>
 class vector FAST_IO_TRIVIALLY_RELOCATABLE_IF_ELIGIBLE
 {
 public:


### PR DESCRIPTION
::std::copyable is too strict for copy constructor because it requires both is_copy_constructible_v and
::std::is_copy_assignable_v. A class has copy constructor but disables copy assign operator may sounds weird but it DO troubles me. Therefore, if you agree with me, I'll handle other similar requires.