### PR TITLE
Refactor file size retrieval and enhance POSIX socket error handling

### DIFF
--- a/include/fast_io_hosted/file_loaders/file_size.h
+++ b/include/fast_io_hosted/file_loaders/file_size.h
@@ -170,7 +170,8 @@ inline ::std::size_t file_size(::fast_io::basic_win32_family_io_observer<family,
 template <nt_family family, ::std::integral char_type>
 inline ::std::size_t file_size(::fast_io::basic_nt_family_io_observer<family, char_type> observer)
 {
-	return win32::nt::details::nt_load_file_get_file_size(observer.handle);
+	constexpr bool zw{family == nt_family::zw};
+	return win32::nt::details::nt_load_file_get_file_size<zw>(observer.handle);
 }
 #endif
 

--- a/include/fast_io_hosted/filesystem/posix_at.h
+++ b/include/fast_io_hosted/filesystem/posix_at.h
@@ -186,13 +186,13 @@ inline void posix_faccessat_impl(int dirfd, char const *pathname, int mode, int 
 {
 	system_call_throw_error(
 #if defined(__linux__) && defined(__NR_faccessat2)
-		system_call<__NR_faccessat2, int>
+		system_call<__NR_faccessat2, int>(dirfd, pathname, mode, flags)
 #elif defined(__linux__) && defined(__NR_faccessat)
-		system_call<__NR_faccessat, int>
+		system_call<__NR_faccessat, int>(dirfd, pathname, mode)
 #else
-		::fast_io::posix::libc_faccessat
+		::fast_io::posix::libc_faccessat(dirfd, pathname, mode, flags)
 #endif
-		(dirfd, pathname, mode, flags));
+		);
 }
 
 #if defined(__wasi__) && !defined(__wasilibc_unmodified_upstream)

--- a/include/fast_io_hosted/filesystem/posix_at.h
+++ b/include/fast_io_hosted/filesystem/posix_at.h
@@ -336,11 +336,11 @@ inline void posix_unlinkat_impl(int dirfd, char const *path, int flags)
 
 namespace details
 {
-inline constexpr struct timespec unix_timestamp_to_struct_timespec64(unix_timestamp stmp) noexcept
+inline constexpr struct timespec unix_timestamp_to_struct_timespec(unix_timestamp stmp) noexcept
 {
 	constexpr ::std::uint_least64_t mul_factor{uint_least64_subseconds_per_second / 1000000000u};
 	return {static_cast<::std::time_t>(stmp.seconds),
-			static_cast<long>(static_cast<long unsigned>((stmp.subseconds) / mul_factor))};
+			static_cast<long>(static_cast<long unsigned>(stmp.subseconds / mul_factor))};
 }
 
 inline
@@ -348,7 +348,7 @@ inline
 	constexpr
 #endif
 	struct timespec
-	unix_timestamp_to_struct_timespec64([[maybe_unused]] unix_timestamp_option opt) noexcept
+	unix_timestamp_to_struct_timespec([[maybe_unused]] unix_timestamp_option opt) noexcept
 {
 #if defined(UTIME_NOW) && defined(UTIME_OMIT)
 	switch (opt.flags)
@@ -358,12 +358,51 @@ inline
 	case utime_flags::omit:
 		return {.tv_sec = 0, .tv_nsec = UTIME_OMIT};
 	default:
+		return unix_timestamp_to_struct_timespec(opt.timestamp);
+	}
+#else
+	throw_posix_error(EINVAL);
+#endif
+}
+
+#if defined(__linux__) && defined(__NR_utimensat_time64)
+
+// https://github.com/torvalds/linux/blob/07e27ad16399afcd693be20211b0dfae63e0615f/include/uapi/linux/time_types.h#L7
+struct kernel_timespec64
+{
+	::std::int_least64_t tv_sec;
+	::std::int_least64_t tv_nsec;
+};
+
+inline constexpr kernel_timespec64 unix_timestamp_to_struct_timespec64(unix_timestamp stmp) noexcept
+{
+	constexpr ::std::uint_least64_t mul_factor{uint_least64_subseconds_per_second / 1000000000u};
+	return {static_cast<::std::int_least64_t>(stmp.seconds),
+			static_cast<::std::int_least64_t>(stmp.subseconds / mul_factor)};
+}
+
+inline
+#if defined(UTIME_NOW) && defined(UTIME_OMIT)
+	constexpr
+#endif
+    kernel_timespec64
+	unix_timestamp_to_struct_timespec64([[maybe_unused]] unix_timestamp_option opt) noexcept
+{
+#if defined(UTIME_NOW) && defined(UTIME_OMIT)
+	switch (opt.flags)
+	{
+	case utime_flags::now:
+		return {.tv_sec = 0, .tv_nsec = static_cast<::std::int_least64_t>(UTIME_NOW)};
+	case utime_flags::omit:
+		return {.tv_sec = 0, .tv_nsec = static_cast<::std::int_least64_t>(UTIME_OMIT)};
+	default:
 		return unix_timestamp_to_struct_timespec64(opt.timestamp);
 	}
 #else
 	throw_posix_error(EINVAL);
 #endif
 }
+#endif
 
 } // namespace details
 
@@ -375,11 +414,21 @@ inline void posix_utimensat_impl(int dirfd, char const *path, unix_timestamp_opt
 	{
 		throw_posix_error(EINVAL);
 	}
-	struct timespec ts[2]{
+
+#if defined(__linux__) && defined(__NR_utimensat_time64)
+    details::kernel_timespec64 ts[2]{
 		details::unix_timestamp_to_struct_timespec64(last_access_time),
 		details::unix_timestamp_to_struct_timespec64(last_modification_time),
 	};
+	details::kernel_timespec64 *tsptr{ts};
+#else
+	struct timespec ts[2]{
+		details::unix_timestamp_to_struct_timespec(last_access_time),
+		details::unix_timestamp_to_struct_timespec(last_modification_time),
+	};
 	struct timespec *tsptr{ts};
+#endif
+
 	system_call_throw_error(
 #if defined(__linux__)
 #if defined(__NR_utimensat_time64)

--- a/include/fast_io_hosted/filesystem/posix_at.h
+++ b/include/fast_io_hosted/filesystem/posix_at.h
@@ -368,6 +368,8 @@ inline
 #if defined(__linux__) && defined(__NR_utimensat_time64)
 
 // https://github.com/torvalds/linux/blob/07e27ad16399afcd693be20211b0dfae63e0615f/include/uapi/linux/time_types.h#L7
+// https://github.com/qemu/qemu/blob/ab8008b231e758e03c87c1c483c03afdd9c02e19/linux-user/syscall_defs.h#L251
+// https://github.com/bminor/glibc/blob/b7e0ec907ba94b6fcc6142bbaddea995bcc3cef3/include/struct___timespec64.h#L15
 struct kernel_timespec64
 {
 	::std::int_least64_t tv_sec;

--- a/include/fast_io_hosted/platforms/nt.h
+++ b/include/fast_io_hosted/platforms/nt.h
@@ -88,7 +88,7 @@ inline constexpr nt_open_mode calculate_nt_open_mode(open_mode_perms ompm) noexc
 	constexpr auto default_write_attribute{0x00020000L /*READ_CONTROL*/ | 0x0002 /*FILE_WRITE_DATA*/ | 0x0004 /*FILE_APPEND_DATA*/};
 	constexpr auto default_read_attribute{0x00020000L /*READ_CONTROL*/ | 0x0001 /*FILE_READ_DATA*/};
 
-	mode.DesiredAccess |= 0x00100000L /*SYNCHRONIZE*/ | 0x0080 /*FILE_READ_ATTRIBUTES*/;
+	mode.DesiredAccess |= 0x00100000L /*SYNCHRONIZE*/ | 0x0080 /*FILE_READ_ATTRIBUTES*/ | 0x0100 /*FILE_WRITE_ATTRIBUTES*/;
 
 	if ((value & open_mode::no_shared_read) == open_mode::none)
 	{

--- a/include/fast_io_hosted/platforms/posix.h
+++ b/include/fast_io_hosted/platforms/posix.h
@@ -1378,12 +1378,12 @@ inline void posix_truncate_impl(int fd, ::fast_io::uintfpos_t size)
 #endif
 
 #elif defined(__linux__)
-	if constexpr(sizeof(::std::size_t) >= sizeof(::std::uint_least64_t))
+	if constexpr (sizeof(::std::size_t) >= sizeof(::std::uint_least64_t))
 	{
 #if defined(__NR_ftruncate)
-		if constexpr(::std::numeric_limits<::fast_io::uintfpos_t>::max() > ::std::numeric_limits<::std::uint_least64_t>::max())
+		if constexpr (::std::numeric_limits<::fast_io::uintfpos_t>::max() > ::std::numeric_limits<::std::uint_least64_t>::max())
 		{
-            if (size > ::std::numeric_limits<::std::uint_least64_t>::max())
+			if (size > ::std::numeric_limits<::std::uint_least64_t>::max())
 			{
 				throw_posix_error(EINVAL);
 			}
@@ -1391,7 +1391,7 @@ inline void posix_truncate_impl(int fd, ::fast_io::uintfpos_t size)
 
 		system_call_throw_error(system_call<__NR_ftruncate, int>(fd, static_cast<::std::uint_least64_t>(size)));
 #else
-		if constexpr(::std::numeric_limits<::fast_io::uintfpos_t>::max() > ::std::numeric_limits<off_t>::max())
+		if constexpr (::std::numeric_limits<::fast_io::uintfpos_t>::max() > ::std::numeric_limits<off_t>::max())
 		{
 			if (size > ::std::numeric_limits<off_t>::max())
 			{
@@ -1408,7 +1408,7 @@ inline void posix_truncate_impl(int fd, ::fast_io::uintfpos_t size)
 	else if constexpr (sizeof(::std::size_t) >= sizeof(::std::uint_least32_t))
 	{
 #if defined(__NR_ftruncate64)
-		if constexpr(::std::numeric_limits<::fast_io::uintfpos_t>::max() > ::std::numeric_limits<::std::uint_least64_t>::max())
+		if constexpr (::std::numeric_limits<::fast_io::uintfpos_t>::max() > ::std::numeric_limits<::std::uint_least64_t>::max())
 		{
 			if (size > ::std::numeric_limits<::std::uint_least64_t>::max())
 			{
@@ -1420,9 +1420,9 @@ inline void posix_truncate_impl(int fd, ::fast_io::uintfpos_t size)
 		::std::uint_least32_t size_u32_low{static_cast<::std::uint_least32_t>(size_u64)};
 		::std::uint_least32_t size_u32_high{static_cast<::std::uint_least32_t>(size_u64 >> 32u)};
 
-		int result_syscall;  // no initlize
+		int result_syscall; // no initlize
 
-		if constexpr(::std::endian::native == ::std::endian::big)
+		if constexpr (::std::endian::native == ::std::endian::big)
 		{
 			/* 3 args: fd, size (high, low) */
 			result_syscall = ::fast_io::system_call<__NR_ftruncate64, int>(fd, size_u32_high, size_u32_low);
@@ -1437,7 +1437,7 @@ inline void posix_truncate_impl(int fd, ::fast_io::uintfpos_t size)
 
 #elif defined(__NR_ftruncate)
 
-		if constexpr(::std::numeric_limits<::fast_io::uintfpos_t>::max() > ::std::numeric_limits<::std::uint_least32_t>::max())
+		if constexpr (::std::numeric_limits<::fast_io::uintfpos_t>::max() > ::std::numeric_limits<::std::uint_least32_t>::max())
 		{
 			if (size > ::std::numeric_limits<::std::uint_least32_t>::max())
 			{
@@ -1447,7 +1447,7 @@ inline void posix_truncate_impl(int fd, ::fast_io::uintfpos_t size)
 
 		system_call_throw_error(system_call<__NR_ftruncate, int>(fd, static_cast<::std::uint_least32_t>(size)));
 #else
-		if constexpr(::std::numeric_limits<::fast_io::uintfpos_t>::max() > ::std::numeric_limits<off_t>::max())
+		if constexpr (::std::numeric_limits<::fast_io::uintfpos_t>::max() > ::std::numeric_limits<off_t>::max())
 		{
 			if (size > ::std::numeric_limits<off_t>::max())
 			{
@@ -1463,7 +1463,7 @@ inline void posix_truncate_impl(int fd, ::fast_io::uintfpos_t size)
 	}
 	else
 	{
-		if constexpr(::std::numeric_limits<::fast_io::uintfpos_t>::max() > ::std::numeric_limits<off_t>::max())
+		if constexpr (::std::numeric_limits<::fast_io::uintfpos_t>::max() > ::std::numeric_limits<off_t>::max())
 		{
 			if (size > ::std::numeric_limits<off_t>::max())
 			{
@@ -1477,7 +1477,7 @@ inline void posix_truncate_impl(int fd, ::fast_io::uintfpos_t size)
 		}
 	}
 #else
-	if constexpr(::std::numeric_limits<::fast_io::uintfpos_t>::max() > ::std::numeric_limits<off_t>::max())
+	if constexpr (::std::numeric_limits<::fast_io::uintfpos_t>::max() > ::std::numeric_limits<off_t>::max())
 	{
 		if (size > ::std::numeric_limits<off_t>::max())
 		{
@@ -1520,17 +1520,25 @@ public:
 
 #if (defined(_WIN32) && !defined(__WINE__) && !defined(__BIONIC__)) && !defined(__CYGWIN__)
 		if (noexcept_call(::_pipe, a2, 131072u, _O_BINARY) == -1)
+		{
 			throw_posix_error();
+		}
 #elif defined(__linux__)
 		if (noexcept_call(::pipe2, a2, O_CLOEXEC) == -1)
+		{
 			throw_posix_error();
+		}
 #elif (defined(__MSDOS__) || defined(__DJGPP__)) || defined(__NEWLIB__)
 		if (noexcept_call(::pipe, a2) == -1)
+		{
 			throw_posix_error();
+		}
 #else
 		{
 			if (noexcept_call(::pipe, a2) == -1)
+			{
 				throw_posix_error();
+			}
 			::fast_io::posix_file_factory fd0(a2[0]);
 			::fast_io::posix_file_factory fd1(a2[1]);
 			::fast_io::details::sys_fcntl(fd0.fd, F_SETFD, FD_CLOEXEC);

--- a/include/fast_io_hosted/platforms/posix/win32.h
+++ b/include/fast_io_hosted/platforms/posix/win32.h
@@ -8,15 +8,15 @@ namespace details
 
 inline ::std::byte *posix_pread_bytes_impl(int fd, ::std::byte *first, ::std::byte *last, ::fast_io::intfpos_t off)
 {
-	return ::fast_io::win32::details::pread_some_bytes_impl(::fast_io::details::my_get_osfile_handle(fd), first, last,
-															off);
+	// Here, functions from the operations module must be selected because Windows 9x may not provide the p-series functions.
+    return ::fast_io::operations::pread_some_bytes(::fast_io::win32_io_observer{::fast_io::details::my_get_osfile_handle(fd)}, first, last, off);
 }
 
 inline ::std::byte const *posix_pwrite_bytes_impl(int fd, ::std::byte const *first, ::std::byte const *last,
 												  ::fast_io::intfpos_t off)
 {
-	return ::fast_io::win32::details::pwrite_some_bytes_impl(::fast_io::details::my_get_osfile_handle(fd), first, last,
-															 off);
+	// Here, functions from the operations module must be selected because Windows 9x may not provide the p-series functions.
+	return ::fast_io::operations::pwrite_some_bytes(::fast_io::win32_io_observer{::fast_io::details::my_get_osfile_handle(fd)}, first, last, off);
 }
 
 } // namespace details

--- a/include/fast_io_hosted/platforms/posix_mapping.h
+++ b/include/fast_io_hosted/platforms/posix_mapping.h
@@ -44,7 +44,7 @@ inline ::std::byte *sys_mmap(void *addr, ::std::size_t len, int prot, int flags,
 		}
 	}
 	auto ret{reinterpret_cast<::std::byte *>(
-		::mmap(addr, len, prot, flags, fd, static_cast<off_t>(static_cast<my_make_unsigned_t<off_t>>(offset))))};
+		::fast_io::noexcept_call(::mmap, addr, len, prot, flags, fd, static_cast<off_t>(static_cast<my_make_unsigned_t<off_t>>(offset))))};
 	if (ret == MAP_FAILED)
 	{
 		throw_posix_error();

--- a/include/fast_io_hosted/platforms/posix_netmode.h
+++ b/include/fast_io_hosted/platforms/posix_netmode.h
@@ -639,7 +639,7 @@ inline int sys_socket(int domain, int type, int protocol)
 	system_call_throw_error(fd);
 	return fd;
 #else
-	int fd{socket(domain, type, protocol)};
+	int fd{::fast_io::noexcept_call(::socket, domain, type, protocol)};
 	if (fd == -1)
 	{
 		throw_posix_error();
@@ -661,7 +661,7 @@ inline ::std::size_t posix_socket_write_impl(int fd, void const *data, ::std::si
 	system_call_throw_error(written);
 	return static_cast<::std::size_t>(written);
 #else
-	::std::ptrdiff_t written{send(fd, data, to_write, 0)};
+	::std::ptrdiff_t written{::fast_io::noexcept_call(::send, fd, data, to_write, 0)};
 	if (written < 0)
 	{
 		throw_posix_error();
@@ -677,7 +677,7 @@ inline ::std::size_t posix_socket_read_impl(int fd, void *data, ::std::size_t to
 	system_call_throw_error(written);
 	return static_cast<::std::size_t>(written);
 #else
-	::std::ptrdiff_t written{recv(fd, data, to_write, 0)};
+	::std::ptrdiff_t written{::fast_io::noexcept_call(::recv, fd, data, to_write, 0)};
 	if (written < 0)
 	{
 		throw_posix_error();
@@ -696,7 +696,7 @@ inline void posix_connect_posix_socket_impl(int fd, void const *addr, posix_sock
 		[[__gnu__::__may_alias__]]
 #endif
 		= struct sockaddr const *;
-	if (::connect(fd, reinterpret_cast<sockaddr_alias_const_ptr>(addr), addrlen) == -1)
+	if (::fast_io::noexcept_call(::connect, fd, reinterpret_cast<sockaddr_alias_const_ptr>(addr), addrlen) == -1)
 	{
 		throw_posix_error();
 	}
@@ -713,7 +713,7 @@ inline void posix_bind_posix_socket_impl(int fd, void const *addr, posix_socklen
 		[[__gnu__::__may_alias__]]
 #endif
 		= struct sockaddr const *;
-	if (::bind(fd, reinterpret_cast<sockaddr_alias_const_ptr>(addr), addrlen) == -1)
+	if (::fast_io::noexcept_call(::bind, fd, reinterpret_cast<sockaddr_alias_const_ptr>(addr), addrlen) == -1)
 	{
 		throw_posix_error();
 	}
@@ -725,7 +725,7 @@ inline void posix_listen_posix_socket_impl(int fd, int backlog)
 #if defined(__linux__) && defined(__NR_listen)
 	system_call_throw_error(system_call<__NR_listen, int>(fd, backlog));
 #else
-	if (::listen(fd, backlog) == -1)
+	if (::fast_io::noexcept_call(::listen, fd, backlog) == -1)
 	{
 		throw_posix_error();
 	}
@@ -744,7 +744,7 @@ inline int posix_accept_posix_socket_impl(int fd, void *addr, posix_socklen_t *a
 		[[__gnu__::__may_alias__]]
 #endif
 		= struct sockaddr *;
-	int socfd{::accept(fd, reinterpret_cast<sockaddr_alias_ptr>(addr), addrlen)};
+	int socfd{::fast_io::noexcept_call(::accept, fd, reinterpret_cast<sockaddr_alias_ptr>(addr), addrlen)};
 	if (socfd == -1)
 	{
 		throw_posix_error();
@@ -765,7 +765,7 @@ inline ::std::ptrdiff_t posix_recvfrom_posix_socket_impl(int fd, void *buf, ::st
 		[[__gnu__::__may_alias__]]
 #endif
 		= struct sockaddr *;
-	::std::ptrdiff_t ret{::recvfrom(fd, buf, len, flags, reinterpret_cast<sockaddr_alias_ptr>(src_addr), addrlen)};
+	::std::ptrdiff_t ret{::fast_io::noexcept_call(::recvfrom, fd, buf, len, flags, reinterpret_cast<sockaddr_alias_ptr>(src_addr), addrlen)};
 	if (ret == -1)
 	{
 		throw_posix_error();
@@ -786,7 +786,7 @@ inline ::std::ptrdiff_t posix_sendto_posix_socket_impl(int fd, void const *buf, 
 		[[__gnu__::__may_alias__]]
 #endif
 		= struct sockaddr const *;
-	::std::ptrdiff_t ret{::sendto(fd, buf, len, flags, reinterpret_cast<sockaddr_const_alias_ptr>(src_addr), addrlen)};
+	::std::ptrdiff_t ret{::fast_io::noexcept_call(::sendto, fd, buf, len, flags, reinterpret_cast<sockaddr_const_alias_ptr>(src_addr), addrlen)};
 	if (ret == -1)
 	{
 		throw_posix_error();

--- a/include/fast_io_hosted/platforms/win32.h
+++ b/include/fast_io_hosted/platforms/win32.h
@@ -775,14 +775,15 @@ inline ::std::byte *read_or_pread_some_bytes_common_impl(void *__restrict handle
 	return first + number_of_bytes;
 }
 
-inline ::std::byte *read_some_bytes_impl(void *__restrict handle, ::std::byte *first, ::std::byte *last)
+inline ::std::byte *win32_read_some_bytes_impl(void *__restrict handle, ::std::byte *first, ::std::byte *last)
 {
 	return ::fast_io::win32::details::read_or_pread_some_bytes_common_impl(handle, first, last, nullptr);
 }
 
-inline ::std::byte *pread_some_bytes_impl(void *__restrict handle, ::std::byte *first, ::std::byte *last,
+inline ::std::byte *win32_ntw_pread_some_bytes_impl(void *__restrict handle, ::std::byte *first, ::std::byte *last,
 										  ::fast_io::intfpos_t off)
 {
+	// The use of overlapped behavior is not supported in Windows 95.
 	::fast_io::win32::overlapped overlap{};
 	::fast_io::win32::details::win32_calculate_offset_impl(handle, overlap, off);
 	return ::fast_io::win32::details::read_or_pread_some_bytes_common_impl(handle, first, last,
@@ -803,15 +804,16 @@ inline ::std::byte const *write_or_pwrite_some_bytes_common_impl(void *__restric
 	return first + number_of_bytes;
 }
 
-inline ::std::byte const *write_some_bytes_impl(void *__restrict handle, ::std::byte const *first,
+inline ::std::byte const *win32_write_some_bytes_impl(void *__restrict handle, ::std::byte const *first,
 												::std::byte const *last)
 {
 	return ::fast_io::win32::details::write_or_pwrite_some_bytes_common_impl(handle, first, last, nullptr);
 }
 
-inline ::std::byte const *pwrite_some_bytes_impl(void *__restrict handle, ::std::byte const *first,
+inline ::std::byte const *win32_ntw_pwrite_some_bytes_impl(void *__restrict handle, ::std::byte const *first,
 												 ::std::byte const *last, ::fast_io::intfpos_t off)
 {
+	// The use of overlapped behavior is not supported in Windows 95.
 	::fast_io::win32::overlapped overlap{};
 	::fast_io::win32::details::win32_calculate_offset_impl(handle, overlap, off);
 	return ::fast_io::win32::details::write_or_pwrite_some_bytes_common_impl(handle, first, last,
@@ -824,14 +826,14 @@ template <win32_family family, ::std::integral ch_type>
 inline ::std::byte *read_some_bytes_underflow_define(basic_win32_family_io_observer<family, ch_type> wiob,
 													 ::std::byte *first, ::std::byte *last)
 {
-	return ::fast_io::win32::details::read_some_bytes_impl(wiob.handle, first, last);
+	return ::fast_io::win32::details::win32_read_some_bytes_impl(wiob.handle, first, last);
 }
 
 template <win32_family family, ::std::integral ch_type>
 inline ::std::byte const *write_some_bytes_overflow_define(basic_win32_family_io_observer<family, ch_type> wiob,
 														   ::std::byte const *first, ::std::byte const *last)
 {
-	return ::fast_io::win32::details::write_some_bytes_impl(wiob.handle, first, last);
+	return ::fast_io::win32::details::win32_write_some_bytes_impl(wiob.handle, first, last);
 }
 
 template <win32_family family, ::std::integral ch_type>
@@ -845,11 +847,15 @@ inline ::fast_io::intfpos_t io_stream_seek_bytes_define(basic_win32_family_io_ob
 I am not confident that i understand semantics correctly. Disabled first and test it later
 */
 
+// Windows 9x does not support atomic p-series functions. When using operation::p-series functions, 
+// they will be emulated through seek and non-p-series functions.
+// For Win9x, use the operation::p series functions, which automatically combine seek operations with non-p series functions.
+#if !defined(_WIN32_WINDOWS)
 template <win32_family family, ::std::integral ch_type>
 inline ::std::byte *pread_some_bytes_underflow_define(basic_win32_family_io_observer<family, ch_type> niob,
 													  ::std::byte *first, ::std::byte *last, ::fast_io::intfpos_t off)
 {
-	return ::fast_io::win32::details::pread_some_bytes_impl(niob.handle, first, last, off);
+	return ::fast_io::win32::details::win32_ntw_pread_some_bytes_impl(niob.handle, first, last, off);
 }
 
 template <win32_family family, ::std::integral ch_type>
@@ -857,8 +863,9 @@ inline ::std::byte const *pwrite_some_bytes_overflow_define(basic_win32_family_i
 															::std::byte const *first, ::std::byte const *last,
 															::fast_io::intfpos_t off)
 {
-	return ::fast_io::win32::details::pwrite_some_bytes_impl(niob.handle, first, last, off);
+	return ::fast_io::win32::details::win32_ntw_pwrite_some_bytes_impl(niob.handle, first, last, off);
 }
+#endif
 
 template <win32_family family, ::std::integral ch_type>
 inline constexpr basic_win32_family_io_observer<family, ch_type>

--- a/include/fast_io_hosted/platforms/win32.h
+++ b/include/fast_io_hosted/platforms/win32.h
@@ -1750,12 +1750,6 @@ inline posix_file_status win32_9xa_dir_file_status_impl(win32_9xa_dir_handle con
 #endif
 		= char const *;
 
-	using char_may_alias_ptr
-#if __has_cpp_attribute(__gnu__::__may_alias__)
-		[[__gnu__::__may_alias__]]
-#endif
-		= char *;
-
 	// Use A APIs and a char buffer; avoid multiplying by sizeof(char8_t)
 	constexpr ::std::size_t tmp_path_char_size{260u};
 	char tmp_path_char[tmp_path_char_size];

--- a/include/fast_io_hosted/platforms/win32.h
+++ b/include/fast_io_hosted/platforms/win32.h
@@ -710,15 +710,23 @@ inline ::fast_io::intfpos_t seek_impl(void *handle, ::fast_io::intfpos_t offset,
 			throw_win32_error(0x00000057);
 		}
 	}
+
 	::std::int_least32_t distance_to_move_high{};
 	constexpr ::std::uint_least32_t invalid{UINT_LEAST32_MAX};
-	if (::fast_io::win32::SetFilePointer(handle, static_cast<::std::int_least32_t>(offset),
-										 __builtin_addressof(distance_to_move_high),
-										 static_cast<::std::uint_least32_t>(s)) == invalid)
+	auto const low{::fast_io::win32::SetFilePointer(handle, static_cast<::std::int_least32_t>(offset),
+													__builtin_addressof(distance_to_move_high), static_cast<::std::uint_least32_t>(s))};
+
+	if (low == invalid) [[unlikely]]
 	{
-		throw_win32_error();
+		auto const err{::fast_io::win32::GetLastError()};
+		if (err != 0u) [[unlikely]]
+		{
+			throw_win32_error(err);
+		}
 	}
-	return static_cast<::fast_io::intfpos_t>(distance_to_move_high);
+
+	::std::uint_least64_t const combined{(static_cast<::std::uint_least64_t>(static_cast<::std::uint_least32_t>(distance_to_move_high)) << 32u) | static_cast<::std::uint_least32_t>(low)};
+	return static_cast<::fast_io::intfpos_t>(combined);
 #else
 	if constexpr (sizeof(::fast_io::intfpos_t) > sizeof(::std::int_least64_t))
 	{
@@ -729,14 +737,14 @@ inline ::fast_io::intfpos_t seek_impl(void *handle, ::fast_io::intfpos_t offset,
 			throw_win32_error(0x00000057);
 		}
 	}
-	::std::int_least64_t distance_to_move_high{};
+	::std::int_least64_t distance_full{};
 	if (!::fast_io::win32::SetFilePointerEx(handle, static_cast<::std::int_least64_t>(offset),
-											__builtin_addressof(distance_to_move_high),
+											__builtin_addressof(distance_full),
 											static_cast<::std::uint_least32_t>(s)))
 	{
 		throw_win32_error();
 	}
-	return static_cast<::fast_io::intfpos_t>(distance_to_move_high);
+	return static_cast<::fast_io::intfpos_t>(distance_full);
 #endif
 }
 
@@ -954,6 +962,25 @@ struct win32_9xa_dir_handle
 
 namespace win32::details
 {
+struct find_struct_guard
+{
+	void *file_struct{};
+
+	inline explicit constexpr find_struct_guard(void *fs) noexcept : file_struct{fs}
+	{}
+
+	find_struct_guard(find_struct_guard const &) = delete;
+	find_struct_guard &operator=(find_struct_guard const &) = delete;
+
+	inline ~find_struct_guard()
+	{
+		if (file_struct && file_struct != reinterpret_cast<void *>(static_cast<::std::ptrdiff_t>(-1))) [[likely]]
+		{
+			::fast_io::win32::FindClose(file_struct);
+		}
+	}
+};
+
 inline void check_win32_9xa_dir_is_valid(win32_9xa_dir_handle const &h)
 {
 	::fast_io::win32::win32_find_dataa wfda{};
@@ -969,7 +996,7 @@ inline void check_win32_9xa_dir_is_valid(win32_9xa_dir_handle const &h)
 	}
 }
 
-inline bool get_win32_9xa_dir_validity(win32_9xa_dir_handle const &h)
+[[nodiscard]] inline bool get_win32_9xa_dir_validity(win32_9xa_dir_handle const &h) noexcept
 {
 	::fast_io::win32::win32_find_dataa wfda{};
 	tlc_win32_9xa_dir_handle_path_str temp_find_path{concat_tlc_win32_9xa_dir_handle_path_str(h.path, u8"\\*")};
@@ -991,9 +1018,9 @@ inline void close_win32_9xa_dir_handle(win32_9xa_dir_handle &h) noexcept(!throw_
 	if constexpr (throw_eh)
 	{
 		// Make sure to successfully close even if an exception is thrown.
-		bool const is_win32_9xa_dir_validid{get_win32_9xa_dir_validity(h)};
+		bool const is_win32_9xa_dir_valid{get_win32_9xa_dir_validity(h)};
 		h.path.clear();
-		if (!is_win32_9xa_dir_validid) [[unlikely]]
+		if (!is_win32_9xa_dir_valid) [[unlikely]]
 		{
 			throw_win32_error(0x5);
 		}
@@ -1004,7 +1031,7 @@ inline void close_win32_9xa_dir_handle(win32_9xa_dir_handle &h) noexcept(!throw_
 	}
 }
 
-inline win32_9xa_dir_handle win32_9xa_dir_dup_impl(win32_9xa_dir_handle const &h) 
+inline win32_9xa_dir_handle win32_9xa_dir_dup_impl(win32_9xa_dir_handle const &h)
 {
 	check_win32_9xa_dir_is_valid(h);
 	return {h.path};
@@ -1016,25 +1043,6 @@ inline win32_9xa_dir_handle win32_9xa_dir_dup2_impl(win32_9xa_dir_handle const &
 	close_win32_9xa_dir_handle(h2);
 	return temp;
 }
-
-struct find_struct_guard
-{
-	void *file_struct{};
-
-	find_struct_guard(find_struct_guard const &) = delete;
-	find_struct_guard &operator=(find_struct_guard const &) = delete;
-
-	inline ~find_struct_guard()
-	{
-		if (file_struct) [[likely]]
-		{
-			if (!::fast_io::win32::FindClose(file_struct))
-			{
-				throw_win32_error();
-			}
-		}
-	}
-};
 
 inline win32_9xa_dir_handle basic_win32_9xa_create_dir_file_impl(char const *filename_c_str, ::std::size_t filename_c_str_len)
 {
@@ -1545,7 +1553,7 @@ public:
 template <win32_family family, ::std::integral ch_type>
 inline void truncate(basic_win32_family_io_observer<family, ch_type> handle, ::fast_io::uintfpos_t size)
 {
-	win32::details::seek_impl(handle, size, seekdir::beg);
+	win32::details::seek_impl(handle.handle, size, seekdir::beg);
 	if (!::fast_io::win32::SetEndOfFile(handle.handle))
 	{
 		throw_win32_error();
@@ -1698,6 +1706,86 @@ inline posix_file_status win32_status_impl(void *__restrict handle)
 							 0};
 }
 
+inline posix_file_status win32_9xa_dir_file_status_impl(win32_9xa_dir_handle const &handle)
+{
+	::fast_io::posix_file_status tmp_file{};
+
+	// find data
+	::fast_io::win32::win32_find_dataa wfda{};
+	tlc_win32_9xa_dir_handle_path_str temp_find_path{concat_tlc_win32_9xa_dir_handle_path_str(handle.path, u8"\\*")};
+	auto find_struct{::fast_io::win32::FindFirstFileA(reinterpret_cast<char const *>(temp_find_path.c_str()), __builtin_addressof(wfda))};
+	if (find_struct == reinterpret_cast<void *>(static_cast<::std::ptrdiff_t>(-1))) [[unlikely]]
+	{
+		throw_win32_error(0x5);
+	}
+	else
+	{
+		find_struct_guard guard{find_struct};
+		// The first piece of information obtained by findfirstfile is current path ('.')
+
+		::std::underlying_type_t<perms> pm{0444};
+		if ((wfda.dwFileAttributes & 0x1) == 0x0)
+		{
+			pm |= 0222;
+		}
+
+		tmp_file.perm = static_cast<perms>(pm);
+		tmp_file.type = ::fast_io::file_type::directory;
+		tmp_file.nlink = 1u;
+		tmp_file.size = static_cast<::std::uintmax_t>((static_cast<::std::uint_least64_t>(wfda.nFileSizeHigh) << 32u) | wfda.nFileSizeLow);
+		tmp_file.blksize = 512u;
+		tmp_file.blocks = (tmp_file.size + 511u) / 512u;
+		tmp_file.atim = to_unix_timestamp(wfda.ftLastAccessTime);
+		tmp_file.mtim = to_unix_timestamp(wfda.ftLastWriteTime);
+		tmp_file.ctim = tmp_file.mtim;
+		tmp_file.btim = to_unix_timestamp(wfda.ftCreationTime);
+
+		// find_struct destructor will close the handle
+	}
+
+	// dev
+	using char_const_may_alias_ptr
+#if __has_cpp_attribute(__gnu__::__may_alias__)
+		[[__gnu__::__may_alias__]]
+#endif
+		= char const *;
+
+	using char_may_alias_ptr
+#if __has_cpp_attribute(__gnu__::__may_alias__)
+		[[__gnu__::__may_alias__]]
+#endif
+		= char *;
+
+	// Use A APIs and a char buffer; avoid multiplying by sizeof(char8_t)
+	constexpr ::std::size_t tmp_path_char_size{260u};
+	char tmp_path_char[tmp_path_char_size];
+
+	auto const full_len{::fast_io::win32::GetFullPathNameA(reinterpret_cast<char_const_may_alias_ptr>(handle.path.c_str()), tmp_path_char_size, tmp_path_char, nullptr)};
+	if (!full_len || full_len >= tmp_path_char_size) [[unlikely]]
+	{
+		return tmp_file;
+	}
+
+	// Build root like "C:\\" safely
+	if (full_len < 3u) [[unlikely]]
+	{
+		return tmp_file;
+	}
+
+	tmp_path_char[3u] = static_cast<char>(u8'\0');
+
+	::std::uint_least32_t serial{};
+
+	if (!::fast_io::win32::GetVolumeInformationA(tmp_path_char, nullptr, 0u, __builtin_addressof(serial), nullptr, nullptr, nullptr, 0u))
+	{
+		return tmp_file;
+	}
+
+	tmp_file.dev = static_cast<::std::uintmax_t>(serial);
+
+	return tmp_file;
+}
+
 /*
 Thanks Fseuio for providing source code.
 */
@@ -1761,6 +1849,11 @@ template <win32_family family, ::std::integral ch_type>
 inline posix_file_status status(basic_win32_family_io_observer<family, ch_type> wiob)
 {
 	return win32::details::win32_status_impl(wiob.handle);
+}
+
+inline posix_file_status status(win32_9xa_dir_io_observer w9xiob)
+{
+	return win32::details::win32_9xa_dir_file_status_impl(w9xiob.handle);
 }
 
 template <win32_family family, ::std::integral ch_type>

--- a/include/fast_io_hosted/platforms/win32.h
+++ b/include/fast_io_hosted/platforms/win32.h
@@ -1732,9 +1732,9 @@ inline posix_file_status win32_9xa_dir_file_status_impl(win32_9xa_dir_handle con
 		tmp_file.perm = static_cast<perms>(pm);
 		tmp_file.type = ::fast_io::file_type::directory;
 		tmp_file.nlink = 1u;
-		tmp_file.size = static_cast<::std::uintmax_t>((static_cast<::std::uint_least64_t>(wfda.nFileSizeHigh) << 32u) | wfda.nFileSizeLow);
-		tmp_file.blksize = 512u;
-		tmp_file.blocks = (tmp_file.size + 511u) / 512u;
+		tmp_file.size = static_cast<::std::uintmax_t>((static_cast<::std::uint_least64_t>(wfda.nFileSizeHigh) << 32u) | wfda.nFileSizeLow);  // always zero
+		tmp_file.blksize = 512u;  // default
+		tmp_file.blocks = (tmp_file.size + 511u) / 512u;  // default
 		tmp_file.atim = to_unix_timestamp(wfda.ftLastAccessTime);
 		tmp_file.mtim = to_unix_timestamp(wfda.ftLastWriteTime);
 		tmp_file.ctim = tmp_file.mtim;
@@ -1755,27 +1755,29 @@ inline posix_file_status win32_9xa_dir_file_status_impl(win32_9xa_dir_handle con
 	char tmp_path_char[tmp_path_char_size];
 
 	auto const full_len{::fast_io::win32::GetFullPathNameA(reinterpret_cast<char_const_may_alias_ptr>(handle.path.c_str()), tmp_path_char_size, tmp_path_char, nullptr)};
-	if (!full_len || full_len >= tmp_path_char_size) [[unlikely]]
+
+	if (full_len > 2u && full_len <= tmp_path_char_size && ::fast_io::char_category::is_c_alpha(tmp_path_char[0])) [[likely]]
 	{
-		return tmp_file;
+		// Build root like "C:\\" safely
+		// The Character size of the tmp_path_char_size can accommodate the size
+		tmp_path_char[3u] = static_cast<char>(u8'\0');
+
+		// get dev
+		::std::uint_least32_t serial{};
+		if (::fast_io::win32::GetVolumeInformationA(tmp_path_char, nullptr, 0u, __builtin_addressof(serial), nullptr, nullptr, nullptr, 0u)) [[likely]]
+		{
+			tmp_file.dev = static_cast<::std::uintmax_t>(serial);
+		}
+	
+		// get blocksize
+		::std::uint_least32_t sector_per_cluster{};
+		::std::uint_least32_t bytes_per_sector{};
+		if (::fast_io::win32::GetDiskFreeSpaceA(tmp_path_char, __builtin_addressof(sector_per_cluster), __builtin_addressof(bytes_per_sector), nullptr, nullptr)) [[likely]]
+		{
+			tmp_file.blksize = static_cast<::std::uintmax_t>(bytes_per_sector) * static_cast<::std::uintmax_t>(sector_per_cluster);
+			tmp_file.blocks = (tmp_file.blksize + 511u) / 512u;
+		}
 	}
-
-	// Build root like "C:\\" safely
-	if (full_len < 3u) [[unlikely]]
-	{
-		return tmp_file;
-	}
-
-	tmp_path_char[3u] = static_cast<char>(u8'\0');
-
-	::std::uint_least32_t serial{};
-
-	if (!::fast_io::win32::GetVolumeInformationA(tmp_path_char, nullptr, 0u, __builtin_addressof(serial), nullptr, nullptr, nullptr, 0u))
-	{
-		return tmp_file;
-	}
-
-	tmp_file.dev = static_cast<::std::uintmax_t>(serial);
 
 	return tmp_file;
 }

--- a/include/fast_io_hosted/platforms/win32/apis.h
+++ b/include/fast_io_hosted/platforms/win32/apis.h
@@ -179,5 +179,7 @@ FAST_IO_DLLIMPORT ::std::uint_least32_t FAST_IO_WINSTDCALL GetFullPathNameW(char
 FAST_IO_DLLIMPORT ::std::uint_least32_t FAST_IO_WINSTDCALL GetFullPathNameA(char const*, ::std::uint_least32_t, char*, char**) noexcept FAST_IO_WINSTDCALL_RENAME(GetFullPathNameA, 16);
 FAST_IO_DLLIMPORT int FAST_IO_WINSTDCALL GetVolumeInformationW(char16_t const*, char16_t*, ::std::uint_least32_t, ::std::uint_least32_t*, ::std::uint_least32_t*, ::std::uint_least32_t*, char16_t*, ::std::uint_least32_t) noexcept FAST_IO_WINSTDCALL_RENAME(GetVolumeInformationW, 32);
 FAST_IO_DLLIMPORT int FAST_IO_WINSTDCALL GetVolumeInformationA(char const*, char*, ::std::uint_least32_t, ::std::uint_least32_t*, ::std::uint_least32_t*, ::std::uint_least32_t*, char*, ::std::uint_least32_t) noexcept FAST_IO_WINSTDCALL_RENAME(GetVolumeInformationA, 32);
+FAST_IO_DLLIMPORT int FAST_IO_WINSTDCALL GetDiskFreeSpaceW(char16_t const*, ::std::uint_least32_t*, ::std::uint_least32_t*, ::std::uint_least32_t*, ::std::uint_least32_t*) noexcept FAST_IO_WINSTDCALL_RENAME(GetDiskFreeSpaceW, 20);
+FAST_IO_DLLIMPORT int FAST_IO_WINSTDCALL GetDiskFreeSpaceA(char const*, ::std::uint_least32_t*, ::std::uint_least32_t*, ::std::uint_least32_t*, ::std::uint_least32_t*) noexcept FAST_IO_WINSTDCALL_RENAME(GetDiskFreeSpaceA, 20);
 
 } // namespace fast_io::win32

--- a/include/fast_io_hosted/platforms/win32/apis.h
+++ b/include/fast_io_hosted/platforms/win32/apis.h
@@ -174,4 +174,10 @@ FAST_IO_DLLIMPORT char16_t *FAST_IO_WINSTDCALL GetEnvironmentStringsW() noexcept
 FAST_IO_DLLIMPORT char *FAST_IO_WINSTDCALL GetEnvironmentStringsA() noexcept FAST_IO_WINSTDCALL_RENAME(GetEnvironmentStringsA, 0);
 FAST_IO_DLLIMPORT int FAST_IO_WINSTDCALL FreeEnvironmentStringsW(char16_t*) noexcept FAST_IO_WINSTDCALL_RENAME(FreeEnvironmentStringsW, 4);
 FAST_IO_DLLIMPORT int FAST_IO_WINSTDCALL FreeEnvironmentStringsA(char*) noexcept FAST_IO_WINSTDCALL_RENAME(FreeEnvironmentStringsA, 4);
+FAST_IO_DLLIMPORT int FAST_IO_WINSTDCALL getsockopt(::std::size_t, int, int, char*, int*) noexcept FAST_IO_WINSTDCALL_RENAME(getsockopt, 20);
+FAST_IO_DLLIMPORT ::std::uint_least32_t FAST_IO_WINSTDCALL GetFullPathNameW(char16_t const*, ::std::uint_least32_t, char16_t*, char16_t**) noexcept FAST_IO_WINSTDCALL_RENAME(GetFullPathNameW, 16);
+FAST_IO_DLLIMPORT ::std::uint_least32_t FAST_IO_WINSTDCALL GetFullPathNameA(char const*, ::std::uint_least32_t, char*, char**) noexcept FAST_IO_WINSTDCALL_RENAME(GetFullPathNameA, 16);
+FAST_IO_DLLIMPORT int FAST_IO_WINSTDCALL GetVolumeInformationW(char16_t const*, char16_t*, ::std::uint_least32_t, ::std::uint_least32_t*, ::std::uint_least32_t*, ::std::uint_least32_t*, char16_t*, ::std::uint_least32_t) noexcept FAST_IO_WINSTDCALL_RENAME(GetVolumeInformationW, 32);
+FAST_IO_DLLIMPORT int FAST_IO_WINSTDCALL GetVolumeInformationA(char const*, char*, ::std::uint_least32_t, ::std::uint_least32_t*, ::std::uint_least32_t*, ::std::uint_least32_t*, char*, ::std::uint_least32_t) noexcept FAST_IO_WINSTDCALL_RENAME(GetVolumeInformationA, 32);
+
 } // namespace fast_io::win32


### PR DESCRIPTION
- Updated `file_size` function to use a template parameter for NT family file size retrieval.
- Replaced direct socket calls with `::fast_io::noexcept_call` in POSIX networking functions to improve error handling.
- Introduced a `find_struct_guard` for automatic resource management in Win32 directory handling.
- Added `win32_9xa_dir_file_status_impl` to retrieve file status for Win32 9xa directory handles, enhancing compatibility with POSIX file status functions.