### PR TITLE
string: fix constexpr compliance of basic_string default construction

### DIFF
--- a/include/fast_io_dsal/impl/string.h
+++ b/include/fast_io_dsal/impl/string.h
@@ -34,7 +34,7 @@ inline constexpr ::fast_io::basic_allocation_least_result<chtype *> string_alloc
 	// n is not possible to SIZE_MAX since that would overflow the memory which is not possible
 	::std::size_t const np1{static_cast<::std::size_t>(n + 1u)};
 	auto [ptr, allocn]{typed_allocator_type::allocate_at_least(np1)};
-	*::fast_io::freestanding::non_overlapped_copy_n(first, n, ptr) = 0;
+	::std::construct_at(::fast_io::freestanding::non_overlapped_copy_n(first, n, ptr), chtype{});
 	return {ptr, static_cast<::std::size_t>(allocn - 1u)};
 }
 
@@ -118,7 +118,7 @@ private:
 			using untyped_allocator_type = generic_allocator_adapter<allocator_type>;
 			using typed_allocator_type = typed_generic_allocator_adapter<untyped_allocator_type, chtype>;
 			auto [ptr, cap]{typed_allocator_type::allocate_at_least(2)};
-			*ptr = 0;
+			::std::construct_at(ptr, char_type{});
 			this->imp = {ptr, ptr, ptr + static_cast<size_type>(cap - 1u)};
 		}
 		else

--- a/tests/0026.container/0004.string/constexpr_construct.cc
+++ b/tests/0026.container/0004.string/constexpr_construct.cc
@@ -1,0 +1,14 @@
+#include <fast_io_dsal/string.h>
+
+// Tests that default construction (reset_imp) works in constexpr context.
+constexpr bool default_construct()
+{
+	::fast_io::u8string s{};
+	return s.empty();
+}
+static_assert(default_construct());
+
+int main()
+{
+	return 0;
+}


### PR DESCRIPTION
Replace raw pointer write `*ptr = 0` with `std::construct_at(ptr, char_type{})` in both `reset_imp()` and `string_allocate_init()`.  In C++20 constexpr dynamic allocation, storage returned by `operator new` / `allocate_at_least` has not had its lifetime started; writing through the pointer without `std::construct_at` is ill-formed in a constant expression (Clang rejects it outright). Add constexpr_construct.cc test verifying `u8string{}` compiles and evaluates as a constant expression.