### PR TITLE
Add validation for trailing single colon in IPv6 address parsing

### DIFF
--- a/include/fast_io_core_impl/socket/addrscn.h
+++ b/include/fast_io_core_impl/socket/addrscn.h
@@ -515,7 +515,11 @@ scn_cnt_define_in6addr_shorten_impl(char_type const *begin, char_type const *end
 
 		// Here *it == ':'
 		++it;
-		if (it != end && *it == colon)
+		if (it == end)
+		{
+			return {it, parse_code::invalid};
+		}
+		if (*it == colon)
 		{
 			// Encountered "::"
 			if (colonp != nullptr) [[unlikely]]


### PR DESCRIPTION
- Added check in `scn_cnt_define_in6addr_shorten_impl` to return `parse_code::invalid` when buffer ends with single colon
- Prevents accepting malformed IPv6 addresses ending with ":" instead of "::" or valid hex digit
- Split compound condition to validate buffer bounds before checking for double colon