### PR TITLE
mark gnu::always_inline to fast_exit

### DIFF
--- a/include/fast_io_hosted/platforms/linux/aarch64.h
+++ b/include/fast_io_hosted/platforms/linux/aarch64.h
@@ -29,6 +29,7 @@ inline return_value_type system_call(auto p1) noexcept
 
 template <::std::uint_least64_t syscall_number>
 [[noreturn]]
+[[__gnu__::__always_inline__]]
 inline void system_call_no_return(auto p1) noexcept
 {
 	register ::std::uint_least64_t x8 __asm__("x8") = syscall_number;
@@ -119,6 +120,7 @@ inline return_value_type system_call(auto p1, auto p2, auto p3, auto p4, auto p5
 
 template <::std::integral I>
 [[noreturn]]
+[[__gnu__::__always_inline__, __gnu__::__artificial__]]
 inline void fast_exit(I ret) noexcept
 {
 	system_call_no_return<__NR_exit>(ret);

--- a/include/fast_io_hosted/platforms/linux/amd64.h
+++ b/include/fast_io_hosted/platforms/linux/amd64.h
@@ -36,6 +36,7 @@ inline return_value_type system_call(auto p1) noexcept
 
 template <::std::uint_least64_t syscall_number>
 [[noreturn]]
+[[__gnu__::__always_inline__]]
 inline void system_call_no_return(auto p1) noexcept
 {
 	::std::uint_least64_t ret;
@@ -134,6 +135,7 @@ inline return_value_type system_call(auto p1, auto p2, auto p3, auto p4, auto p5
 
 template <::std::integral I>
 [[noreturn]]
+[[__gnu__::__always_inline__, __gnu__::__artificial__]]
 inline void fast_exit(I ret) noexcept
 {
 	system_call_no_return<__NR_exit>(ret);

--- a/include/fast_io_hosted/platforms/linux/generic.h
+++ b/include/fast_io_hosted/platforms/linux/generic.h
@@ -27,6 +27,7 @@ inline return_value_type inline_syscall(auto p1, auto p2) noexcept
 
 template <::std::size_t syscall_number>
 [[noreturn]]
+[[__gnu__::__always_inline__]]
 inline void system_call_no_return(auto p1) noexcept
 {
 	::syscall(syscall_number, p1);
@@ -35,6 +36,7 @@ inline void system_call_no_return(auto p1) noexcept
 
 template <::std::integral I>
 [[noreturn]]
+[[__gnu__::__always_inline__, __gnu__::__artificial__]]
 inline void fast_exit(I ret) noexcept
 {
 	system_call_no_return<__NR_exit>(ret);

--- a/include/fast_io_hosted/platforms/linux/loongarch64.h
+++ b/include/fast_io_hosted/platforms/linux/loongarch64.h
@@ -36,6 +36,7 @@ inline return_value_type system_call(auto p1) noexcept
 
 template <::std::uint_least64_t syscall_number>
 [[noreturn]]
+[[__gnu__::__always_inline__]]
 inline void system_call_no_return(auto p1) noexcept
 {
 	register ::std::uint_least64_t a7 __asm__("$a7") = syscall_number;
@@ -130,6 +131,7 @@ inline return_value_type system_call(auto p1, auto p2, auto p3, auto p4, auto p5
 
 template <::std::integral I>
 [[noreturn]]
+[[__gnu__::__always_inline__, __gnu__::__artificial__]]
 inline void fast_exit(I ret) noexcept
 {
 	system_call_no_return<__NR_exit>(ret);

--- a/include/fast_io_hosted/platforms/linux/riscv64.h
+++ b/include/fast_io_hosted/platforms/linux/riscv64.h
@@ -34,6 +34,7 @@ inline return_value_type system_call(auto p1) noexcept
 
 template <::std::uint_least64_t syscall_number>
 [[noreturn]]
+[[__gnu__::__always_inline__]]
 inline void system_call_no_return(auto p1) noexcept
 {
 	register ::std::uint_least64_t a7 __asm__("a7") = syscall_number;
@@ -121,6 +122,7 @@ inline return_value_type system_call(auto p1, auto p2, auto p3, auto p4, auto p5
 
 template <::std::integral I>
 [[noreturn]]
+[[__gnu__::__always_inline__, __gnu__::__artificial__]]
 inline void fast_exit(I ret) noexcept
 {
 	system_call_no_return<__NR_exit>(ret);


### PR DESCRIPTION
which should be safe and helpful