### PR TITLE
Add erase/erase_index to deque

### DIFF
--- a/benchmark/0011.containers/deque/0001.push_back/fast_io_reverse.cc
+++ b/benchmark/0011.containers/deque/0001.push_back/fast_io_reverse.cc
@@ -4,7 +4,7 @@
 
 int main()
 {
-	fast_io::timer tm(u8"fast_io::deque");
+	fast_io::timer tm(u8"fast_io::deque reverse");
 	fast_io::deque<std::size_t> deq;
 	constexpr std::size_t n{100000000};
 	{
@@ -16,8 +16,8 @@ int main()
 	}
 	::std::size_t sum{};
 	{
-		fast_io::timer tm1(u8"loop");
-		for (auto const e : deq)
+		fast_io::timer tm1(u8"loop reverse");
+		for (auto const e : ::std::ranges::reverse_view(deq))
 		{
 			sum += e;
 		}

--- a/fuzzing/0007.containers/deque/fuzz_deque_erase.cc
+++ b/fuzzing/0007.containers/deque/fuzz_deque_erase.cc
@@ -1,0 +1,130 @@
+// deque_erase_fuzz.cc
+#include <cstddef>
+#include <cstdint>
+#include <deque>
+#include <vector>
+
+#include <source_location>
+#include <fast_io.h>
+#include <fast_io_dsal/deque.h>
+
+using T = std::size_t;
+
+// Check equality between fast_io::deque and std::deque
+static void check_equal(::fast_io::deque<T> const& dq,
+                        ::std::deque<T> const& ref)
+{
+    if (dq.size() != ref.size())
+    {
+        __builtin_trap(); // mismatch: size
+    }
+
+    for (std::size_t i{}; i != dq.size(); ++i)
+    {
+        if (dq[i] != ref[i])
+        {
+            __builtin_trap(); // mismatch: value
+        }
+    }
+}
+
+// Map a byte to an operation kind
+enum class OpKind : uint8_t
+{
+    PushBack       = 0,
+    PushFront      = 1,
+    EraseIndex     = 2,
+    EraseRangeIter = 3,
+    // you can add more later
+};
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, std::size_t size)
+{
+    ::fast_io::deque<T> dq;
+    ::std::deque<T> ref;
+
+    // We interpret the input as a stream of small commands.
+    // Each command may consume 1~3 bytes depending on the op.
+    std::size_t i = 0;
+    while (i < size)
+    {
+        uint8_t op_raw = data[i++] % 4; // we currently have 4 ops
+        OpKind op = static_cast<OpKind>(op_raw);
+
+        switch (op)
+        {
+        case OpKind::PushBack:
+        {
+            if (i >= size) break;
+            // use the next byte as low bits of the value
+            T v = static_cast<T>(data[i++]);
+            dq.push_back(v);
+            ref.push_back(v);
+            break;
+        }
+        case OpKind::PushFront:
+        {
+            if (i >= size) break;
+            T v = static_cast<T>(data[i++]);
+            dq.push_front(v);
+            ref.push_front(v);
+            break;
+        }
+        case OpKind::EraseIndex:
+        {
+            if (dq.empty())
+                break;
+
+            if (i >= size) break;
+            std::size_t pos = static_cast<std::size_t>(data[i++]);
+            if (!dq.empty())
+            {
+                pos %= dq.size();
+
+                dq.erase_index(pos);
+                ref.erase(ref.begin() + static_cast<std::ptrdiff_t>(pos));
+            }
+            break;
+        }
+        case OpKind::EraseRangeIter:
+        {
+            if (dq.empty())
+                break;
+
+            if (i + 1 > size) // need at least 1 byte
+                break;
+
+            std::size_t n = dq.size();
+            if (n == 0)
+                break;
+
+            // choose two indices from bytes
+            std::size_t a = static_cast<std::size_t>(data[i++]) % n;
+            std::size_t b = static_cast<std::size_t>(data[i++ % size]) % (n + 1);
+
+            std::size_t first_idx = (a < b ? a : b);
+            std::size_t last_idx  = (a < b ? b : a);
+
+            if (last_idx > n) last_idx = n;
+            if (first_idx > last_idx) first_idx = last_idx;
+            if (first_idx == last_idx)
+                break; // empty range, skip
+
+            auto dq_first  = dq.begin() + static_cast<std::ptrdiff_t>(first_idx);
+            auto dq_last   = dq.begin() + static_cast<std::ptrdiff_t>(last_idx);
+            auto ref_first = ref.begin() + static_cast<std::ptrdiff_t>(first_idx);
+            auto ref_last  = ref.begin() + static_cast<std::ptrdiff_t>(last_idx);
+
+            dq.erase(dq_first, dq_last);
+            ref.erase(ref_first, ref_last);
+            break;
+        }
+        }
+
+        // After each operation, verify dq == ref
+        check_equal(dq, ref);
+    }
+
+    return 0;
+}
+

--- a/fuzzing/0007.containers/deque/fuzz_deque_erase.cc
+++ b/fuzzing/0007.containers/deque/fuzz_deque_erase.cc
@@ -11,120 +11,143 @@
 using T = std::size_t;
 
 // Check equality between fast_io::deque and std::deque
-static void check_equal(::fast_io::deque<T> const& dq,
-                        ::std::deque<T> const& ref)
+static void check_equal(::fast_io::deque<T> const &dq,
+						::std::deque<T> const &ref)
 {
-    if (dq.size() != ref.size())
-    {
-        __builtin_trap(); // mismatch: size
-    }
+	if (dq.size() != ref.size())
+	{
+		__builtin_trap(); // mismatch: size
+	}
 
-    for (std::size_t i{}; i != dq.size(); ++i)
-    {
-        if (dq[i] != ref[i])
-        {
-            __builtin_trap(); // mismatch: value
-        }
-    }
+	for (std::size_t i{}; i != dq.size(); ++i)
+	{
+		if (dq[i] != ref[i])
+		{
+			__builtin_trap(); // mismatch: value
+		}
+	}
 }
 
 // Map a byte to an operation kind
 enum class OpKind : uint8_t
 {
-    PushBack       = 0,
-    PushFront      = 1,
-    EraseIndex     = 2,
-    EraseRangeIter = 3,
-    // you can add more later
+	PushBack = 0,
+	PushFront = 1,
+	EraseIndex = 2,
+	EraseRangeIter = 3,
+	// you can add more later
 };
 
-extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, std::size_t size)
+extern "C" int LLVMFuzzerTestOneInput(uint8_t const *data, std::size_t size)
 {
-    ::fast_io::deque<T> dq;
-    ::std::deque<T> ref;
+	::fast_io::deque<T> dq;
+	::std::deque<T> ref;
 
-    // We interpret the input as a stream of small commands.
-    // Each command may consume 1~3 bytes depending on the op.
-    std::size_t i = 0;
-    while (i < size)
-    {
-        uint8_t op_raw = data[i++] % 4; // we currently have 4 ops
-        OpKind op = static_cast<OpKind>(op_raw);
+	// We interpret the input as a stream of small commands.
+	// Each command may consume 1~3 bytes depending on the op.
+	std::size_t i = 0;
+	while (i < size)
+	{
+		uint8_t op_raw = data[i++] % 4; // we currently have 4 ops
+		OpKind op = static_cast<OpKind>(op_raw);
 
-        switch (op)
-        {
-        case OpKind::PushBack:
-        {
-            if (i >= size) break;
-            // use the next byte as low bits of the value
-            T v = static_cast<T>(data[i++]);
-            dq.push_back(v);
-            ref.push_back(v);
-            break;
-        }
-        case OpKind::PushFront:
-        {
-            if (i >= size) break;
-            T v = static_cast<T>(data[i++]);
-            dq.push_front(v);
-            ref.push_front(v);
-            break;
-        }
-        case OpKind::EraseIndex:
-        {
-            if (dq.empty())
-                break;
+		switch (op)
+		{
+		case OpKind::PushBack:
+		{
+			if (i >= size)
+			{
+				break;
+			}
+			// use the next byte as low bits of the value
+			T v = static_cast<T>(data[i++]);
+			dq.push_back(v);
+			ref.push_back(v);
+			break;
+		}
+		case OpKind::PushFront:
+		{
+			if (i >= size)
+			{
+				break;
+			}
+			T v = static_cast<T>(data[i++]);
+			dq.push_front(v);
+			ref.push_front(v);
+			break;
+		}
+		case OpKind::EraseIndex:
+		{
+			if (dq.empty())
+			{
+				break;
+			}
 
-            if (i >= size) break;
-            std::size_t pos = static_cast<std::size_t>(data[i++]);
-            if (!dq.empty())
-            {
-                pos %= dq.size();
+			if (i >= size)
+			{
+				break;
+			}
+			std::size_t pos = static_cast<std::size_t>(data[i++]);
+			if (!dq.empty())
+			{
+				pos %= dq.size();
+				dq.erase_index(pos);
+				ref.erase(ref.begin() + static_cast<std::ptrdiff_t>(pos));
+			}
+			break;
+		}
+		case OpKind::EraseRangeIter:
+		{
+			if (dq.empty())
+			{
+				break;
+			}
 
-                dq.erase_index(pos);
-                ref.erase(ref.begin() + static_cast<std::ptrdiff_t>(pos));
-            }
-            break;
-        }
-        case OpKind::EraseRangeIter:
-        {
-            if (dq.empty())
-                break;
+			if (i + 1 > size) // need at least 1 byte
+			{
+				break;
+			}
 
-            if (i + 1 > size) // need at least 1 byte
-                break;
+			std::size_t n = dq.size();
+			if (n == 0)
+			{
+				break;
+			}
 
-            std::size_t n = dq.size();
-            if (n == 0)
-                break;
+			// choose two indices from bytes
+			std::size_t a = static_cast<std::size_t>(data[i++]) % n;
+			std::size_t b = static_cast<std::size_t>(data[i++ % size]) % (n + 1);
 
-            // choose two indices from bytes
-            std::size_t a = static_cast<std::size_t>(data[i++]) % n;
-            std::size_t b = static_cast<std::size_t>(data[i++ % size]) % (n + 1);
+			std::size_t first_idx = (a < b ? a : b);
+			std::size_t last_idx = (a < b ? b : a);
 
-            std::size_t first_idx = (a < b ? a : b);
-            std::size_t last_idx  = (a < b ? b : a);
+			if (last_idx > n)
+			{
+				last_idx = n;
+			}
+			if (first_idx > last_idx)
+			{
+				first_idx = last_idx;
+			}
+			if (first_idx == last_idx)
+			{
+				break; // empty range, skip
+			}
 
-            if (last_idx > n) last_idx = n;
-            if (first_idx > last_idx) first_idx = last_idx;
-            if (first_idx == last_idx)
-                break; // empty range, skip
+			auto dq_first = dq.begin() + static_cast<std::ptrdiff_t>(first_idx);
+			auto dq_last = dq.begin() + static_cast<std::ptrdiff_t>(last_idx);
+			auto ref_first = ref.begin() + static_cast<std::ptrdiff_t>(first_idx);
+			auto ref_last = ref.begin() + static_cast<std::ptrdiff_t>(last_idx);
 
-            auto dq_first  = dq.begin() + static_cast<std::ptrdiff_t>(first_idx);
-            auto dq_last   = dq.begin() + static_cast<std::ptrdiff_t>(last_idx);
-            auto ref_first = ref.begin() + static_cast<std::ptrdiff_t>(first_idx);
-            auto ref_last  = ref.begin() + static_cast<std::ptrdiff_t>(last_idx);
+			dq.erase(dq_first, dq_last);
+			ref.erase(ref_first, ref_last);
+			break;
+		}
+		}
 
-            dq.erase(dq_first, dq_last);
-            ref.erase(ref_first, ref_last);
-            break;
-        }
-        }
+		// After each operation, verify dq == ref
+		check_equal(dq, ref);
+	}
 
-        // After each operation, verify dq == ref
-        check_equal(dq, ref);
-    }
-
-    return 0;
+	return 0;
 }
-

--- a/include/fast_io_core_impl/integers/impl.h
+++ b/include/fast_io_core_impl/integers/impl.h
@@ -618,6 +618,15 @@ inline constexpr auto pointervw(scalar_type t) noexcept
 }
 
 template <bool uppercase = false, typename scalar_type>
+	requires((::std::is_pointer_v<scalar_type> || ::std::contiguous_iterator<scalar_type>) &&
+			 (!::std::is_function_v<::std::remove_cvref_t<scalar_type>>))
+inline constexpr auto itervw(scalar_type t) noexcept
+{
+	return ::fast_io::details::scalar_flags_int_cache<
+		::fast_io::details::base_mani_flags_cache<16, uppercase, true, true, false>>(t);
+}
+
+template <bool uppercase = false, typename scalar_type>
 	requires(::std::is_function_v<scalar_type>)
 inline constexpr auto funcvw(scalar_type *t) noexcept
 {

--- a/include/fast_io_dsal/impl/deque.h
+++ b/include/fast_io_dsal/impl/deque.h
@@ -1693,19 +1693,6 @@ public:
 	}
 
 private:
-	inline constexpr ::fast_io::containers::details::deque_control_block<value_type> end_common() noexcept
-	{
-		::fast_io::containers::details::deque_control_block<value_type> backblock{this->controller.back_block};
-		if (backblock.curr_ptr == this->controller.back_end_ptr) [[unlikely]]
-		{
-			if (backblock.controller_ptr) [[likely]]
-			{
-				backblock.curr_ptr = backblock.begin_ptr = (*++backblock.controller_ptr);
-			}
-		}
-		return {backblock};
-	}
-
 	inline constexpr ::fast_io::containers::details::deque_control_block<value_type> end_common() const noexcept
 	{
 		::fast_io::containers::details::deque_control_block<value_type> backblock{this->controller.back_block};

--- a/include/fast_io_dsal/impl/deque.h
+++ b/include/fast_io_dsal/impl/deque.h
@@ -1850,6 +1850,23 @@ public:
 	}
 #endif
 
+#if 0
+	inline constexpr iterator erase(const_iterator from, const_iterator to) noexcept
+	{
+
+	}
+
+	inline constexpr size_type erase_index(size_type fromidx, size_type toidx) noexcept
+	{
+		size_type const n{this->size()};
+		if (n < fromidx || n < todix) [[unlikely]]
+		{
+			::fast_io::fast_terminate();
+		}
+		return fromidx;
+	}
+#endif
+
 	inline constexpr ~deque()
 	{
 		destroy_deque_controller(this->controller);

--- a/include/fast_io_dsal/impl/freestanding.h
+++ b/include/fast_io_dsal/impl/freestanding.h
@@ -8,6 +8,11 @@ concept has_uninitialized_relocate_define = requires(T *ptr) {
 };
 
 template <typename T>
+concept has_uninitialized_relocate_backward_define = requires(T *ptr) {
+	{ uninitialized_relocate_backward_define(ptr, ptr, ptr) } -> ::std::same_as<T *>;
+};
+
+template <typename T>
 concept has_uninitialized_move_define = requires(T *ptr) {
 	{ uninitialized_move_define(ptr, ptr, ptr) } -> ::std::same_as<T *>;
 };
@@ -72,7 +77,7 @@ inline constexpr Iter2 uninitialized_relocate(Iter1 first, Iter1 last, Iter2 des
 		// we do not allow move constructor to throw EH.
 		while (first != last)
 		{
-			::std::construct_at(dest, ::std::move(*first));
+			::std::construct_at(::std::addressof(*dest), ::std::move(*first));
 			if constexpr (!::std::is_trivially_destructible_v<iter1valuetype>)
 			{
 				if constexpr (::std::is_pointer_v<Iter1>)
@@ -87,6 +92,108 @@ inline constexpr Iter2 uninitialized_relocate(Iter1 first, Iter1 last, Iter2 des
 			++first;
 			++dest;
 		}
+		return dest;
+	}
+}
+
+template <::std::bidirectional_iterator Iter1, ::std::bidirectional_iterator Iter2>
+inline constexpr Iter2 uninitialized_relocate_backward(Iter1 first, Iter1 last, Iter2 dest) noexcept
+{
+	// Semantics:
+	//   Relocate the range [first, last) into the uninitialized memory ending at `dest`.
+	//   `dest` is treated as the end iterator (one past the last element) of the destination range.
+	//   The function returns the begin iterator of the destination range:
+	//       dest - (last - first)
+
+	if constexpr (::std::contiguous_iterator<Iter1> && !::std::is_pointer_v<Iter1> &&
+				  ::std::contiguous_iterator<Iter2> && !::std::is_pointer_v<Iter2>)
+	{
+		return uninitialized_relocate_backward(::std::to_address(first),
+											   ::std::to_address(last),
+											   ::std::to_address(dest)) -
+			   ::std::to_address(dest) + dest;
+	}
+	else if constexpr (::std::contiguous_iterator<Iter1> && !::std::is_pointer_v<Iter1>)
+	{
+		return uninitialized_relocate_backward(::std::to_address(first),
+											   ::std::to_address(last),
+											   dest);
+	}
+	else if constexpr (::std::contiguous_iterator<Iter2> && !::std::is_pointer_v<Iter2>)
+	{
+		return uninitialized_relocate_backward(first,
+											   last,
+											   ::std::to_address(dest)) -
+			   ::std::to_address(dest) + dest;
+	}
+	else
+	{
+		using iter1valuetype = ::std::iter_value_t<Iter1>;
+		using iter2valuetype = ::std::iter_value_t<Iter2>;
+
+		// Fast path: trivial relocation via byte copy
+		if constexpr (::std::is_pointer_v<Iter1> && ::std::is_pointer_v<Iter2> &&
+					  (::fast_io::freestanding::is_trivially_copyable_or_relocatable_v<iter1valuetype> &&
+					   ::fast_io::freestanding::is_trivially_copyable_or_relocatable_v<iter2valuetype> &&
+					   (::std::same_as<iter1valuetype, iter2valuetype> ||
+						((::std::integral<iter1valuetype> || ::std::same_as<iter1valuetype, ::std::byte>) &&
+						 (::std::integral<iter2valuetype> || ::std::same_as<iter2valuetype, ::std::byte>) &&
+						 sizeof(iter1valuetype) == sizeof(iter2valuetype)))))
+		{
+#if __cpp_if_consteval >= 202106L
+			if !consteval
+#else
+			if (!__builtin_is_constant_evaluated())
+#endif
+			{
+				auto const firstbyteptr{reinterpret_cast<::std::byte const *>(first)};
+				auto const lastbyteptr{reinterpret_cast<::std::byte const *>(last)};
+				auto const n{lastbyteptr - firstbyteptr};
+
+				// Compute the beginning of the destination range
+				auto const destfirst{reinterpret_cast<::std::byte *>(dest) - n};
+
+				// Perform the raw byte copy
+				::fast_io::freestanding::bytes_copy(firstbyteptr,
+													lastbyteptr,
+													destfirst);
+
+				return reinterpret_cast<Iter2>(destfirst);
+			}
+		}
+		// Custom relocate_backward hook for user-defined types
+		else if constexpr (::std::same_as<iter1valuetype, iter2valuetype> &&
+						   ::fast_io::operations::defines::has_uninitialized_relocate_define<iter1valuetype>)
+		{
+			return uninitialized_relocate_define_backward(first, last, dest);
+		}
+
+		// Generic slow path:
+		//   Move-construct elements in reverse order into uninitialized memory,
+		//   then destroy the original elements.
+		while (first != last)
+		{
+			--last;
+			--dest;
+#if 0
+			__builtin_fprintf(stderr, "%s %d\n", __FILE__, __LINE__);
+#endif
+			::std::construct_at(::std::addressof(*dest), ::std::move(*last));
+
+			if constexpr (!::std::is_trivially_destructible_v<iter1valuetype>)
+			{
+				if constexpr (::std::is_pointer_v<Iter1>)
+				{
+					::std::destroy_at(last);
+				}
+				else
+				{
+					::std::destroy_at(__builtin_addressof(*last));
+				}
+			}
+		}
+
+		// Return the begin iterator of the relocated range
 		return dest;
 	}
 }
@@ -138,7 +245,7 @@ inline constexpr Iter2 uninitialized_move(Iter1 first, Iter1 last, Iter2 dest) n
 		// we do not allow move constructor to throw EH.
 		while (first != last)
 		{
-			::std::construct_at(dest, ::std::move(*first));
+			::std::construct_at(::std::addressof(*dest), ::std::move(*first));
 			++first;
 			++dest;
 		}

--- a/include/fast_io_dsal/impl/freestanding.h
+++ b/include/fast_io_dsal/impl/freestanding.h
@@ -78,6 +78,7 @@ inline constexpr Iter2 uninitialized_relocate(Iter1 first, Iter1 last, Iter2 des
 		while (first != last)
 		{
 			::std::construct_at(::std::addressof(*dest), ::std::move(*first));
+
 			if constexpr (!::std::is_trivially_destructible_v<iter1valuetype>)
 			{
 				if constexpr (::std::is_pointer_v<Iter1>)
@@ -175,9 +176,6 @@ inline constexpr Iter2 uninitialized_relocate_backward(Iter1 first, Iter1 last, 
 		{
 			--last;
 			--dest;
-#if 0
-			__builtin_fprintf(stderr, "%s %d\n", __FILE__, __LINE__);
-#endif
 			::std::construct_at(::std::addressof(*dest), ::std::move(*last));
 
 			if constexpr (!::std::is_trivially_destructible_v<iter1valuetype>)

--- a/include/fast_io_dsal/impl/misc/push_macros.h
+++ b/include/fast_io_dsal/impl/misc/push_macros.h
@@ -218,6 +218,7 @@ Internal assert macros for fuzzing fast_io.
 #endif
 
 #pragma push_macro("FAST_IO_TRIVIALLY_RELOCATABLE_IF_ELIGIBLE")
+#if 0
 #if defined(__cpp_trivial_relocatability)
 #undef FAST_IO_TRIVIALLY_RELOCATABLE_IF_ELIGIBLE
 #if defined(__clang__)
@@ -227,6 +228,10 @@ Internal assert macros for fuzzing fast_io.
 #define FAST_IO_TRIVIALLY_RELOCATABLE_IF_ELIGIBLE trivially_relocatable_if_eligible
 #endif // ^^^ !defined(__clang__)
 #else
+#define FAST_IO_TRIVIALLY_RELOCATABLE_IF_ELIGIBLE
+#endif
+#else
+#undef FAST_IO_TRIVIALLY_RELOCATABLE_IF_ELIGIBLE
 #define FAST_IO_TRIVIALLY_RELOCATABLE_IF_ELIGIBLE
 #endif
 

--- a/include/fast_io_dsal/impl/string.h
+++ b/include/fast_io_dsal/impl/string.h
@@ -524,7 +524,7 @@ public:
 		this->assign_impl(other.imp.begin_ptr, static_cast<::std::size_t>(other.imp.curr_ptr - other.imp.begin_ptr));
 		return *this;
 	}
-	inline constexpr basic_string& operator=(string_view_type const &other) noexcept
+	inline constexpr basic_string &operator=(string_view_type const &other) noexcept
 	{
 		this->assign(other);
 		return *this;
@@ -888,7 +888,7 @@ public:
 			return this->erase_impl(const_cast<pointer>(first), const_cast<pointer>(last));
 		}
 	}
-	inline constexpr void erase_index(size_type firstidx, size_type lastidx) noexcept
+	inline constexpr size_type erase_index(size_type firstidx, size_type lastidx) noexcept
 	{
 		auto beginptr{this->imp.begin_ptr};
 		auto currptr{this->imp.curr_ptr};
@@ -898,6 +898,7 @@ public:
 			::fast_io::fast_terminate();
 		}
 		this->erase_impl(beginptr + firstidx, beginptr + lastidx);
+		return firstidx;
 	}
 	inline constexpr iterator erase(const_iterator it) noexcept
 	{
@@ -911,7 +912,7 @@ public:
 			return this->erase_impl(const_cast<pointer>(it));
 		}
 	}
-	inline constexpr void erase_index(size_type idx) noexcept
+	inline constexpr size_type erase_index(size_type idx) noexcept
 	{
 		auto beginptr{this->imp.begin_ptr};
 		auto currptr{this->imp.curr_ptr};
@@ -921,6 +922,7 @@ public:
 			::fast_io::fast_terminate();
 		}
 		this->erase_impl(beginptr + idx);
+		return idx;
 	}
 	inline constexpr void swap(basic_string &other) noexcept
 	{

--- a/include/fast_io_dsal/impl/vector.h
+++ b/include/fast_io_dsal/impl/vector.h
@@ -1011,7 +1011,7 @@ public:
 		}
 	}
 
-	inline constexpr void erase_index(size_type idx) noexcept
+	inline constexpr size_type erase_index(size_type idx) noexcept
 	{
 		auto beginptr{imp.begin_ptr};
 		auto currptr{imp.curr_ptr};
@@ -1021,6 +1021,7 @@ public:
 			::fast_io::fast_terminate();
 		}
 		this->erase_common(beginptr + idx);
+		return idx;
 	}
 
 	inline constexpr iterator erase(const_iterator first, const_iterator last) noexcept
@@ -1035,7 +1036,7 @@ public:
 		}
 	}
 
-	inline constexpr void erase_index(size_type firstidx, size_type lastidx) noexcept
+	inline constexpr size_type erase_index(size_type firstidx, size_type lastidx) noexcept
 	{
 		auto beginptr{imp.begin_ptr};
 		auto currptr{imp.curr_ptr};
@@ -1045,6 +1046,7 @@ public:
 			::fast_io::fast_terminate();
 		}
 		this->erase_iters_common(beginptr + firstidx, beginptr + lastidx);
+		return firstidx;
 	}
 
 	inline constexpr void resize(size_type n) noexcept(::std::is_nothrow_default_constructible_v<value_type>)

--- a/tests/0026.container/0003.deque/erase.cc
+++ b/tests/0026.container/0003.deque/erase.cc
@@ -1,0 +1,316 @@
+#include <fast_io.h>
+#include <fast_io_dsal/deque.h>
+#include <deque>
+#include <vector>
+
+namespace
+{
+
+inline void test_erase()
+{
+	::fast_io::io::perr("=== deque erase test ===\n");
+
+	using T = ::std::size_t;
+	::fast_io::deque<T> dq;
+	::std::deque<T> ref;
+
+	// Fill initial data
+	for (::std::size_t i{}; i != 200u; ++i)
+	{
+		dq.push_back(i);
+		ref.push_back(i);
+	}
+
+	// Helper to compare dq and ref
+	auto check_equal = [&](auto const &msg,
+						   ::std::source_location src = ::std::source_location::current()) {
+		if (dq.size() != ref.size())
+		{
+			::fast_io::io::panicln(src, "\tERROR: size mismatch: ", msg);
+		}
+		for (::std::size_t i{}; i != dq.size(); ++i)
+		{
+			if (dq[i] != ref[i])
+			{
+				::fast_io::io::panicln(src,
+									   "\tERROR: value mismatch at index ",
+									   i,
+									   "\tdq[i]=",
+									   dq[i],
+									   "\tref[i]=",
+									   ref[i],
+									   " : ",
+									   msg);
+			}
+		}
+	};
+
+	// 1. Erase single element at front
+	{
+		dq.erase(dq.begin());
+		ref.erase(ref.begin());
+		check_equal("erase single at front");
+	}
+
+	// 2. Erase single element in the middle
+	{
+		if (!dq.empty())
+		{
+			::std::size_t pos{dq.size() / 2};
+			dq.erase(dq.begin() + pos);
+			ref.erase(ref.begin() + pos);
+			check_equal("erase single in middle");
+		}
+	}
+
+	// 3. Erase single element at back (last element)
+	{
+		if (!dq.empty())
+		{
+			::std::size_t pos{dq.size() - 1};
+			dq.erase(dq.begin() + pos);
+			ref.erase(ref.begin() + pos);
+			check_equal("erase single at back");
+		}
+	}
+
+	// 4. Erase a range at the front
+	{
+		if (dq.size() >= 10u)
+		{
+			dq.erase(dq.begin(), dq.begin() + 10);
+			ref.erase(ref.begin(), ref.begin() + 10);
+			check_equal("erase range at front");
+		}
+	}
+
+	// 5. Erase a range in the middle
+	{
+		if (dq.size() >= 30u)
+		{
+			::std::size_t start{dq.size() / 3};
+			::std::size_t len{20u};
+			if (start + len > dq.size())
+			{
+				len = dq.size() - start;
+			}
+
+			dq.erase(dq.begin() + start, dq.begin() + start + len);
+			ref.erase(ref.begin() + start, ref.begin() + start + len);
+			check_equal("erase range in middle");
+		}
+	}
+
+	// 6. Erase a range at the back
+	{
+		if (dq.size() >= 15u)
+		{
+			::std::size_t len{15u};
+			::std::size_t start{dq.size() - len};
+
+			dq.erase(dq.begin() + start, dq.end());
+			ref.erase(ref.begin() + start, ref.end());
+			check_equal("erase range at back");
+		}
+	}
+
+	// 7. Randomized erases: erase random ranges until we have done enough iterations
+	for (::std::size_t iter{}; iter != 200u; ++iter)
+	{
+		if (dq.empty())
+		{
+			break;
+		}
+
+		::std::size_t current_size{dq.size()};
+		::std::size_t pos{iter % current_size};
+
+		// Choose a small length depending on iter, clamped to the remaining size
+		::std::size_t max_len{5u};
+		::std::size_t len{(iter * 7u) % max_len + 1u};
+		if (pos + len > current_size)
+		{
+			len = current_size - pos;
+		}
+
+		auto dq_first = dq.begin() + pos;
+		auto dq_last = dq.begin() + pos + len;
+
+		auto ref_first = ref.begin() + pos;
+		auto ref_last = ref.begin() + pos + len;
+
+		dq.erase(dq_first, dq_last);
+		ref.erase(ref_first, ref_last);
+
+		check_equal("randomized erase");
+	}
+
+	::fast_io::io::print("deque erase test finished\n");
+}
+
+inline void test_erase_index()
+{
+	::fast_io::io::perr("=== deque erase_index test ===\n");
+
+	using T = ::std::size_t;
+	::fast_io::deque<T> dq;
+	::std::deque<T> ref;
+
+	// Fill initial data
+	for (::std::size_t i{}; i != 200u; ++i)
+	{
+		dq.push_back(i);
+		ref.push_back(i);
+	}
+
+	// Helper to compare dq and ref
+	auto check_equal = [&](auto const &msg,
+						   ::std::source_location src = ::std::source_location::current()) {
+		if (dq.size() != ref.size())
+		{
+			::fast_io::io::panicln(src, "\tERROR: size mismatch: ", msg);
+		}
+		for (::std::size_t i{}; i != dq.size(); ++i)
+		{
+			if (dq[i] != ref[i])
+			{
+				::fast_io::io::panicln(src,
+									   "\tERROR: value mismatch at index ",
+									   i,
+									   "\tdq[i]=", dq[i],
+									   "\tref[i]=", ref[i],
+									   " : ", msg);
+			}
+		}
+	};
+
+	//
+	// === 1. Single‑index erase ===
+	//
+
+	// Erase at front
+	{
+		dq.erase_index(0);
+		ref.erase(ref.begin());
+		check_equal("erase_index(pos) front");
+	}
+
+	// Erase in middle
+	{
+		if (!dq.empty())
+		{
+			::std::size_t pos{dq.size() / 2};
+			dq.erase_index(pos);
+			ref.erase(ref.begin() + pos);
+			check_equal("erase_index(pos) middle");
+		}
+	}
+
+	// Erase at back
+	{
+		if (!dq.empty())
+		{
+			::std::size_t pos{dq.size() - 1};
+			dq.erase_index(pos);
+			ref.erase(ref.begin() + pos);
+			check_equal("erase_index(pos) back");
+		}
+	}
+
+	//
+	// === 2. Range erase ===
+	//
+
+	// Erase range at front
+	{
+		if (dq.size() >= 10u)
+		{
+			dq.erase_index(0, 10);
+			ref.erase(ref.begin(), ref.begin() + 10);
+			check_equal("erase_index(first,last) front");
+		}
+	}
+
+	// Erase range in middle
+	{
+		if (dq.size() >= 30u)
+		{
+			::std::size_t start{dq.size() / 3};
+			::std::size_t len{20u};
+			if (start + len > dq.size())
+			{
+				len = dq.size() - start;
+			}
+
+			dq.erase_index(start, start + len);
+			ref.erase(ref.begin() + start, ref.begin() + start + len);
+			check_equal("erase_index(first,last) middle");
+		}
+	}
+
+	// Erase range at back
+	{
+		if (dq.size() >= 15u)
+		{
+			::std::size_t len{15u};
+			::std::size_t start{dq.size() - len};
+
+			dq.erase_index(start, dq.size());
+			ref.erase(ref.begin() + start, ref.end());
+			check_equal("erase_index(first,last) back");
+		}
+	}
+
+	//
+	// === 3. Randomized single‑index erase ===
+	//
+	for (::std::size_t iter{}; iter != 200u; ++iter)
+	{
+		if (dq.empty())
+		{
+			break;
+		}
+
+		::std::size_t pos = iter % dq.size();
+
+		dq.erase_index(pos);
+		ref.erase(ref.begin() + pos);
+
+		check_equal("randomized erase_index(pos)");
+	}
+
+	//
+	// === 4. Randomized range erase ===
+	//
+	for (::std::size_t iter{}; iter != 200u; ++iter)
+	{
+		if (dq.empty())
+		{
+			break;
+		}
+
+		::std::size_t n = dq.size();
+		::std::size_t first = (iter * 7) % n;
+		::std::size_t last = first + (iter % 5 + 1);
+
+		if (last > n)
+		{
+			last = n;
+		}
+
+		dq.erase_index(first, last);
+		ref.erase(ref.begin() + first, ref.begin() + last);
+
+		check_equal("randomized erase_index(first,last)");
+	}
+
+	::fast_io::io::print("deque erase_index test finished\n");
+}
+
+} // namespace
+
+int main()
+{
+	test_erase();
+	test_erase_index();
+}


### PR DESCRIPTION
Also disable trivially_relocatable keywords thing here since clang fails to understand the keyword. guess standard chooses to remove it?