### PR TITLE
feat(string): unsafe_detached_release

### DIFF
--- a/include/fast_io_dsal/impl/string.h
+++ b/include/fast_io_dsal/impl/string.h
@@ -218,6 +218,17 @@ public:
 		return imp.begin_ptr;
 	}
 
+	/**
+	 * @brief Detach the string and release the memory which against RAII
+	 * @return The pointer to the string
+	 * @note This methods is dangerous, which only helps to c-ptr style interface
+	 */
+	inline constexpr pointer unsafe_detached_release() noexcept {
+		auto result = imp.begin_ptr;
+		imp = {nullptr, nullptr, nullptr};
+		return result;
+	}
+
 	inline constexpr bool is_empty() const noexcept
 	{
 		return imp.begin_ptr == imp.curr_ptr;

--- a/tests/0026.container/0004.string/unsafe_detached_release.cc
+++ b/tests/0026.container/0004.string/unsafe_detached_release.cc
@@ -1,0 +1,13 @@
+#include <cstdlib>
+#include <fast_io_dsal/string.h>
+
+int main()
+{
+	fast_io::basic_string<char, ::fast_io::generic_allocator_adapter<::fast_io::c_malloc_allocator>> str("hello world");
+	auto ptr = str.unsafe_detached_release();
+    ::std::free(ptr);
+    str.append("hello world");
+    if (str != "hello world") [[unlikely]] {
+        ::fast_io::fast_terminate();
+    }
+}


### PR DESCRIPTION
Which help to avoid redundant copy when supplying c-ptr style interface