### PR TITLE
crt uses full name ::fast_io::details::crt_iobuf for crt_iobuf

### DIFF
--- a/benchmark/0011.containers/deque/0001.push_back/fast_io_reverse.cc
+++ b/benchmark/0011.containers/deque/0001.push_back/fast_io_reverse.cc
@@ -23,5 +23,5 @@ int main()
 			sum += e;
 		}
 	}
-	::fast_io::io::perrln("sum=",sum);
+	::fast_io::io::perrln("sum=", sum);
 }

--- a/include/fast_io_dsal/impl/deque.h
+++ b/include/fast_io_dsal/impl/deque.h
@@ -1230,12 +1230,12 @@ deque_erase_common_trivial_impl(::fast_io::containers::details::deque_controller
 	return first;
 }
 
-#if 0
+#if 1
 
 template <typename allocator, typename dequecontroltype>
 inline constexpr void deque_rebalance_or_grow_insertation_impl(dequecontroltype &controller, ::std::size_t extrablocks) noexcept
 {
-//ignore overchecked first
+	// ignore overchecked first
 	auto const used_blocks_count{
 		static_cast<::std::size_t>(controller.back_block.controller_ptr - controller.front_block.controller_ptr) + 1zu};
 	auto const total_slots_count{
@@ -1243,14 +1243,13 @@ inline constexpr void deque_rebalance_or_grow_insertation_impl(dequecontroltype 
 	auto const half_slots_count{static_cast<::std::size_t>(total_slots_count >> 1u)};
 #if defined(__GNUC__) || defined(__clang__)
 	::std::size_t new_used_blocks_count;
-	if(__builtin_add_overflow(used_blocks_count, extrablocks,__builtin_addressof(new_used_blocks_count))) [[unlikely]]
+	if (__builtin_add_overflow(used_blocks_count, extrablocks, __builtin_addressof(new_used_blocks_count))) [[unlikely]]
 	{
 		::fast_io::fast_terminate();
 	}
 #else
-	constexpr
-		::std::size_t mx{::std::numeric_limits<::std::size_t>::max()};
-	::std::size_t const mx_sub_extrablocks{mx-extrablocks};
+	constexpr ::std::size_t mx{::std::numeric_limits<::std::size_t>::max()};
+	::std::size_t const mx_sub_extrablocks{mx - extrablocks};
 	if (mx_sub_extrablocks < used_blocks_count)
 	{
 		::fast_io::fast_terminate();
@@ -1272,19 +1271,18 @@ inline constexpr void deque_rebalance_or_grow_insertation_impl(dequecontroltype 
 			::fast_io::fast_terminate();
 		}
 #else
-		::std::size_t mx_total_slots{mx-extrablocks};
-		if(mx_total_slots < total_slots_count)
+		::std::size_t mx_total_slots{mx - extrablocks};
+		if (mx_total_slots < total_slots_count)
 		{
 			::fast_io::fast_terminate();
 		}
 		::std::size_t doubleslotsextra{extrablocks + total_slots_count};
-		constexpr
-			::std::size_t mxdv2m1{(mx >> 1u)};
+		constexpr ::std::size_t mxdv2m1{(mx >> 1u)};
 		if (mxdv2m1 < doubleslotsextra)
 		{
 			::fast_io::fast_terminate();
 		}
-		doubleslotsextra<<=1u;
+		doubleslotsextra <<= 1u;
 #endif
 
 		::fast_io::containers::details::deque_grow_to_new_blocks_count_impl<allocator>(controller, doubleslotsextra);
@@ -1357,8 +1355,7 @@ inline constexpr void deque_reserve_back_blocks_impl(dequecontroltype &controlle
 	{
 		std::size_t distance_back_to_reserve{
 			static_cast<std::size_t>(controller.controller_block.controller_after_reserved_ptr -
-				controller.back_block.controller_ptr)
-		};
+									 controller.back_block.controller_ptr)};
 		if (distance_back_to_reserve < nb)
 		{
 			::fast_io::containers::details::deque_rebalance_or_grow_insertation_impl<allocator>(controller, nb);
@@ -1370,8 +1367,7 @@ inline constexpr void deque_reserve_back_blocks_impl(dequecontroltype &controlle
 		if (diff_to_after_ptr2 <= nb)
 		{
 			::std::size_t front_reserved_blocks{
-				static_cast<::std::size_t>(controller.front_block.controller_ptr - controller.controller_block.controller_start_reserved_ptr)
-			};
+				static_cast<::std::size_t>(controller.front_block.controller_ptr - controller.controller_block.controller_start_reserved_ptr)};
 
 			::std::size_t front_borrowed_blocks_count{front_reserved_blocks};
 			::std::size_t to_allocate_blocks{nb};
@@ -1382,25 +1378,23 @@ inline constexpr void deque_reserve_back_blocks_impl(dequecontroltype &controlle
 			}
 			else
 			{
-				to_allocate_blocks-=front_borrowed_blocks_count;
+				to_allocate_blocks -= front_borrowed_blocks_count;
 			}
 
 			auto controller_start_reserved_ptr{
-				controller.controller_block.controller_start_reserved_ptr
-			};
+				controller.controller_block.controller_start_reserved_ptr};
 
 			auto pos{
-				controller.controller_block.controller_after_reserved_ptr
-			};
+				controller.controller_block.controller_after_reserved_ptr};
 			pos = ::fast_io::freestanding::non_overlapped_copy_n(controller_start_reserved_ptr,
-					front_borrowed_blocks_count,
-					pos);
-			controller.controller_block.controller_start_reserved_ptr=
-				controller_start_reserved_ptr+front_borrowed_blocks_count;
-			
-			for(auto e{pos+to_allocate_blocks};pos!=e;++pos)
+																 front_borrowed_blocks_count,
+																 pos);
+			controller.controller_block.controller_start_reserved_ptr =
+				controller_start_reserved_ptr + front_borrowed_blocks_count;
+
+			for (auto e{pos + to_allocate_blocks}; pos != e; ++pos)
 			{
-				::std::construct_at(pos, static_cast<begin_ptrtype>(allocator::allocate_aligned(align, blockbytes)));			
+				::std::construct_at(pos, static_cast<begin_ptrtype>(allocator::allocate_aligned(align, blockbytes)));
 			}
 			*pos = nullptr;
 			controller.controller_block.controller_after_reserved_ptr = pos;
@@ -1416,7 +1410,7 @@ inline constexpr void deque_reserve_back_blocks_impl(dequecontroltype &controlle
 		controller.front_end_ptr = front_begin_ptr + blockbytes;
 	}
 
-	controller.back_block.controller_ptr+=nb;
+	controller.back_block.controller_ptr += nb;
 	auto begin_ptr =
 		static_cast<begin_ptrtype>(*controller.back_block.controller_ptr);
 
@@ -1425,11 +1419,12 @@ inline constexpr void deque_reserve_back_blocks_impl(dequecontroltype &controlle
 	controller.back_end_ptr = begin_ptr + blockbytes;
 }
 
+#if 0
 template <typename allocator, ::std::size_t align, ::std::size_t sz, ::std::size_t block_size, typename dequecontroltype>
 inline constexpr void deque_reserve_back_spaces(dequecontroltype &controller, ::std::size_t n)
 {
-
 }
+#endif
 #endif
 
 } // namespace details

--- a/include/fast_io_legacy_impl/c/wincrt.h
+++ b/include/fast_io_legacy_impl/c/wincrt.h
@@ -120,7 +120,7 @@ CRT heap debugging does not exist on mingw-w64
 
 inline void wincrt_fp_allocate_buffer_impl(FILE *__restrict fpp) noexcept
 {
-	crt_iobuf *fp{reinterpret_cast<crt_iobuf *>(fpp)};
+	::fast_io::details::crt_iobuf *fp{reinterpret_cast<::fast_io::details::crt_iobuf *>(fpp)};
 	if (fp->_bufsiz < 4)
 	{
 		fp->_bufsiz = wincrt_internal_buffer_size;
@@ -145,7 +145,7 @@ inline void wincrt_fp_write_cold_malloc_case_impl(FILE *__restrict fpp, char con
 		return;
 	}
 
-	crt_iobuf *fp{reinterpret_cast<crt_iobuf *>(fpp)};
+	::fast_io::details::crt_iobuf *fp{reinterpret_cast<::fast_io::details::crt_iobuf *>(fpp)};
 
 	::std::size_t allocated_buffer_size{wincrt_internal_buffer_size};
 
@@ -173,7 +173,7 @@ inline void wincrt_fp_write_cold_malloc_case_impl(FILE *__restrict fpp, char con
 inline void wincrt_fp_write_cold_normal_case_impl(FILE *__restrict fpp, char const *__restrict first,
 												  ::std::size_t diff)
 {
-	crt_iobuf *fp{reinterpret_cast<crt_iobuf *>(fpp)};
+	::fast_io::details::crt_iobuf *fp{reinterpret_cast<::fast_io::details::crt_iobuf *>(fpp)};
 	fp->_flag |= crt_dirty_value;
 
 	if (::std::size_t const remain{static_cast<::std::size_t>(static_cast<::std::uint_least32_t>(fp->_cnt))}; diff < remain)
@@ -210,7 +210,7 @@ inline void wincrt_fp_write_cold_normal_case_impl(FILE *__restrict fpp, char con
 inline void wincrt_fp_write_cold_impl(FILE *__restrict fp, char const *first, char const *last)
 {
 	::std::size_t diff{static_cast<::std::size_t>(last - first)};
-	crt_iobuf *fpp{reinterpret_cast<crt_iobuf *>(fp)};
+	::fast_io::details::crt_iobuf *fpp{reinterpret_cast<::fast_io::details::crt_iobuf *>(fp)};
 	if (fpp->_base == nullptr)
 	{
 		if (auto const fd{fpp->_file}; fd == ::fast_io::posix_stderr_number)
@@ -237,7 +237,7 @@ template <::std::integral char_type>
 #endif
 inline void wincrt_fp_overflow_impl(FILE *__restrict fpp, char_type ch)
 {
-	crt_iobuf *fp{reinterpret_cast<crt_iobuf *>(fpp)};
+	::fast_io::details::crt_iobuf *fp{reinterpret_cast<::fast_io::details::crt_iobuf *>(fpp)};
 	if (fp->_base == nullptr)
 	{
 		wincrt_fp_allocate_buffer_impl(fpp);
@@ -259,7 +259,7 @@ inline void wincrt_fp_overflow_impl(FILE *__restrict fpp, char_type ch)
 #endif
 inline void wincrt_fp_flush_stdout_impl()
 {
-	crt_iobuf *fp{reinterpret_cast<crt_iobuf *>(::fast_io::win32::wincrt_acrt_iob_func(1))};
+	::fast_io::details::crt_iobuf *fp{reinterpret_cast<::fast_io::details::crt_iobuf *>(::fast_io::win32::wincrt_acrt_iob_func(1))};
 	if (fp->_ptr == fp->_base) [[unlikely]]
 	{
 		return;
@@ -278,7 +278,7 @@ inline char *wincrt_fp_read_cold_impl(FILE *__restrict fpp, char *first, ::std::
 	{
 		wincrt_fp_flush_stdout_impl();
 	}
-	crt_iobuf *fp{reinterpret_cast<crt_iobuf *>(fpp)};
+	::fast_io::details::crt_iobuf *fp{reinterpret_cast<::fast_io::details::crt_iobuf *>(fpp)};
 	::std::size_t cnt{static_cast<::std::size_t>(static_cast<::std::uint_least32_t>(fp->_cnt))};
 	non_overlapped_copy_n(fp->_ptr, cnt, first);
 	first += cnt;
@@ -332,7 +332,7 @@ inline bool wincrt_fp_underflow_impl(FILE *__restrict fpp)
 	{
 		wincrt_fp_flush_stdout_impl();
 	}
-	crt_iobuf *fp{reinterpret_cast<crt_iobuf *>(fpp)};
+	::fast_io::details::crt_iobuf *fp{reinterpret_cast<::fast_io::details::crt_iobuf *>(fpp)};
 	if (fp->_base == nullptr)
 	{
 		wincrt_fp_allocate_buffer_impl(fpp);
@@ -362,7 +362,7 @@ template <typename T, ::std::size_t num>
 inline T *wincrt_get_buffer_ptr_impl(FILE *__restrict fpp) noexcept
 {
 	static_assert(num < 4);
-	crt_iobuf *fp{reinterpret_cast<crt_iobuf *>(fpp)};
+	::fast_io::details::crt_iobuf *fp{reinterpret_cast<::fast_io::details::crt_iobuf *>(fpp)};
 	if constexpr (num == 0)
 	{
 		return reinterpret_cast<T *>(fp->_base);
@@ -383,7 +383,7 @@ inline void wincrt_set_buffer_curr_ptr_impl(FILE *__restrict fpp,
 #endif
 											void *ptr) noexcept
 {
-	crt_iobuf *fp{reinterpret_cast<crt_iobuf *>(fpp)};
+	::fast_io::details::crt_iobuf *fp{reinterpret_cast<::fast_io::details::crt_iobuf *>(fpp)};
 	fp->_cnt -= static_cast<::std::int_least32_t>(
 		static_cast<::std::uint_least32_t>(static_cast<::std::size_t>(reinterpret_cast<char *>(ptr) - fp->_ptr)));
 	fp->_ptr = reinterpret_cast<char *>(ptr);
@@ -395,12 +395,12 @@ WINE has not correctly implemented this yet. I am submitting patches.
 inline void ucrt_lock_file(FILE *__restrict fp) noexcept
 {
 	char *fp2{reinterpret_cast<char *>(fp)};
-	::fast_io::win32::EnterCriticalSection(fp2 + sizeof(crt_iobuf));
+	::fast_io::win32::EnterCriticalSection(fp2 + sizeof(::fast_io::details::crt_iobuf));
 }
 inline void ucrt_unlock_file(FILE *__restrict fp) noexcept
 {
 	char *fp2{reinterpret_cast<char *>(fp)};
-	::fast_io::win32::LeaveCriticalSection(fp2 + sizeof(crt_iobuf));
+	::fast_io::win32::LeaveCriticalSection(fp2 + sizeof(::fast_io::details::crt_iobuf));
 }
 #endif
 } // namespace details
@@ -487,7 +487,7 @@ template <::std::integral char_type>
 inline ::std::byte *read_some_bytes_underflow_define(::fast_io::basic_c_io_observer_unlocked<char_type> ciob,
 													 ::std::byte *first, ::std::byte *last)
 {
-	return reinterpret_cast<::std::byte *>(::fast_io::details::wincrt_fp_read_cold_impl(ciob.fp, 
+	return reinterpret_cast<::std::byte *>(::fast_io::details::wincrt_fp_read_cold_impl(ciob.fp,
 																						reinterpret_cast<char *>(first),
 																						reinterpret_cast<char *>(last)));
 }


### PR DESCRIPTION
it may reduce some issues with name collision