### PR TITLE
Refactor timestamp conversion and enhance POSIX linkat functionality

### DIFF
--- a/include/fast_io_hosted/filesystem/dos_at.h
+++ b/include/fast_io_hosted/filesystem/dos_at.h
@@ -201,7 +201,7 @@ inline
 	constexpr
 #endif
 	::std::time_t
-	unix_timestamp_to_time_t(unix_timestamp_option opt) noexcept
+	unix_timestamp_to_time_t(unix_timestamp_option opt)
 {
 	switch (opt.flags)
 	{

--- a/include/fast_io_hosted/filesystem/posix_at.h
+++ b/include/fast_io_hosted/filesystem/posix_at.h
@@ -747,6 +747,17 @@ template <::fast_io::constructible_to_os_c_str old_path_type, ::fast_io::constru
 inline void posix_linkat(posix_at_entry oldent, old_path_type const &oldpath, posix_at_entry newent,
 						 new_path_type const &newpath, posix_at_flags flags = posix_at_flags::symlink_nofollow)
 {
+	if ((flags & posix_at_flags::symlink_nofollow) == posix_at_flags::symlink_nofollow)
+	{
+		flags &= ~posix_at_flags::symlink_nofollow;
+	}
+	else
+	{
+#ifdef AT_SYMLINK_FOLLOW
+		flags |= static_cast<posix_at_flags>(AT_SYMLINK_FOLLOW);
+#endif
+	}
+
 	details::posix_deal_with22<details::posix_api_22::linkat>(oldent.fd, oldpath, newent.fd, newpath,
 															  static_cast<int>(flags));
 }
@@ -755,6 +766,17 @@ template <::fast_io::constructible_to_os_c_str old_path_type, ::fast_io::constru
 inline void native_linkat(posix_at_entry oldent, old_path_type const &oldpath, posix_at_entry newent,
 						  new_path_type const &newpath, posix_at_flags flags = posix_at_flags::symlink_nofollow)
 {
+	if ((flags & posix_at_flags::symlink_nofollow) == posix_at_flags::symlink_nofollow)
+	{
+		flags &= ~posix_at_flags::symlink_nofollow;
+	}
+	else
+	{
+#ifdef AT_SYMLINK_FOLLOW
+		flags |= static_cast<posix_at_flags>(AT_SYMLINK_FOLLOW);
+#endif
+	}
+
 	details::posix_deal_with22<details::posix_api_22::linkat>(oldent.fd, oldpath, newent.fd, newpath,
 															  static_cast<int>(flags));
 }

--- a/include/fast_io_hosted/white_hole/linux_getrandom.h
+++ b/include/fast_io_hosted/white_hole/linux_getrandom.h
@@ -1,5 +1,5 @@
 ﻿#pragma once
-#if !(defined(__linux__) && defined(__NR_getrandom)) && !__has_include(<sys/random.h>)
+#if !(defined(__linux__) && defined(__NR_getrandom)) && __has_include(<sys/random.h>)
 #include <sys/random.h>
 #endif
 

--- a/include/fast_io_hosted/white_hole/white_hole.h
+++ b/include/fast_io_hosted/white_hole/white_hole.h
@@ -25,7 +25,7 @@ concept minimum_buffer_input_stream_require_size_impl =
 
 } // namespace fast_io::details
 #if ((defined(__linux__) && defined(__NR_getrandom)) || \
-	 (!defined(__linux__) && __has_include(<sys/random.h>))) && !defined(__wasi__) && !defined(__DARWIN_C_LEVEL) && !defined(__CYGWIN__)
+	 (!(defined(__linux__) && defined(__NR_getrandom)) && __has_include(<sys/random.h>))) && !defined(__wasi__) && !defined(__DARWIN_C_LEVEL) && !defined(__CYGWIN__)
 #include "linux_getrandom.h"
 #endif
 #if ((defined(__linux__) && defined(__GLIBC__)) || (defined(__BSD_VISIBLE) && !defined(__DARWIN_C_LEVEL))) && 0


### PR DESCRIPTION
- Updated `unix_timestamp_to_time_t` function signature for consistency.
- Improved handling of `posix_linkat` and `native_linkat` functions to manage `symlink_nofollow` flags more effectively.
- Adjusted conditional compilation checks in `linux_getrandom.h` and `white_hole.h` for better compatibility across platforms.