### PR TITLE
Supporting incomplete type for fast_io::vector

### DIFF
--- a/include/fast_io_dsal/impl/vector.h
+++ b/include/fast_io_dsal/impl/vector.h
@@ -397,8 +397,10 @@ public:
 	}
 
 	inline constexpr vector(vector const &vec)
-		requires(::std::is_copy_constructible_v<value_type>)
 	{
+		// Using static_assert instead of requires to delay the check
+		// related to tests/0026.container/0001.vector/recursive.cc
+		static_assert(::std::is_copy_constructible_v<value_type>, "vector's value type must be copy constructible to use copy constructor");
 		std::size_t const vecsize{static_cast<std::size_t>(vec.imp.curr_ptr - vec.imp.begin_ptr)};
 		if (vecsize == 0)
 		{
@@ -433,10 +435,12 @@ public:
 		}
 		des.thisvec = nullptr;
 	}
-	inline constexpr vector(vector const &vec) = delete;
+
 	inline constexpr vector &operator=(vector const &vec)
-		requires(::std::copyable<value_type>)
 	{
+		// Using static_assert instead of requires to delay the check
+		// related to tests/0026.container/0001.vector/recursive.cc
+		static_assert(::std::copyable<value_type>, "vector's value type must be copyable to use copy assignment operator");
 		if (__builtin_addressof(vec) == this) [[unlikely]]
 		{
 			return *this;
@@ -445,7 +449,7 @@ public:
 		this->operator=(::std::move(newvec));
 		return *this;
 	}
-	inline constexpr vector &operator=(vector const &vec) = delete;
+
 	inline constexpr vector(vector &&vec) noexcept
 		: imp(vec.imp)
 	{

--- a/tests/0026.container/0001.vector/recursive.cc
+++ b/tests/0026.container/0001.vector/recursive.cc
@@ -1,0 +1,69 @@
+#include <variant>
+#include <fast_io_dsal/vector.h>
+
+struct Base;
+
+struct Node1
+{};
+struct Node3
+{};
+
+struct Node2
+{
+	fast_io::vector<Base> subast;
+
+	Node2();
+	Node2(fast_io::vector<Base> sub);
+	~Node2();
+};
+
+struct Base
+{
+	std::variant<Node1, Node2, Node3> data;
+
+
+	Base(Node1 n) : data(std::move(n))
+	{}
+	Base(Node2 n) : data(std::move(n))
+	{}
+	Base(Node3 n) : data(std::move(n))
+	{}
+};
+
+Node2::Node2() = default;
+Node2::Node2(fast_io::vector<Base> sub) : subast(std::move(sub))
+{}
+Node2::~Node2() = default;
+
+using Ast = fast_io::vector<Base>;
+
+int main()
+{
+	Ast ast;
+	ast.emplace_back(Node1{});
+	ast.emplace_back(Node3{});
+
+
+	Node2 nested;
+	nested.subast.emplace_back(Node1{});
+	ast.emplace_back(std::move(nested));
+
+
+	for (auto const &node : ast)
+	{
+		std::visit([](auto const &n) {
+			using T = std::decay_t<decltype(n)>;
+			if constexpr (std::is_same_v<T, Node1>)
+			{
+			}
+			else if constexpr (std::is_same_v<T, Node2>)
+			{
+			}
+			else if constexpr (std::is_same_v<T, Node3>)
+			{
+			}
+		},
+				   node.data);
+	}
+	return 0;
+}


### PR DESCRIPTION
This is also part of the [standard](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2015/n4510.html), and it also helps improve the performance of cases like the newly added recursive.cc.