### PR TITLE
Fix try block enable mechanism

### DIFF
--- a/include/fast_io_dsal/impl/misc/pop_macros.h
+++ b/include/fast_io_dsal/impl/misc/pop_macros.h
@@ -1,5 +1,6 @@
 ﻿// Please keep it in reverse order with the macros in push_macros.h
 
+#pragma pop_macro("FAST_IO_CPP_EXCEPTIONS")
 #pragma pop_macro("FAST_IO_HAS_BUILTIN")
 #pragma pop_macro("FAST_IO_TRIVIALLY_RELOCATABLE_IF_ELIGIBLE")
 #pragma pop_macro("FAST_IO_ASSERT")

--- a/include/fast_io_dsal/impl/misc/pop_macros.h
+++ b/include/fast_io_dsal/impl/misc/pop_macros.h
@@ -1,6 +1,7 @@
 ﻿// Please keep it in reverse order with the macros in push_macros.h
 
 #pragma pop_macro("FAST_IO_CPP_EXCEPTIONS")
+#pragma pop_macro("FAST_IO_CPP_RTTI")
 #pragma pop_macro("FAST_IO_HAS_BUILTIN")
 #pragma pop_macro("FAST_IO_TRIVIALLY_RELOCATABLE_IF_ELIGIBLE")
 #pragma pop_macro("FAST_IO_ASSERT")

--- a/include/fast_io_dsal/impl/misc/push_macros.h
+++ b/include/fast_io_dsal/impl/misc/push_macros.h
@@ -225,14 +225,26 @@ Internal assert macros for fuzzing fast_io.
 # define FAST_IO_HAS_BUILTIN(...) 0
 #endif
 
+#pragma push_macro("FAST_IO_CPP_RTTI")
+#undef FAST_IO_CPP_RTTI
+#if defined(_MSC_VER) && !defined(__clang__)
+#if __cpp_rtti >= 199711L && _HAS_RTTI != 0
+#define FAST_IO_CPP_RTTI
+#endif
+#else
+#if __cpp_rtti >= 199711L
+#define FAST_IO_CPP_RTTI
+#endif
+#endif
+
 #pragma push_macro("FAST_IO_CPP_EXCEPTIONS")
 #undef FAST_IO_CPP_EXCEPTIONS
 #if defined(_MSC_VER) && !defined(__clang__)
-#if __cpp_exceptions >= 199711L && _HAS_EXCEPTIONS != 0
+#if defined(FAST_IO_CPP_RTTI) && __cpp_exceptions >= 199711L && _HAS_EXCEPTIONS != 0
 #define FAST_IO_CPP_EXCEPTIONS
 #endif
 #else
-#if __cpp_exceptions >= 199711L
+#if defined(FAST_IO_CPP_RTTI) && __cpp_exceptions >= 199711L
 #define FAST_IO_CPP_EXCEPTIONS
 #endif
 #endif

--- a/include/fast_io_dsal/impl/misc/push_macros.h
+++ b/include/fast_io_dsal/impl/misc/push_macros.h
@@ -227,7 +227,7 @@ Internal assert macros for fuzzing fast_io.
 
 #pragma push_macro("FAST_IO_CPP_EXCEPTIONS")
 #undef FAST_IO_CPP_EXCEPTIONS
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && !defined(__clang__)
 #if __cpp_exceptions >= 199711L && _HAS_EXCEPTIONS != 0
 #define FAST_IO_CPP_EXCEPTIONS
 #endif

--- a/include/fast_io_dsal/impl/misc/push_macros.h
+++ b/include/fast_io_dsal/impl/misc/push_macros.h
@@ -224,3 +224,15 @@ Internal assert macros for fuzzing fast_io.
 #else
 # define FAST_IO_HAS_BUILTIN(...) 0
 #endif
+
+#pragma push_macro("FAST_IO_CPP_EXCEPTIONS")
+#undef FAST_IO_CPP_EXCEPTIONS
+#ifdef _MSC_VER
+#if __cpp_exceptions >= 199711L && _HAS_EXCEPTIONS != 0
+#define FAST_IO_CPP_EXCEPTIONS
+#endif
+#else
+#if __cpp_exceptions >= 199711L
+#define FAST_IO_CPP_EXCEPTIONS
+#endif
+#endif

--- a/include/fast_io_freestanding_impl/io_buffer/destroy.h
+++ b/include/fast_io_freestanding_impl/io_buffer/destroy.h
@@ -37,13 +37,13 @@ inline constexpr void destroy_basic_io_buffer(T &t) noexcept
 	constexpr auto mode{traits_type::mode};
 	if constexpr ((mode & buffer_mode::out) == buffer_mode::out)
 	{
-#if (defined(_MSC_VER) && _HAS_EXCEPTIONS != 0) || (!defined(_MSC_VER) && defined(__cpp_exceptions))
+#if __cpp_exceptions >= 199711L
 		try
-		{
 #endif
+		{
 			::fast_io::details::close_basic_io_buffer(t);
-#if (defined(_MSC_VER) && _HAS_EXCEPTIONS != 0) || (!defined(_MSC_VER) && defined(__cpp_exceptions))
 		}
+#if __cpp_exceptions >= 199711L
 		catch (...)
 		{
 		}

--- a/include/fast_io_freestanding_impl/io_buffer/destroy.h
+++ b/include/fast_io_freestanding_impl/io_buffer/destroy.h
@@ -37,13 +37,13 @@ inline constexpr void destroy_basic_io_buffer(T &t) noexcept
 	constexpr auto mode{traits_type::mode};
 	if constexpr ((mode & buffer_mode::out) == buffer_mode::out)
 	{
-#if (defined(_MSC_VER) && !defined(__clang__) && _HAS_EXCEPTIONS != 0) || (!defined(_MSC_VER) && defined(__cpp_exceptions))
+#ifdef FAST_IO_CPP_EXCEPTIONS
 		try
 #endif
 		{
 			::fast_io::details::close_basic_io_buffer(t);
 		}
-#if (defined(_MSC_VER) && !defined(__clang__) && _HAS_EXCEPTIONS != 0) || (!defined(_MSC_VER) && defined(__cpp_exceptions))
+#ifdef FAST_IO_CPP_EXCEPTIONS
 		catch (...)
 		{
 		}

--- a/include/fast_io_freestanding_impl/io_buffer/destroy.h
+++ b/include/fast_io_freestanding_impl/io_buffer/destroy.h
@@ -37,13 +37,13 @@ inline constexpr void destroy_basic_io_buffer(T &t) noexcept
 	constexpr auto mode{traits_type::mode};
 	if constexpr ((mode & buffer_mode::out) == buffer_mode::out)
 	{
-#if __cpp_exceptions >= 199711L
+#if (defined(_MSC_VER) && !defined(__clang__) && _HAS_EXCEPTIONS != 0) || (!defined(_MSC_VER) && defined(__cpp_exceptions))
 		try
 #endif
 		{
 			::fast_io::details::close_basic_io_buffer(t);
 		}
-#if __cpp_exceptions >= 199711L
+#if (defined(_MSC_VER) && !defined(__clang__) && _HAS_EXCEPTIONS != 0) || (!defined(_MSC_VER) && defined(__cpp_exceptions))
 		catch (...)
 		{
 		}


### PR DESCRIPTION
* Following is the prove:

In file included from D:\a\pltxt2htm\pltxt2htm\cmd\..\include\fast_io/fast_io.h:10: In file included from D:\a\pltxt2htm\pltxt2htm\cmd\..\include\fast_io\fast_io_hosted.h:19: In file included from D:\a\pltxt2htm\pltxt2htm\cmd\..\include\fast_io\fast_io_freestanding.h:23: In file included from D:\a\pltxt2htm\pltxt2htm\cmd\..\include\fast_io\fast_io_freestanding_impl/io_buffer/impl.h:8: D:\a\pltxt2htm\pltxt2htm\cmd\..\include\fast_io\fast_io_freestanding_impl/io_buffer\destroy.h:41:3: error: cannot use 'try' with exceptions disabled
   41 |                 try
      |                 ^

Because

C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\vcruntime.h:104:33: note: expanded from macro '_HAS_EXCEPTIONS'
  104 |         #define _HAS_EXCEPTIONS 1
      |                                 ^

Above build error occured in x86_64-windows-msvc-clang with -fno-exceptions flag