### PR TITLE
Bugfix: const iter for fast_io::list

### DIFF
--- a/include/fast_io_dsal/impl/list.h
+++ b/include/fast_io_dsal/impl/list.h
@@ -566,7 +566,7 @@ public:
 	}
 	[[nodiscard]] inline constexpr const_iterator end() const noexcept
 	{
-		return {__builtin_addressof(imp)};
+		return {const_cast<::fast_io::containers::details::list_node_common*>(__builtin_addressof(imp))};
 	}
 
 	[[nodiscard]] inline constexpr const_iterator cbegin() const noexcept
@@ -575,16 +575,17 @@ public:
 	}
 	[[nodiscard]] inline constexpr const_iterator cend() const noexcept
 	{
-		return {__builtin_addressof(imp)};
+		return {const_cast<::fast_io::containers::details::list_node_common*>(__builtin_addressof(imp))};
+	}
+
+	[[nodiscard]] inline constexpr reverse_iterator rbegin() noexcept
+	{
+		return reverse_iterator({__builtin_addressof(imp)});
 	}
 
 	[[nodiscard]] inline constexpr reverse_iterator rend() noexcept
 	{
 		return reverse_iterator({imp.next});
-	}
-	[[nodiscard]] inline constexpr reverse_iterator rbegin() noexcept
-	{
-		return reverse_iterator({__builtin_addressof(imp)});
 	}
 
 	[[nodiscard]] inline constexpr const_reverse_iterator rend() const noexcept
@@ -593,7 +594,7 @@ public:
 	}
 	[[nodiscard]] inline constexpr const_reverse_iterator rbegin() const noexcept
 	{
-		return const_reverse_iterator({__builtin_addressof(imp)});
+		return const_reverse_iterator({const_cast<::fast_io::containers::details::list_node_common*>(__builtin_addressof(imp))});
 	}
 
 	[[nodiscard]] inline constexpr const_reverse_iterator crend() const noexcept
@@ -602,7 +603,7 @@ public:
 	}
 	[[nodiscard]] inline constexpr const_reverse_iterator crbegin() const noexcept
 	{
-		return const_reverse_iterator({__builtin_addressof(imp)});
+		return const_reverse_iterator({const_cast<::fast_io::containers::details::list_node_common*>(__builtin_addressof(imp))});
 	}
 
 	[[nodiscard]] inline constexpr bool empty() const noexcept

--- a/tests/0026.container/0002.list/list_iter.cc
+++ b/tests/0026.container/0002.list/list_iter.cc
@@ -1,0 +1,174 @@
+#include <fast_io_dsal/list.h>
+
+struct X
+{
+	int a;
+};
+
+void test_iter()
+{
+	::fast_io::list<X> l{X{1}, X{2}, X{3}};
+
+	auto iter = l.begin();
+	{
+		auto &&value = *iter;
+		auto &&value2 = iter->a;
+		auto value3 = *iter++;
+
+		if (value.a != 1 || value2 != 1 || value3.a != 1)
+		{
+			::fast_io::fast_terminate();
+		}
+	}
+
+	++iter;
+
+	{
+		auto &&value = *iter;
+		auto &&value2 = iter->a;
+		auto value3 = *iter++;
+
+		if (value.a != 3 || value2 != 3 || value3.a != 3)
+		{
+			::fast_io::fast_terminate();
+		}
+	}
+
+	if (iter != l.end())
+	{
+		::fast_io::fast_terminate();
+	}
+}
+
+void test_iter2()
+{
+	::fast_io::list<X> l{X{1}, X{2}, X{3}};
+
+	for (auto &&v : l)
+	{
+		if (v.a != 1 && v.a != 2 && v.a != 3)
+		{
+			::fast_io::fast_terminate();
+		}
+	}
+}
+
+void test_const_iter()
+{
+    ::fast_io::list<X> const l{X{1}, X{2}, X{3}};
+
+	auto iter = l.begin();
+	{
+		auto &&value = *iter;
+		auto &&value2 = iter->a;
+		auto value3 = *iter++;
+
+		if (value.a != 1 || value2 != 1 || value3.a != 1)
+		{
+			::fast_io::fast_terminate();
+		}
+	}
+
+	++iter;
+
+	{
+		auto &&value = *iter;
+		auto &&value2 = iter->a;
+		auto value3 = *iter++;
+
+		if (value.a != 3 || value2 != 3 || value3.a != 3)
+		{
+			::fast_io::fast_terminate();
+		}
+	}
+
+	if (iter != l.end())
+	{
+		::fast_io::fast_terminate();
+	}
+}
+
+void test_const_iter2()
+{
+	::fast_io::list<X> const l{X{1}, X{2}, X{3}};
+
+	for (auto &&v : l)
+	{
+		if (v.a != 1 && v.a != 2 && v.a != 3)
+		{
+			::fast_io::fast_terminate();
+		}
+	}
+}
+
+void test_reverse_iter()
+{
+    ::fast_io::list<X> l{X{1}, X{2}, X{3}};
+    auto iter = l.rbegin();
+    {
+        auto &&value = *iter;
+        auto &&value2 = iter->a;
+        auto value3 = *iter++;
+
+        if (value.a != 3 || value2 != 3 || value3.a != 3)
+        {
+            ::fast_io::fast_terminate();
+        }
+    }
+    {
+        auto &&value = *iter;
+        auto &&value2 = iter->a;
+        auto value3 = *iter++;
+
+        if (value.a != 2 || value2 != 2 || value3.a != 2)
+        {
+            ::fast_io::fast_terminate();
+        }
+    }
+    ++iter;
+    if (iter != l.rend())
+    {
+        ::fast_io::fast_terminate();
+    }
+}
+
+void test_reverse_const_iter()
+{
+    ::fast_io::list<X> const l{X{1}, X{2}, X{3}};
+    auto iter = l.crbegin();
+    {
+        auto &&value = *iter;
+        auto &&value2 = iter->a;
+        auto value3 = *iter++;
+
+        if (value.a != 3 || value2 != 3 || value3.a != 3)
+        {
+            ::fast_io::fast_terminate();
+        }
+    }
+    {
+        auto &&value = *iter;
+        auto &&value2 = iter->a;
+        auto value3 = *iter++;
+
+        if (value.a != 2 || value2 != 2 || value3.a != 2)
+        {
+            ::fast_io::fast_terminate();
+        }
+    }
+    ++iter;
+    if (iter != l.crend())
+    {
+        ::fast_io::fast_terminate();
+    }
+}
+
+int main()
+{
+	::test_iter();
+	::test_iter2();
+	::test_const_iter();
+    ::test_const_iter2();
+	::test_reverse_iter();
+	::test_reverse_const_iter();
+}


### PR DESCRIPTION
following code won't compile before this patch:
<img width="266" height="48" alt="image" src="https://github.com/user-attachments/assets/95477f7c-84a1-46c5-be6c-a02b8aebe3ad" />
