### PR TITLE
fix bug caused by MacroModel

### DIFF
--- a/include/fast_io_hosted/platforms/systemcall_details.h
+++ b/include/fast_io_hosted/platforms/systemcall_details.h
@@ -29,9 +29,9 @@ inline int sys_dup(int old_fd)
 #else
 	auto fd{noexcept_call(
 #if defined(_WIN32) && !defined(__BIONIC__)
-		::_dup
+		_dup
 #else
-		::dup
+		dup
 #endif
 		,
 		old_fd)};


### PR DESCRIPTION
- a week ago, MacroModel want to merge a huge pr, which edited here I have no idea why he did this change, or simply a bug-scanner ai reported this "problem"
  - Following error messages just to prove why this patch exists:

In file included from ..\include/fast_io/fast_io.h:10: In file included from ..\include/fast_io/fast_io_hosted.h:69: In file included from ..\include/fast_io/fast_io_hosted/platforms/native.h:3: In file included from ..\include/fast_io/fast_io_hosted/platforms/native_base.h:27: In file included from ..\include/fast_io/fast_io_hosted/platforms/posix.h:46: ..\include/fast_io/fast_io_hosted/platforms/systemcall_details.h:34:3: error: no member named 'dup' in the global namespace; did you mean simply 'dup'?
   34 |                 ::dup
      |                 ^~~~~
      |                 dup
..\include/fast_io/fast_io_hosted/platforms/systemcall_details.h:11:12: note: 'dup' declared here
   11 | inline int dup(int) noexcept
      |            ^
1 error generated.