### PR TITLE
Bugfix: move construct an empty fast_io::list

### DIFF
--- a/include/fast_io_dsal/impl/list.h
+++ b/include/fast_io_dsal/impl/list.h
@@ -911,7 +911,7 @@ public:
 		  : allochdl(std::move(other.allochdl))
 		  #endif
 	{
-		if (other.empty()) {
+		if (other.is_empty()) {
 			imp = {__builtin_addressof(imp), __builtin_addressof(imp)};
 		} else {
 			imp = other.imp;

--- a/include/fast_io_dsal/impl/list.h
+++ b/include/fast_io_dsal/impl/list.h
@@ -907,15 +907,19 @@ public:
 	}
 
 	inline constexpr list(list &&other) noexcept
-		: imp(other.imp)
 		  #if 0
-		  , allochdl(std::move(other.allochdl))
+		  : allochdl(std::move(other.allochdl))
 		  #endif
 	{
-		auto prev = static_cast<::fast_io::containers::details::list_node_common *>(imp.prev);
-		auto next = static_cast<::fast_io::containers::details::list_node_common *>(imp.next);
-		next->prev = prev->next = __builtin_addressof(imp);
-		other.imp = {__builtin_addressof(other.imp), __builtin_addressof(other.imp)};
+		if (other.empty()) {
+			imp = {__builtin_addressof(imp), __builtin_addressof(imp)};
+		} else {
+			imp = other.imp;
+			auto prev = static_cast<::fast_io::containers::details::list_node_common *>(imp.prev);
+			auto next = static_cast<::fast_io::containers::details::list_node_common *>(imp.next);
+			next->prev = prev->next = __builtin_addressof(imp);
+			other.imp = {__builtin_addressof(other.imp), __builtin_addressof(other.imp)};
+		}
 	}
 
 	inline constexpr list &operator=(list &&other) noexcept

--- a/tests/0026.container/0002.list/list_move.cc
+++ b/tests/0026.container/0002.list/list_move.cc
@@ -3,23 +3,23 @@
 
 int main() {
     ::fast_io::list<int> l1{};
-    if (!l1.empty()) {
+    if (!l1.is_empty()) {
         ::fast_io::fast_terminate();
     }
 
     ::fast_io::list<int> l2(::std::move(l1));
-    if (!l2.empty()) {
+    if (!l2.is_empty()) {
         ::fast_io::fast_terminate();
     }
 
     ::fast_io::list<int> l3{};
     l3.emplace_back(1);
-    if (l3.empty()) {
+    if (l3.is_empty()) {
         ::fast_io::fast_terminate();
     }
 
     ::fast_io::list<int> l4(::std::move(l3));
-    if (l4.empty()) {
+    if (l4.is_empty()) {
         ::fast_io::fast_terminate();
     }
 

--- a/tests/0026.container/0002.list/list_move.cc
+++ b/tests/0026.container/0002.list/list_move.cc
@@ -1,0 +1,27 @@
+
+#include <fast_io_dsal/list.h>
+
+int main() {
+    ::fast_io::list<int> l1{};
+    if (!l1.empty()) {
+        ::fast_io::fast_terminate();
+    }
+
+    ::fast_io::list<int> l2(::std::move(l1));
+    if (!l2.empty()) {
+        ::fast_io::fast_terminate();
+    }
+
+    ::fast_io::list<int> l3{};
+    l3.emplace_back(1);
+    if (l3.empty()) {
+        ::fast_io::fast_terminate();
+    }
+
+    ::fast_io::list<int> l4(::std::move(l3));
+    if (l4.empty()) {
+        ::fast_io::fast_terminate();
+    }
+
+    return 0;
+}


### PR DESCRIPTION
- before this patch, the list_move.cc#L10 will crash

Following information comes from GDB to prove why the move constructor before this patch is wrong:
```
gef➤  p result
$6 = {
  static alloc_with_status = 0x0,
  allochdl = {
    value = {
      static has_status = 0x0
    }
  },
  imp = {
    prev = 0x7fffffffd528,
    next = 0x7fffffffd528
  }
}
gef➤  p &result
$7 = (pltxt2htm::details::MdListAst *) 0x7fffffffd528


gef➤  p call_stack.top().result
$8 = {
  static alloc_with_status = 0x0,
  allochdl = {
    value = {
      static has_status = 0x0
    }
  },
  imp = {
    prev = 0x7fffffffd528,
    next = 0x7fffffffd528
  }
}
gef➤  p &call_stack.top().result
$9 = (pltxt2htm::details::MdListAst *) 0x55555556f548 // Mistake here
```