### PR TITLE
Refactor memory unmapping functions to improve error handling

### DIFF
--- a/include/fast_io_hosted/file_loaders/posix_file_loader.h
+++ b/include/fast_io_hosted/file_loaders/posix_file_loader.h
@@ -34,7 +34,7 @@ inline void posix_unload_address(void *address, [[maybe_unused]] ::std::size_t f
 {
 	if (address != (void *)-1) [[likely]]
 	{
-		sys_munmap(address, file_size);
+		sys_munmap_nothrow(address, file_size);
 	}
 }
 

--- a/include/fast_io_hosted/platforms/posix_mapping.h
+++ b/include/fast_io_hosted/platforms/posix_mapping.h
@@ -69,7 +69,7 @@ inline int sys_mprotect(void *start, ::std::size_t len, int prot)
 	return result;
 }
 
-inline int sys_munmap(void *addr, ::std::size_t len)
+inline int sys_munmap_nothrow(void *addr, ::std::size_t len)
 {
 	return
 #if defined(__linux__) && defined(__NR_munmap)
@@ -79,9 +79,9 @@ inline int sys_munmap(void *addr, ::std::size_t len)
 #endif
 }
 
-inline void sys_munmap_throw_error(void *addr, ::std::size_t len)
+inline void sys_munmap(void *addr, ::std::size_t len)
 {
-	system_call_throw_error(sys_munmap(addr, len));
+	system_call_throw_error(sys_munmap_nothrow(addr, len));
 }
 } // namespace details
 
@@ -195,7 +195,7 @@ public:
 		}
 		if (this->address_begin != reinterpret_cast<::std::byte *>(MAP_FAILED)) [[likely]]
 		{
-			details::sys_munmap(this->address_begin, static_cast<::std::size_t>(address_end - address_begin));
+			details::sys_munmap_nothrow(this->address_begin, static_cast<::std::size_t>(address_end - address_begin));
 		}
 		this->address_begin = other.address_begin;
 		this->address_end = other.address_end;
@@ -295,7 +295,7 @@ public:
 	{
 		if (this->address_begin != MAP_FAILED) [[likely]]
 		{
-			auto ret{details::sys_munmap(this->address_begin, static_cast<::std::size_t>(address_end - address_begin))};
+			auto ret{details::sys_munmap_nothrow(this->address_begin, static_cast<::std::size_t>(address_end - address_begin))};
 			this->address_end = this->address_begin = reinterpret_cast<::std::byte *>(MAP_FAILED);
 			system_call_throw_error(ret);
 		}
@@ -304,7 +304,7 @@ public:
 	{
 		if (this->address_begin != MAP_FAILED) [[likely]]
 		{
-			details::sys_munmap(this->address_begin, static_cast<::std::size_t>(address_end - address_begin));
+			details::sys_munmap_nothrow(this->address_begin, static_cast<::std::size_t>(address_end - address_begin));
 		}
 	}
 };


### PR DESCRIPTION
- Renamed `sys_munmap` to `sys_munmap_nothrow` to indicate it does not throw errors.
- Updated calls to `sys_munmap` in `posix_file_loader.h` to use the new `sys_munmap_nothrow` function for safer memory management.