### PR TITLE
Add NT event and timer APIs, improve path handling, and enhance socke…

### DIFF
--- a/include/fast_io_hosted/platforms/nt/nt_api.h
+++ b/include/fast_io_hosted/platforms/nt/nt_api.h
@@ -32,6 +32,8 @@ FAST_IO_DLLIMPORT ::std::uint_least32_t FAST_IO_WINSTDCALL NtDuplicateObject(voi
 FAST_IO_DLLIMPORT ::std::uint_least32_t FAST_IO_WINSTDCALL ZwDuplicateObject(void *, void *, void *, void **, ::std::uint_least32_t, ::std::uint_least32_t, ::std::uint_least32_t) noexcept FAST_IO_WINSTDCALL_RENAME(ZwDuplicateObject, 28);
 FAST_IO_DLLIMPORT ::std::uint_least32_t FAST_IO_WINSTDCALL NtWaitForSingleObject(void *, int, ::std::uint_least64_t *) noexcept FAST_IO_WINSTDCALL_RENAME(NtWaitForSingleObject, 12);
 FAST_IO_DLLIMPORT ::std::uint_least32_t FAST_IO_WINSTDCALL ZwWaitForSingleObject(void *, int, ::std::uint_least64_t *) noexcept FAST_IO_WINSTDCALL_RENAME(ZwWaitForSingleObject, 12);
+FAST_IO_DLLIMPORT ::std::uint_least32_t FAST_IO_WINSTDCALL NtWaitForMultipleObjects(::std::uint_least32_t, void *const *, ::fast_io::win32::nt::wait_type, int, ::std::uint_least64_t *) noexcept FAST_IO_WINSTDCALL_RENAME(NtWaitForMultipleObjects, 20);
+FAST_IO_DLLIMPORT ::std::uint_least32_t FAST_IO_WINSTDCALL ZwWaitForMultipleObjects(::std::uint_least32_t, void *const *, ::fast_io::win32::nt::wait_type, int, ::std::uint_least64_t *) noexcept FAST_IO_WINSTDCALL_RENAME(ZwWaitForMultipleObjects, 20);
 FAST_IO_DLLIMPORT ::std::uint_least32_t FAST_IO_WINSTDCALL NtSetSystemTime(::std::int_least64_t *, ::std::int_least64_t *) noexcept FAST_IO_WINSTDCALL_RENAME(NtSetSystemTime, 8);
 FAST_IO_DLLIMPORT ::std::uint_least32_t FAST_IO_WINSTDCALL ZwSetSystemTime(::std::int_least64_t *, ::std::int_least64_t *) noexcept FAST_IO_WINSTDCALL_RENAME(ZwSetSystemTime, 8);
 FAST_IO_DLLIMPORT ::std::uint_least32_t FAST_IO_WINSTDCALL NtCreateProcess(void **, ::std::uint_least32_t, ::fast_io::win32::nt::object_attributes *, void *, ::std::uint_least32_t, void *, void *, void *) noexcept FAST_IO_WINSTDCALL_RENAME(NtCreateProcess, 32);
@@ -96,6 +98,12 @@ FAST_IO_DLLIMPORT ::std::uint_least64_t FAST_IO_WINSTDCALL RtlGetSystemTimePreci
 FAST_IO_DLLIMPORT ::std::uint_least32_t FAST_IO_WINSTDCALL NtQueryInformationThread(void *__restrict, ::fast_io::win32::nt::thread_information_class, void *, ::std::uint_least32_t, ::std::uint_least32_t *) noexcept FAST_IO_WINSTDCALL_RENAME(NtQueryInformationThread, 20);
 FAST_IO_DLLIMPORT ::std::uint_least32_t FAST_IO_WINSTDCALL ZwQueryInformationThread(void *__restrict, ::fast_io::win32::nt::thread_information_class, void *, ::std::uint_least32_t, ::std::uint_least32_t *) noexcept FAST_IO_WINSTDCALL_RENAME(ZwQueryInformationThread, 20);
 FAST_IO_DLLIMPORT ::std::uint_least32_t FAST_IO_WINSTDCALL RtlAdjustPrivilege(::std::uint_least32_t, ::std::uint_least8_t, ::std::uint_least8_t, ::std::uint_least8_t *) noexcept FAST_IO_WINSTDCALL_RENAME(RtlAdjustPrivilege, 16); // TODO can the first param be `::fast_io::win32::nt::privileges`?
+FAST_IO_DLLIMPORT ::std::uint_least32_t FAST_IO_WINSTDCALL NtCreateEvent(void **, ::std::uint_least32_t, ::fast_io::win32::nt::object_attributes *, ::fast_io::win32::nt::event_type, ::std::uint_least8_t) noexcept FAST_IO_WINSTDCALL_RENAME(NtCreateEvent, 20);
+FAST_IO_DLLIMPORT ::std::uint_least32_t FAST_IO_WINSTDCALL ZwCreateEvent(void **, ::std::uint_least32_t, ::fast_io::win32::nt::object_attributes *, ::fast_io::win32::nt::event_type, ::std::uint_least8_t) noexcept FAST_IO_WINSTDCALL_RENAME(ZwCreateEvent, 20);
+FAST_IO_DLLIMPORT ::std::uint_least32_t FAST_IO_WINSTDCALL NtSetEvent(void *, ::std::uint_least32_t *) noexcept FAST_IO_WINSTDCALL_RENAME(NtSetEvent, 8);
+FAST_IO_DLLIMPORT ::std::uint_least32_t FAST_IO_WINSTDCALL ZwSetEvent(void *, ::std::uint_least32_t *) noexcept FAST_IO_WINSTDCALL_RENAME(ZwSetEvent, 8);
+FAST_IO_DLLIMPORT ::std::uint_least32_t FAST_IO_WINSTDCALL NtResetEvent(void *, ::std::uint_least32_t *) noexcept FAST_IO_WINSTDCALL_RENAME(NtResetEvent, 8);
+FAST_IO_DLLIMPORT ::std::uint_least32_t FAST_IO_WINSTDCALL ZwResetEvent(void *, ::std::uint_least32_t *) noexcept FAST_IO_WINSTDCALL_RENAME(ZwResetEvent, 8);
 FAST_IO_DLLIMPORT ::std::uint_least32_t FAST_IO_WINSTDCALL NtSetInformationObject(void *__restrict, ::fast_io::win32::nt::object_information_class, void *, ::std::uint_least32_t) noexcept FAST_IO_WINSTDCALL_RENAME(NtSetInformationObject, 16);
 FAST_IO_DLLIMPORT ::std::uint_least32_t FAST_IO_WINSTDCALL ZwSetInformationObject(void *__restrict, ::fast_io::win32::nt::object_information_class, void *, ::std::uint_least32_t) noexcept FAST_IO_WINSTDCALL_RENAME(ZwSetInformationObject, 16);
 FAST_IO_DLLIMPORT ::std::uint_least32_t FAST_IO_WINSTDCALL NtQueryAuxiliaryCounterFrequency(::std::uint_least64_t *) noexcept FAST_IO_WINSTDCALL_RENAME(NtQueryAuxiliaryCounterFrequency, 4);
@@ -143,5 +151,11 @@ FAST_IO_DLLIMPORT ::std::uint_least32_t FAST_IO_WINSTDCALL NtDelayExecution(bool
 FAST_IO_DLLIMPORT ::std::uint_least32_t FAST_IO_WINSTDCALL ZwDelayExecution(bool, ::std::int_least64_t *) noexcept FAST_IO_WINSTDCALL_RENAME(ZwDelayExecution, 8);
 FAST_IO_DLLIMPORT ::std::uint_least32_t FAST_IO_WINSTDCALL NtSetTimerResolution(::std::uint_least32_t, bool, ::std::uint_least32_t *) noexcept FAST_IO_WINSTDCALL_RENAME(NtSetTimerResolution, 12);
 FAST_IO_DLLIMPORT ::std::uint_least32_t FAST_IO_WINSTDCALL ZwSetTimerResolution(::std::uint_least32_t, bool, ::std::uint_least32_t *) noexcept FAST_IO_WINSTDCALL_RENAME(ZwSetTimerResolution, 12);
+FAST_IO_DLLIMPORT ::std::uint_least32_t FAST_IO_WINSTDCALL NtCreateTimer(void **, ::std::uint_least32_t, ::fast_io::win32::nt::object_attributes *, ::fast_io::win32::nt::timer_type) noexcept FAST_IO_WINSTDCALL_RENAME(NtCreateTimer, 16);
+FAST_IO_DLLIMPORT ::std::uint_least32_t FAST_IO_WINSTDCALL ZwCreateTimer(void **, ::std::uint_least32_t, ::fast_io::win32::nt::object_attributes *, ::fast_io::win32::nt::timer_type) noexcept FAST_IO_WINSTDCALL_RENAME(ZwCreateTimer, 16);
+FAST_IO_DLLIMPORT ::std::uint_least32_t FAST_IO_WINSTDCALL NtSetTimer(void *, ::std::uint_least64_t const *, ::fast_io::win32::nt::ptimer_apc_routine, void *, ::std::uint_least8_t, ::std::int_least32_t, ::std::uint_least8_t *) noexcept FAST_IO_WINSTDCALL_RENAME(NtSetTimer, 28);
+FAST_IO_DLLIMPORT ::std::uint_least32_t FAST_IO_WINSTDCALL ZwSetTimer(void *, ::std::uint_least64_t const *, ::fast_io::win32::nt::ptimer_apc_routine, void *, ::std::uint_least8_t, ::std::int_least32_t, ::std::uint_least8_t *) noexcept FAST_IO_WINSTDCALL_RENAME(ZwSetTimer, 28);
+FAST_IO_DLLIMPORT ::std::uint_least32_t FAST_IO_WINSTDCALL NtCancelTimer(void *, ::std::uint_least8_t *) noexcept FAST_IO_WINSTDCALL_RENAME(NtCancelTimer, 8);
+FAST_IO_DLLIMPORT ::std::uint_least32_t FAST_IO_WINSTDCALL ZwCancelTimer(void *, ::std::uint_least8_t *) noexcept FAST_IO_WINSTDCALL_RENAME(ZwCancelTimer, 8);
 
 } // namespace fast_io::win32::nt

--- a/include/fast_io_hosted/platforms/nt/nt_definitions.h
+++ b/include/fast_io_hosted/platforms/nt/nt_definitions.h
@@ -1,6 +1,7 @@
 ﻿#pragma once
 
 #include <cstdint>
+#include <cstddef>
 #include "../../../fast_io_core_impl/allocation/common.h"
 
 namespace fast_io::win32::nt
@@ -50,7 +51,27 @@ struct io_status_block
 	::std::size_t Information;
 };
 
+enum class wait_type
+{
+	WaitAll,
+	WaitAny
+};
+
+enum class event_type
+{
+	NotificationEvent,
+	SynchronizationEvent
+};
+
+enum class timer_type
+{
+	NotificationTimer,
+	SynchronizationTimer
+};
+
 using pio_apc_routine = void (*)(void *, io_status_block *, ::std::uint_least32_t) noexcept;
+
+using ptimer_apc_routine = void (*)(void *, ::std::uint_least32_t, ::std::int_least32_t) noexcept;
 
 struct rtlp_curdir_def
 {

--- a/include/fast_io_hosted/platforms/nt/nt_zw.h
+++ b/include/fast_io_hosted/platforms/nt/nt_zw.h
@@ -185,6 +185,20 @@ inline ::std::uint_least32_t nt_wait_for_single_object(Args... args) noexcept
 }
 
 template <bool zw, typename... Args>
+	requires(sizeof...(Args) == 5)
+inline ::std::uint_least32_t nt_wait_for_multiple_objects(Args... args) noexcept
+{
+	if constexpr (zw)
+	{
+		return ::fast_io::win32::nt::ZwWaitForMultipleObjects(args...);
+	}
+	else
+	{
+		return ::fast_io::win32::nt::NtWaitForMultipleObjects(args...);
+	}
+}
+
+template <bool zw, typename... Args>
 	requires(sizeof...(Args) == 2)
 inline ::std::uint_least32_t nt_set_system_time(Args... args) noexcept
 {
@@ -727,6 +741,90 @@ inline ::std::uint_least32_t nt_set_timer_resolution(Args... args) noexcept
 	else
 	{
 		return ::fast_io::win32::nt::NtSetTimerResolution(args...);
+	}
+}
+
+template <bool zw, typename... Args>
+	requires(sizeof...(Args) == 5)
+inline ::std::uint_least32_t nt_create_event(Args... args) noexcept
+{
+	if constexpr (zw)
+	{
+		return ::fast_io::win32::nt::ZwCreateEvent(args...);
+	}
+	else
+	{
+		return ::fast_io::win32::nt::NtCreateEvent(args...);
+	}
+}
+
+template <bool zw, typename... Args>
+	requires(sizeof...(Args) == 2)
+inline ::std::uint_least32_t nt_set_event(Args... args) noexcept
+{
+	if constexpr (zw)
+	{
+		return ::fast_io::win32::nt::ZwSetEvent(args...);
+	}
+	else
+	{
+		return ::fast_io::win32::nt::NtSetEvent(args...);
+	}
+}
+
+template <bool zw, typename... Args>
+	requires(sizeof...(Args) == 2)
+inline ::std::uint_least32_t nt_reset_event(Args... args) noexcept
+{
+	if constexpr (zw)
+	{
+		return ::fast_io::win32::nt::ZwResetEvent(args...);
+	}
+	else
+	{
+		return ::fast_io::win32::nt::NtResetEvent(args...);
+	}
+}
+
+template <bool zw, typename... Args>
+	requires(sizeof...(Args) == 4)
+inline ::std::uint_least32_t nt_create_timer(Args... args) noexcept
+{
+	if constexpr (zw)
+	{
+		return ::fast_io::win32::nt::ZwCreateTimer(args...);
+	}
+	else
+	{
+		return ::fast_io::win32::nt::NtCreateTimer(args...);
+	}
+}
+
+template <bool zw, typename... Args>
+	requires(sizeof...(Args) == 7)
+inline ::std::uint_least32_t nt_set_timer(Args... args) noexcept
+{
+	if constexpr (zw)
+	{
+		return ::fast_io::win32::nt::ZwSetTimer(args...);
+	}
+	else
+	{
+		return ::fast_io::win32::nt::NtSetTimer(args...);
+	}
+}
+
+template <bool zw, typename... Args>
+	requires(sizeof...(Args) == 2)
+inline ::std::uint_least32_t nt_cancel_timer(Args... args) noexcept
+{
+	if constexpr (zw)
+	{
+		return ::fast_io::win32::nt::ZwCancelTimer(args...);
+	}
+	else
+	{
+		return ::fast_io::win32::nt::NtCancelTimer(args...);
 	}
 }
 

--- a/include/fast_io_hosted/platforms/posix.h
+++ b/include/fast_io_hosted/platforms/posix.h
@@ -1094,7 +1094,7 @@ inline int my_posix_open(char const *pathname, int flags,
 {
 #if defined(__MSDOS__) || (defined(__NEWLIB__) && !defined(AT_FDCWD)) || defined(_PICOLIBC__)
 	int fd{::fast_io::details::my_posix_open_noexcept(pathname, flags, mode)};
-	if(fd == -1) [[unlikely]]
+	if (fd == -1) [[unlikely]]
 	{
 		if constexpr (always_terminate)
 		{
@@ -1570,7 +1570,13 @@ inline void posix_truncate_impl(int fd, ::fast_io::uintfpos_t size)
 		}
 	}
 
-	if (noexcept_call(::ftruncate, fd, static_cast<off_t>(size)) < 0)
+	if (
+#if defined(__CYGWIN__)
+		::fast_io::details::ftruncate(fd, static_cast<off_t>(size)) < 0
+#else
+		noexcept_call(::ftruncate, fd, static_cast<off_t>(size)) < 0
+#endif
+	)
 	{
 		throw_posix_error();
 	}

--- a/include/fast_io_hosted/platforms/win32/apis.h
+++ b/include/fast_io_hosted/platforms/win32/apis.h
@@ -94,6 +94,11 @@ FAST_IO_DLLIMPORT int FAST_IO_WINSTDCALL recvfrom(::std::size_t, char *, int, in
 FAST_IO_DLLIMPORT int FAST_IO_WINSTDCALL WSARecv(::std::size_t, ::fast_io::win32::wsabuf *, ::std::uint_least32_t, ::std::uint_least32_t *, ::std::uint_least32_t *, ::fast_io::win32::overlapped *, ::fast_io::win32::lpwsaoverlapped_completion_routine) noexcept FAST_IO_WINSTDCALL_RENAME(WSARecv, 28);
 FAST_IO_DLLIMPORT int FAST_IO_WINSTDCALL WSARecvFrom(::std::size_t, ::fast_io::win32::wsabuf *, ::std::uint_least32_t, ::std::uint_least32_t *, ::std::uint_least32_t *, void *, int *, ::fast_io::win32::overlapped *, ::fast_io::win32::lpwsaoverlapped_completion_routine) noexcept FAST_IO_WINSTDCALL_RENAME(WSARecvFrom, 36);
 FAST_IO_DLLIMPORT int FAST_IO_WINSTDCALL connect(::std::size_t, void const *, int) noexcept FAST_IO_WINSTDCALL_RENAME(connect, 12);
+FAST_IO_DLLIMPORT ::std::size_t FAST_IO_WINSTDCALL WSACreateEvent() noexcept FAST_IO_WINSTDCALL_RENAME(WSACreateEvent, 0);
+FAST_IO_DLLIMPORT int FAST_IO_WINSTDCALL WSACloseEvent(::std::size_t) noexcept FAST_IO_WINSTDCALL_RENAME(WSACloseEvent, 4);
+FAST_IO_DLLIMPORT int FAST_IO_WINSTDCALL WSAResetEvent(::std::size_t) noexcept FAST_IO_WINSTDCALL_RENAME(WSAResetEvent, 4);
+FAST_IO_DLLIMPORT int FAST_IO_WINSTDCALL WSAEventSelect(::std::size_t, ::std::size_t, ::std::uint_least32_t) noexcept FAST_IO_WINSTDCALL_RENAME(WSAEventSelect, 12);
+FAST_IO_DLLIMPORT int FAST_IO_WINSTDCALL WSAEnumNetworkEvents(::std::size_t, ::std::size_t, ::fast_io::win32::wsanetworkevents *) noexcept FAST_IO_WINSTDCALL_RENAME(WSAEnumNetworkEvents, 12);
 FAST_IO_DLLIMPORT int FAST_IO_WINSTDCALL WSAConnect(::std::size_t, void const *, int, ::fast_io::win32::wsabuf *, ::fast_io::win32::wsabuf *, ::fast_io::win32::qualityofservice *, ::fast_io::win32::qualityofservice *) noexcept FAST_IO_WINSTDCALL_RENAME(WSAConnect, 28);
 FAST_IO_DLLIMPORT int FAST_IO_WINSTDCALL shutdown(::std::size_t, int) noexcept FAST_IO_WINSTDCALL_RENAME(shutdown, 8);
 FAST_IO_DLLIMPORT ::std::uint_least32_t FAST_IO_WINSTDCALL GetCurrentProcessId() noexcept FAST_IO_WINSTDCALL_RENAME(GetCurrentProcessId, 0);
@@ -161,6 +166,10 @@ FAST_IO_DLLIMPORT void *FAST_IO_WINSTDCALL CreateNamedPipeW(char16_t const *, ::
 FAST_IO_DLLIMPORT void *FAST_IO_WINSTDCALL CreateNamedPipeA(char const *, ::std::uint_least32_t, ::std::uint_least32_t, ::std::uint_least32_t, ::std::uint_least32_t, ::std::uint_least32_t, ::std::uint_least32_t, ::fast_io::win32::security_attributes *) noexcept FAST_IO_WINSTDCALL_RENAME(CreateNamedPipeA, 32);
 FAST_IO_DLLIMPORT int FAST_IO_WINSTDCALL ConnectNamedPipe(void *, ::fast_io::win32::overlapped *) noexcept FAST_IO_WINSTDCALL_RENAME(ConnectNamedPipe, 8);
 FAST_IO_DLLIMPORT int FAST_IO_WINSTDCALL DisconnectNamedPipe(void *) noexcept FAST_IO_WINSTDCALL_RENAME(DisconnectNamedPipe, 4);
+FAST_IO_DLLIMPORT void *FAST_IO_WINSTDCALL CreateWaitableTimerW(::fast_io::win32::security_attributes *, int, char16_t const *) noexcept FAST_IO_WINSTDCALL_RENAME(CreateWaitableTimerW, 12);
+FAST_IO_DLLIMPORT void *FAST_IO_WINSTDCALL CreateWaitableTimerA(::fast_io::win32::security_attributes *, int, char const *) noexcept FAST_IO_WINSTDCALL_RENAME(CreateWaitableTimerA, 12);
+FAST_IO_DLLIMPORT int FAST_IO_WINSTDCALL SetWaitableTimer(void *, ::std::int_least64_t const *, ::std::int_least32_t, ::fast_io::win32::ptimerapcroutine, void *, int) noexcept FAST_IO_WINSTDCALL_RENAME(SetWaitableTimer, 24);
+FAST_IO_DLLIMPORT int FAST_IO_WINSTDCALL CancelWaitableTimer(void *) noexcept FAST_IO_WINSTDCALL_RENAME(CancelWaitableTimer, 4);
 FAST_IO_DLLIMPORT int FAST_IO_WINSTDCALL LookupPrivilegeValueA(char const *__restrict, char const *__restrict, ::std::int_least64_t *) noexcept FAST_IO_WINSTDCALL_RENAME(LookupPrivilegeValueA, 12);
 FAST_IO_DLLIMPORT int FAST_IO_WINSTDCALL LookupPrivilegeValueW(char16_t const *__restrict, char16_t const *__restrict, ::std::int_least64_t *) noexcept FAST_IO_WINSTDCALL_RENAME(LookupPrivilegeValueW, 12);
 FAST_IO_DLLIMPORT void *FAST_IO_WINSTDCALL CreateThread(security_attributes *, ::std::size_t, ::std::uint_least32_t (FAST_IO_WINSTDCALL*)(void*), void*, ::std::uint_least32_t, ::std::uint_least32_t*) noexcept FAST_IO_WINSTDCALL_RENAME(CreateThread, 24);
@@ -181,5 +190,6 @@ FAST_IO_DLLIMPORT int FAST_IO_WINSTDCALL GetVolumeInformationW(char16_t const*, 
 FAST_IO_DLLIMPORT int FAST_IO_WINSTDCALL GetVolumeInformationA(char const*, char*, ::std::uint_least32_t, ::std::uint_least32_t*, ::std::uint_least32_t*, ::std::uint_least32_t*, char*, ::std::uint_least32_t) noexcept FAST_IO_WINSTDCALL_RENAME(GetVolumeInformationA, 32);
 FAST_IO_DLLIMPORT int FAST_IO_WINSTDCALL GetDiskFreeSpaceW(char16_t const*, ::std::uint_least32_t*, ::std::uint_least32_t*, ::std::uint_least32_t*, ::std::uint_least32_t*) noexcept FAST_IO_WINSTDCALL_RENAME(GetDiskFreeSpaceW, 20);
 FAST_IO_DLLIMPORT int FAST_IO_WINSTDCALL GetDiskFreeSpaceA(char const*, ::std::uint_least32_t*, ::std::uint_least32_t*, ::std::uint_least32_t*, ::std::uint_least32_t*) noexcept FAST_IO_WINSTDCALL_RENAME(GetDiskFreeSpaceA, 20);
+FAST_IO_DLLIMPORT void FAST_IO_WINSTDCALL ExitProcess(::std::uint_least32_t) noexcept FAST_IO_WINSTDCALL_RENAME(ExitProcess, 4);
 
 } // namespace fast_io::win32

--- a/include/fast_io_hosted/platforms/win32/win32_definitions.h
+++ b/include/fast_io_hosted/platforms/win32/win32_definitions.h
@@ -284,6 +284,22 @@ struct wsamsg
 	::std::uint_least32_t dwflags;
 };
 
+inline constexpr ::std::size_t fd_max_events{10u};
+
+struct wsanetworkevents
+{
+	::std::int_least32_t lNetworkEvents;
+	int iErrorCode[fd_max_events];
+};
+
+using ptimerapcroutine = void(
+#if defined(_MSC_VER) && (!__has_cpp_attribute(__gnu__::__stdcall__) && !defined(__WINE__))
+	__stdcall
+#elif (__has_cpp_attribute(__gnu__::__stdcall__) && !defined(__WINE__))
+	__attribute__((__stdcall__))
+#endif
+		*)(void *, ::std::uint_least32_t, ::std::uint_least32_t) noexcept;
+
 using lpwsaoverlapped_completion_routine = void(
 #if defined(_MSC_VER) && (!__has_cpp_attribute(__gnu__::__stdcall__) && !defined(__WINE__))
 	__stdcall

--- a/include/fast_io_hosted/platforms/win32_network/socket_file.h
+++ b/include/fast_io_hosted/platforms/win32_network/socket_file.h
@@ -31,7 +31,7 @@ struct win32_socket_event_guard_t
 
 		if(curr_handle) [[likely]]
 		{
-			::fast_io::win32::CloseHandle(curr_handle);
+			::fast_io::win32::WSACloseEvent(curr_handle);
 		}
 
 		curr_handle = other.curr_handle;
@@ -61,7 +61,7 @@ struct win32_socket_event_guard_t
 	{
 		if (curr_handle) [[likely]]
 		{
-			::fast_io::win32::CloseHandle(curr_handle);
+			::fast_io::win32::WSACloseEvent(curr_handle);
 		}
 	}
 };

--- a/include/fast_io_hosted/platforms/win32_network/socket_file.h
+++ b/include/fast_io_hosted/platforms/win32_network/socket_file.h
@@ -3,6 +3,69 @@
 namespace fast_io
 {
 
+struct win32_socket_event_guard_t
+{
+	using native_handle_type = ::std::size_t;
+
+	native_handle_type curr_handle{};
+
+	inline constexpr win32_socket_event_guard_t() noexcept = default;
+
+	inline constexpr win32_socket_event_guard_t(native_handle_type handle) noexcept : curr_handle(handle)
+	{}
+
+	inline constexpr win32_socket_event_guard_t(win32_socket_event_guard_t const &) = delete;
+	inline constexpr win32_socket_event_guard_t &operator=(win32_socket_event_guard_t const &) = delete;
+
+	inline constexpr win32_socket_event_guard_t(win32_socket_event_guard_t &&other) noexcept : curr_handle{other.curr_handle}
+	{
+		other.curr_handle = {};
+	}
+
+	inline constexpr win32_socket_event_guard_t &operator=(win32_socket_event_guard_t &&other) noexcept
+	{
+		if (__builtin_addressof(other) == this) [[unlikely]]
+		{
+			return *this;
+		}
+
+		if(curr_handle) [[likely]]
+		{
+			::fast_io::win32::CloseHandle(curr_handle);
+		}
+
+		curr_handle = other.curr_handle;
+		other.curr_handle = {};
+
+		return *this;
+	}
+
+	inline constexpr native_handle_type release() noexcept
+	{
+		native_handle_type temp{curr_handle};
+		curr_handle = {};
+		return temp;
+	}
+	
+	inline constexpr native_handle_type native_handle() const noexcept
+	{
+		return curr_handle;
+	}
+
+	inline constexpr native_handle_type native_handle() noexcept
+	{
+		return curr_handle;
+	}
+
+	inline constexpr ~win32_socket_event_guard_t()
+	{
+		if (curr_handle) [[likely]]
+		{
+			::fast_io::win32::CloseHandle(curr_handle);
+		}
+	}
+};
+
 using win32_socklen_t = int;
 
 template <win32_family family, ::std::integral ch_type>


### PR DESCRIPTION
…t event management

- Added `NtWaitForMultipleObjects` and `ZwWaitForMultipleObjects` APIs with `wait_type` enumeration for WaitAll/WaitAny modes
- Introduced event APIs: `NtCreateEvent`, `NtSetEvent`, `NtResetEvent` with `event_type` enumeration for NotificationEvent/SynchronizationEvent
- Added timer APIs: `NtCreateTimer`, `NtSetTimer`, `NtCancelTimer` with `timer_type` enumeration and `ptimer_apc_routine` callback type
- Implemente