### PR TITLE
Add support for O_DSYNC and O_RSYNC in POSIX and platform headers

### DIFF
--- a/include/fast_io_core_impl/mode.h
+++ b/include/fast_io_core_impl/mode.h
@@ -287,6 +287,10 @@ enum class open_mode : ::std::uint_least64_t
 	//	*POSIX O_TRUNC
 	tty_init = static_cast<::std::uint_least64_t>(1) << 32,
 	//	POSIX O_TTY_INIT
+	dsync = static_cast<::std::uint_least64_t>(1) << 33,
+	//	POSIX O_DSYNC
+	rsync = static_cast<::std::uint_least64_t>(1) << 34,
+	//	POSIX O_RSYNC
 };
 
 inline constexpr open_mode operator&(open_mode x, open_mode y) noexcept

--- a/include/fast_io_dsal/impl/misc/push_macros.h
+++ b/include/fast_io_dsal/impl/misc/push_macros.h
@@ -16,6 +16,7 @@
 #pragma push_macro("new")
 #if __GNUC__ >= 16
 #pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpragmas"
 #pragma GCC diagnostic ignored "-Wkeyword-macro"
 #undef new
 #pragma GCC diagnostic pop

--- a/include/fast_io_hosted/filesystem/posix.h
+++ b/include/fast_io_hosted/filesystem/posix.h
@@ -332,7 +332,7 @@ inline posix_directory_iterator &operator++(posix_directory_iterator &pdit)
 	To fix: avoid setting errno
 	*/
 	errno = 0; // [tls]
-	auto entry{readdir(pdit.dirp)};
+	auto entry{::fast_io::noexcept_call(::readdir, pdit.dirp)};
 	auto en{errno};
 	if (entry == nullptr && en)
 	{
@@ -357,7 +357,7 @@ inline posix_directory_iterator &operator++(posix_directory_iterator &pdit)
 inline posix_directory_iterator begin(posix_directory_generator const &pdg)
 {
 	auto dirp{pdg.dir_fl.dirp};
-	::rewinddir(dirp);
+	::fast_io::noexcept_call(::rewinddir, dirp);
 	posix_directory_iterator pdit{dirp};
 	++pdit;
 	return pdit;
@@ -433,7 +433,7 @@ operator++(basic_posix_recursive_directory_iterator<StackType> &prdit)
 		errno = 0;
 		if (prdit.stack.empty())
 		{
-			auto entry{readdir(prdit.dirp)};
+			auto entry{::fast_io::noexcept_call(::readdir, prdit.dirp)};
 			if (entry == nullptr)
 			{
 				auto en{errno};
@@ -448,7 +448,7 @@ operator++(basic_posix_recursive_directory_iterator<StackType> &prdit)
 		}
 		else
 		{
-			auto entry = readdir(prdit.stack.back().dirp);
+			auto entry = ::fast_io::noexcept_call(::readdir, prdit.stack.back().dirp);
 			if (entry == nullptr)
 			{
 				auto en{errno};
@@ -515,7 +515,7 @@ inline basic_posix_recursive_directory_iterator<StackType>
 begin(basic_posix_recursive_directory_generator<StackType> const &pdg)
 {
 	auto dirp{pdg.dir_fl.dirp};
-	::rewinddir(dirp);
+	::fast_io::noexcept_call(::rewinddir, dirp);
 	basic_posix_recursive_directory_iterator<StackType> pdit{dirp};
 	++pdit;
 	return pdit;

--- a/include/fast_io_hosted/platforms/nt.h
+++ b/include/fast_io_hosted/platforms/nt.h
@@ -220,7 +220,7 @@ inline constexpr nt_open_mode calculate_nt_open_mode(open_mode_perms ompm) noexc
 	{
 		mode.CreateOptions |= 0x00000002; // FILE_WRITE_THROUGH
 	}
-	if ((value & open_mode::follow) != open_mode::none)
+	if ((value & open_mode::follow) == open_mode::none)
 	{
 		mode.CreateOptions |= 0x00200000; // FILE_FLAG_OPEN_REPARSE_POINT => FILE_OPEN_REPARSE_POINT (0x00200000)
 	}

--- a/include/fast_io_hosted/platforms/posix.h
+++ b/include/fast_io_hosted/platforms/posix.h
@@ -227,6 +227,18 @@ inline constexpr int calculate_posix_open_mode(open_mode value) noexcept
 		mode |= O_SYNC;
 	}
 #endif
+#ifdef O_DSYNC
+	if ((value & open_mode::dsync) != open_mode::none)
+	{
+		mode |= O_DSYNC;
+	}
+#endif
+#ifdef O_RSYNC
+	if ((value & open_mode::rsync) != open_mode::none)
+	{
+		mode |= O_RSYNC;
+	}
+#endif
 #ifdef O_TTY_INIT
 	if ((value & open_mode::tty_init) != open_mode::none)
 	{

--- a/include/fast_io_hosted/platforms/win32.h
+++ b/include/fast_io_hosted/platforms/win32.h
@@ -406,7 +406,7 @@ inline constexpr win32_open_mode calculate_win32_open_mode(open_mode_perms ompm)
 	{
 		mode.dwFlagsAndAttributes |= 0x40000000; // FILE_FLAG_OVERLAPPED
 	}
-	if ((value & open_mode::follow) != open_mode::none)
+	if ((value & open_mode::follow) == open_mode::none)
 	{
 		mode.dwFlagsAndAttributes |= 0x00200000; // FILE_FLAG_OPEN_REPARSE_POINT
 	}


### PR DESCRIPTION
- Introduced `dsync` and `rsync` modes in `open_mode` enumeration.
- Updated `calculate_posix_open_mode` to handle `O_DSYNC` and `O_RSYNC` flags.
- Refactored directory iterator implementations to use `noexcept_call` for safer error handling.
- Adjusted conditional checks in NT and Win32 headers for consistency in handling `follow` mode.