### PR TITLE
Bugfix:  Avoid export posix libc symbol on windows in fast_io for C++…

### DIFF
--- a/share/fast_io/fast_io_inc/host/posix.inc
+++ b/share/fast_io/fast_io_inc/host/posix.inc
@@ -4,9 +4,10 @@ export namespace fast_io
     using ::fast_io::posix_stdin_number;
     using ::fast_io::posix_stdout_number;
     using ::fast_io::posix_stderr_number;
-
+#if ((!defined(_WIN32) || defined(__WINE__)) || defined(__CYGWIN__))
     namespace posix
     {
         using ::fast_io::posix::libc_ioctl;
     }
+#endif
 }


### PR DESCRIPTION
…20 module