### PR TITLE
test(vector): add assertions and fix minor issues in test suite

### DIFF
--- a/tests/0026.container/0001.vector/append_range.cc
+++ b/tests/0026.container/0001.vector/append_range.cc
@@ -1,4 +1,3 @@
-﻿#include <cassert>
 #include <algorithm>
 #include <list>
 #include <fast_io.h>
@@ -11,5 +10,5 @@ int main()
 	auto head = fast_io::vector<int>{1, 2, 3, 4};
 	auto const tail = std::list{-5, -6, -7};
 	head.append_range(tail);
-	assert(std::ranges::equal(head, fast_io::vector<int>{1, 2, 3, 4, -5, -6, -7}));
+	if (!(std::ranges::equal(head, fast_io::vector<int>{1, 2, 3, 4, -5, -6, -7}))) ::fast_io::fast_terminate();
 }

--- a/tests/0026.container/0001.vector/append_range.cc
+++ b/tests/0026.container/0001.vector/append_range.cc
@@ -8,10 +8,8 @@ using namespace fast_io::mnp;
 
 int main()
 {
-#if 0
 	auto head = fast_io::vector<int>{1, 2, 3, 4};
 	auto const tail = std::list{-5, -6, -7};
 	head.append_range(tail);
 	assert(std::ranges::equal(head, fast_io::vector<int>{1, 2, 3, 4, -5, -6, -7}));
-#endif
 }

--- a/tests/0026.container/0001.vector/assign.cc
+++ b/tests/0026.container/0001.vector/assign.cc
@@ -1,4 +1,3 @@
-#include <cassert>
 #include <string>
 #include <fast_io.h>
 #include <fast_io_dsal/vector.h>
@@ -19,10 +18,10 @@ int main()
 	};
 
 	characters.assign(5, 'a');
-	assert(characters.size() == 5);
+	if (!(characters.size() == 5)) ::fast_io::fast_terminate();
 	for (char c : characters)
 	{
-		assert(c == 'a');
+		if (!(c == 'a')) ::fast_io::fast_terminate();
 	}
 	print_vector();
 

--- a/tests/0026.container/0001.vector/assign.cc
+++ b/tests/0026.container/0001.vector/assign.cc
@@ -1,4 +1,5 @@
-﻿#include <string>
+#include <cassert>
+#include <string>
 #include <fast_io.h>
 #include <fast_io_dsal/vector.h>
 using namespace fast_io::io;
@@ -18,6 +19,11 @@ int main()
 	};
 
 	characters.assign(5, 'a');
+	assert(characters.size() == 5);
+	for (char c : characters)
+	{
+		assert(c == 'a');
+	}
 	print_vector();
 
 #if 0

--- a/tests/0026.container/0001.vector/assign_range.cc
+++ b/tests/0026.container/0001.vector/assign_range.cc
@@ -1,5 +1,4 @@
-﻿#include <algorithm>
-#include <cassert>
+#include <algorithm>
 #include <list>
 #include <fast_io.h>
 #include <fast_io_dsal/vector.h>
@@ -10,6 +9,6 @@ int main()
 	auto const source = std::list{2, 7, 1};
 	auto destination = fast_io::vector{3, 1, 4};
 	destination.assign_range(source);
-	assert(std::ranges::equal(source, destination));
+	if (!(std::ranges::equal(source, destination))) ::fast_io::fast_terminate();
 #endif
 }

--- a/tests/0026.container/0001.vector/back.cc
+++ b/tests/0026.container/0001.vector/back.cc
@@ -1,4 +1,5 @@
-﻿#include <fast_io.h>
+#include <cassert>
+#include <fast_io.h>
 #include <fast_io_dsal/vector.h>
 using namespace fast_io::io;
 using namespace fast_io::mnp;
@@ -9,6 +10,7 @@ int main()
 
 	if (!letters.empty())
 	{
-		print("The first character is '", chvw(letters.back()), "'.\n");
+		print("The last character is '", chvw(letters.back()), "'.\n");
 	}
+	assert(letters.back() == 'f');
 }

--- a/tests/0026.container/0001.vector/back.cc
+++ b/tests/0026.container/0001.vector/back.cc
@@ -1,4 +1,3 @@
-#include <cassert>
 #include <fast_io.h>
 #include <fast_io_dsal/vector.h>
 using namespace fast_io::io;
@@ -12,5 +11,5 @@ int main()
 	{
 		print("The last character is '", chvw(letters.back()), "'.\n");
 	}
-	assert(letters.back() == 'f');
+	if (!(letters.back() == 'f')) ::fast_io::fast_terminate();
 }

--- a/tests/0026.container/0001.vector/begin.cc
+++ b/tests/0026.container/0001.vector/begin.cc
@@ -1,4 +1,3 @@
-#include <cassert>
 #include <algorithm>
 #include <numeric>
 #include <string>
@@ -20,18 +19,18 @@ int main()
 	// Sums all integers in the vector nums (if any), printing only the result.
 	auto const sum = std::accumulate(nums.begin(), nums.end(), 0);
 	println("Sum of nums: ", sum);
-	assert(sum == 31);
+	if (!(sum == 31)) ::fast_io::fast_terminate();
 
 	// Prints the first fruit in the vector fruits, checking if there is any.
 	if (!fruits.empty())
 	{
 		println("First fruit: ", *fruits.begin());
-		assert(*fruits.begin() == "orange");
+		if (!(*fruits.begin() == "orange")) ::fast_io::fast_terminate();
 	}
 
 	if (empty.begin() == empty.end())
 	{
 		print("vector 'empty' is indeed empty.\n");
 	}
-	assert(empty.begin() == empty.end());
+	if (!(empty.begin() == empty.end())) ::fast_io::fast_terminate();
 }

--- a/tests/0026.container/0001.vector/begin.cc
+++ b/tests/0026.container/0001.vector/begin.cc
@@ -1,4 +1,5 @@
-﻿#include <algorithm>
+#include <cassert>
+#include <algorithm>
 #include <numeric>
 #include <string>
 #include <fast_io.h>
@@ -17,17 +18,20 @@ int main()
 	print("\n");
 
 	// Sums all integers in the vector nums (if any), printing only the result.
-	println("Sum of nums: ",
-			std::accumulate(nums.begin(), nums.end(), 0));
+	auto const sum = std::accumulate(nums.begin(), nums.end(), 0);
+	println("Sum of nums: ", sum);
+	assert(sum == 31);
 
 	// Prints the first fruit in the vector fruits, checking if there is any.
 	if (!fruits.empty())
 	{
 		println("First fruit: ", *fruits.begin());
+		assert(*fruits.begin() == "orange");
 	}
 
 	if (empty.begin() == empty.end())
 	{
 		print("vector 'empty' is indeed empty.\n");
 	}
+	assert(empty.begin() == empty.end());
 }

--- a/tests/0026.container/0001.vector/capacity.cc
+++ b/tests/0026.container/0001.vector/capacity.cc
@@ -1,4 +1,5 @@
-﻿#include <fast_io.h>
+#include <cassert>
+#include <fast_io.h>
 #include <fast_io_dsal/vector.h>
 using namespace fast_io::io;
 using namespace fast_io::mnp;
@@ -10,8 +11,10 @@ int main()
 
 	auto cap = v.capacity();
 	println("Initial size: ", v.size(), ", capacity: ", cap);
+	assert(v.size() == 0);
+	assert(v.capacity() == 0);
 
-	print("\nDemonstrate the capacity's growth policy."
+	print("\nDemonstrate the capacity'\''s growth policy."
 		  "\nSize:  Capacity:  Ratio:\n");
 	while (sz-- > 0)
 	{
@@ -19,9 +22,11 @@ int main()
 		if (cap != v.capacity())
 		{
 			println(left(v.size(), 7), left(v.capacity(), 11), left(float(v.capacity()) / static_cast<float>(cap), 10));
+			assert(v.capacity() > cap);
 			cap = v.capacity();
 		}
 	}
 
 	println("\nFinal size: ", v.size(), ", capacity: ", v.capacity());
+	assert(v.size() == 100);
 }

--- a/tests/0026.container/0001.vector/capacity.cc
+++ b/tests/0026.container/0001.vector/capacity.cc
@@ -1,4 +1,3 @@
-#include <cassert>
 #include <fast_io.h>
 #include <fast_io_dsal/vector.h>
 using namespace fast_io::io;
@@ -11,8 +10,8 @@ int main()
 
 	auto cap = v.capacity();
 	println("Initial size: ", v.size(), ", capacity: ", cap);
-	assert(v.size() == 0);
-	assert(v.capacity() == 0);
+	if (!(v.size() == 0)) ::fast_io::fast_terminate();
+	if (!(v.capacity() == 0)) ::fast_io::fast_terminate();
 
 	print("\nDemonstrate the capacity'\''s growth policy."
 		  "\nSize:  Capacity:  Ratio:\n");
@@ -22,11 +21,11 @@ int main()
 		if (cap != v.capacity())
 		{
 			println(left(v.size(), 7), left(v.capacity(), 11), left(float(v.capacity()) / static_cast<float>(cap), 10));
-			assert(v.capacity() > cap);
+			if (!(v.capacity() > cap)) ::fast_io::fast_terminate();
 			cap = v.capacity();
 		}
 	}
 
 	println("\nFinal size: ", v.size(), ", capacity: ", v.capacity());
-	assert(v.size() == 100);
+	if (!(v.size() == 100)) ::fast_io::fast_terminate();
 }

--- a/tests/0026.container/0001.vector/clear.cc
+++ b/tests/0026.container/0001.vector/clear.cc
@@ -1,4 +1,5 @@
-﻿#include <string_view>
+#include <cassert>
+#include <string_view>
 #include <fast_io.h>
 #include <fast_io_dsal/vector.h>
 using namespace fast_io::io;
@@ -13,6 +14,10 @@ int main()
 {
 	fast_io::vector<int> container{1, 2, 3};
 	print_info("Before clear: ", container);
+	assert(!container.empty());
+	assert(container.size() == 3);
 	container.clear();
 	print_info("After clear: ", container);
+	assert(container.empty());
+	assert(container.size() == 0);
 }

--- a/tests/0026.container/0001.vector/clear.cc
+++ b/tests/0026.container/0001.vector/clear.cc
@@ -1,4 +1,3 @@
-#include <cassert>
 #include <string_view>
 #include <fast_io.h>
 #include <fast_io_dsal/vector.h>
@@ -14,10 +13,10 @@ int main()
 {
 	fast_io::vector<int> container{1, 2, 3};
 	print_info("Before clear: ", container);
-	assert(!container.empty());
-	assert(container.size() == 3);
+	if (!(!container.empty())) ::fast_io::fast_terminate();
+	if (!(container.size() == 3)) ::fast_io::fast_terminate();
 	container.clear();
 	print_info("After clear: ", container);
-	assert(container.empty());
-	assert(container.size() == 0);
+	if (!(container.empty())) ::fast_io::fast_terminate();
+	if (!(container.size() == 0)) ::fast_io::fast_terminate();
 }

--- a/tests/0026.container/0001.vector/data.cc
+++ b/tests/0026.container/0001.vector/data.cc
@@ -1,4 +1,3 @@
-#include <cassert>
 #include <cstddef>
 #include <span>
 #include <fast_io.h>
@@ -31,8 +30,8 @@ int main()
 	// std::span (C++20) is a safer alternative to separated pointer/size.
 	span_func({container.data(), container.size()});
 
-	assert(container.data()[0] == 1);
-	assert(container.data()[1] == 2);
-	assert(container.data()[2] == 3);
-	assert(container.data()[3] == 4);
+	if (!(container.data()[0] == 1)) ::fast_io::fast_terminate();
+	if (!(container.data()[1] == 2)) ::fast_io::fast_terminate();
+	if (!(container.data()[2] == 3)) ::fast_io::fast_terminate();
+	if (!(container.data()[3] == 4)) ::fast_io::fast_terminate();
 }

--- a/tests/0026.container/0001.vector/data.cc
+++ b/tests/0026.container/0001.vector/data.cc
@@ -1,4 +1,5 @@
-﻿#include <cstddef>
+#include <cassert>
+#include <cstddef>
 #include <span>
 #include <fast_io.h>
 #include <fast_io_dsal/vector.h>
@@ -29,4 +30,9 @@ int main()
 
 	// std::span (C++20) is a safer alternative to separated pointer/size.
 	span_func({container.data(), container.size()});
+
+	assert(container.data()[0] == 1);
+	assert(container.data()[1] == 2);
+	assert(container.data()[2] == 3);
+	assert(container.data()[3] == 4);
 }

--- a/tests/0026.container/0001.vector/emplace.cc
+++ b/tests/0026.container/0001.vector/emplace.cc
@@ -1,4 +1,3 @@
-#include <cassert>
 #include <algorithm>
 #include <ranges>
 #include <string>
@@ -63,8 +62,8 @@ int main()
 	container.emplace(container.end(), std::move(three));
 
 	println("content:\n ", rgvw(container | std::views::transform([](auto const &a) { return a.s; }), " "));
-	assert(container.size() == 3);
-	assert(container[0].s == "one");
-	assert(container[1].s == "two");
-	assert(container[2].s == "three");
+	if (!(container.size() == 3)) ::fast_io::fast_terminate();
+	if (!(container[0].s == "one")) ::fast_io::fast_terminate();
+	if (!(container[1].s == "two")) ::fast_io::fast_terminate();
+	if (!(container[2].s == "three")) ::fast_io::fast_terminate();
 }

--- a/tests/0026.container/0001.vector/emplace.cc
+++ b/tests/0026.container/0001.vector/emplace.cc
@@ -1,4 +1,5 @@
-﻿#include <algorithm>
+#include <cassert>
+#include <algorithm>
 #include <ranges>
 #include <string>
 #include <fast_io.h>
@@ -62,4 +63,8 @@ int main()
 	container.emplace(container.end(), std::move(three));
 
 	println("content:\n ", rgvw(container | std::views::transform([](auto const &a) { return a.s; }), " "));
+	assert(container.size() == 3);
+	assert(container[0].s == "one");
+	assert(container[1].s == "two");
+	assert(container[2].s == "three");
 }

--- a/tests/0026.container/0001.vector/emplace_index.cc
+++ b/tests/0026.container/0001.vector/emplace_index.cc
@@ -1,4 +1,3 @@
-#include <cassert>
 #include <fast_io.h>
 #include <fast_io_dsal/vector.h>
 using namespace fast_io::io;
@@ -15,9 +14,9 @@ int main()
 	// After emplace_index(0,6): [6,4]
 	// After emplace_index(0,8): [8,6,4]
 	// After erase_index(0): [6,4]
-	assert(vec.size() == 2);
-	assert(vec[0] == 6);
-	assert(vec[1] == 4);
+	if (!(vec.size() == 2)) ::fast_io::fast_terminate();
+	if (!(vec[0] == 6)) ::fast_io::fast_terminate();
+	if (!(vec[1] == 4)) ::fast_io::fast_terminate();
 	for(auto const & e : vec)
 	{
 		::fast_io::io::println(e);

--- a/tests/0026.container/0001.vector/emplace_index.cc
+++ b/tests/0026.container/0001.vector/emplace_index.cc
@@ -1,6 +1,4 @@
-﻿#include <algorithm>
-#include <ranges>
-#include <string>
+#include <cassert>
 #include <fast_io.h>
 #include <fast_io_dsal/vector.h>
 using namespace fast_io::io;
@@ -13,6 +11,13 @@ int main()
 	vec.emplace_index(0,6);
 	vec.emplace_index(0,8);
 	vec.erase_index(0);
+	// After push_back(4): [4]
+	// After emplace_index(0,6): [6,4]
+	// After emplace_index(0,8): [8,6,4]
+	// After erase_index(0): [6,4]
+	assert(vec.size() == 2);
+	assert(vec[0] == 6);
+	assert(vec[1] == 4);
 	for(auto const & e : vec)
 	{
 		::fast_io::io::println(e);

--- a/tests/0026.container/0001.vector/empty.cc
+++ b/tests/0026.container/0001.vector/empty.cc
@@ -1,4 +1,3 @@
-#include <cassert>
 #include <fast_io.h>
 #include <fast_io_dsal/vector.h>
 using namespace fast_io::io;
@@ -8,9 +7,9 @@ int main()
 {
 	fast_io::vector<int> numbers;
 	println("Initially, numbers.empty(): ", boolalpha(numbers.empty()));
-	assert(numbers.empty());
+	if (!(numbers.empty())) ::fast_io::fast_terminate();
 
 	numbers.push_back(42);
 	println("After adding elements, numbers.empty(): ", boolalpha(numbers.empty()));
-	assert(!numbers.empty());
+	if (!(!numbers.empty())) ::fast_io::fast_terminate();
 }

--- a/tests/0026.container/0001.vector/empty.cc
+++ b/tests/0026.container/0001.vector/empty.cc
@@ -1,4 +1,5 @@
-﻿#include <fast_io.h>
+#include <cassert>
+#include <fast_io.h>
 #include <fast_io_dsal/vector.h>
 using namespace fast_io::io;
 using namespace fast_io::mnp;
@@ -7,7 +8,9 @@ int main()
 {
 	fast_io::vector<int> numbers;
 	println("Initially, numbers.empty(): ", boolalpha(numbers.empty()));
+	assert(numbers.empty());
 
 	numbers.push_back(42);
 	println("After adding elements, numbers.empty(): ", boolalpha(numbers.empty()));
+	assert(!numbers.empty());
 }

--- a/tests/0026.container/0001.vector/end.cc
+++ b/tests/0026.container/0001.vector/end.cc
@@ -1,4 +1,3 @@
-#include <cassert>
 #include <algorithm>
 #include <numeric>
 #include <string>
@@ -20,18 +19,18 @@ int main()
 	// Sums all integers in the vector nums (if any), printing only the result.
 	auto const sum = std::accumulate(nums.begin(), nums.end(), 0);
 	println("Sum of nums: ", sum);
-	assert(sum == 31);
+	if (!(sum == 31)) ::fast_io::fast_terminate();
 
 	// Prints the first fruit in the vector fruits, checking if there is any.
 	if (!fruits.empty())
 	{
 		println("First fruit: ", *fruits.begin());
-		assert(*fruits.begin() == "orange");
+		if (!(*fruits.begin() == "orange")) ::fast_io::fast_terminate();
 	}
 
 	if (empty.begin() == empty.end())
 	{
 		print("vector 'empty' is indeed empty.\n");
 	}
-	assert(empty.begin() == empty.end());
+	if (!(empty.begin() == empty.end())) ::fast_io::fast_terminate();
 }

--- a/tests/0026.container/0001.vector/end.cc
+++ b/tests/0026.container/0001.vector/end.cc
@@ -1,4 +1,5 @@
-﻿#include <algorithm>
+#include <cassert>
+#include <algorithm>
 #include <numeric>
 #include <string>
 #include <fast_io.h>
@@ -17,17 +18,20 @@ int main()
 	print("\n");
 
 	// Sums all integers in the vector nums (if any), printing only the result.
-	println("Sum of nums: ",
-			std::accumulate(nums.begin(), nums.end(), 0));
+	auto const sum = std::accumulate(nums.begin(), nums.end(), 0);
+	println("Sum of nums: ", sum);
+	assert(sum == 31);
 
 	// Prints the first fruit in the vector fruits, checking if there is any.
 	if (!fruits.empty())
 	{
 		println("First fruit: ", *fruits.begin());
+		assert(*fruits.begin() == "orange");
 	}
 
 	if (empty.begin() == empty.end())
 	{
 		print("vector 'empty' is indeed empty.\n");
 	}
+	assert(empty.begin() == empty.end());
 }

--- a/tests/0026.container/0001.vector/erase.cc
+++ b/tests/0026.container/0001.vector/erase.cc
@@ -1,4 +1,5 @@
-﻿#include <fast_io.h>
+#include <cassert>
+#include <fast_io.h>
 #include <fast_io_dsal/vector.h>
 using namespace fast_io::io;
 using namespace fast_io::mnp;
@@ -11,12 +12,18 @@ void print_container(fast_io::vector<int> const &c)
 int main()
 {
 	fast_io::vector<int> c{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+	assert(c.size() == 10);
 	print_container(c);
 
 	c.erase(c.begin());
+	assert(c.size() == 9);
+	assert(c[0] == 1);
 	print_container(c);
 
 	c.erase(c.begin() + 2, c.begin() + 5);
+	// Before: [1,2,3,4,5,6,7,8,9]; erase indices 2-4 (values 3,4,5)
+	assert(c.size() == 6);
+	assert(c[0] == 1 && c[1] == 2 && c[2] == 6 && c[3] == 7 && c[4] == 8 && c[5] == 9);
 	print_container(c);
 
 	// Erase all even numbers
@@ -31,5 +38,8 @@ int main()
 			++it;
 		}
 	}
+	// After erasing evens from [1,2,6,7,8,9]: [1,7,9]
+	assert(c.size() == 3);
+	assert(c[0] == 1 && c[1] == 7 && c[2] == 9);
 	print_container(c);
 }

--- a/tests/0026.container/0001.vector/erase.cc
+++ b/tests/0026.container/0001.vector/erase.cc
@@ -1,4 +1,3 @@
-#include <cassert>
 #include <fast_io.h>
 #include <fast_io_dsal/vector.h>
 using namespace fast_io::io;
@@ -12,18 +11,18 @@ void print_container(fast_io::vector<int> const &c)
 int main()
 {
 	fast_io::vector<int> c{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
-	assert(c.size() == 10);
+	if (!(c.size() == 10)) ::fast_io::fast_terminate();
 	print_container(c);
 
 	c.erase(c.begin());
-	assert(c.size() == 9);
-	assert(c[0] == 1);
+	if (!(c.size() == 9)) ::fast_io::fast_terminate();
+	if (!(c[0] == 1)) ::fast_io::fast_terminate();
 	print_container(c);
 
 	c.erase(c.begin() + 2, c.begin() + 5);
 	// Before: [1,2,3,4,5,6,7,8,9]; erase indices 2-4 (values 3,4,5)
-	assert(c.size() == 6);
-	assert(c[0] == 1 && c[1] == 2 && c[2] == 6 && c[3] == 7 && c[4] == 8 && c[5] == 9);
+	if (!(c.size() == 6)) ::fast_io::fast_terminate();
+	if (!(c[0] == 1 && c[1] == 2 && c[2] == 6 && c[3] == 7 && c[4] == 8 && c[5] == 9)) ::fast_io::fast_terminate();
 	print_container(c);
 
 	// Erase all even numbers
@@ -39,7 +38,7 @@ int main()
 		}
 	}
 	// After erasing evens from [1,2,6,7,8,9]: [1,7,9]
-	assert(c.size() == 3);
-	assert(c[0] == 1 && c[1] == 7 && c[2] == 9);
+	if (!(c.size() == 3)) ::fast_io::fast_terminate();
+	if (!(c[0] == 1 && c[1] == 7 && c[2] == 9)) ::fast_io::fast_terminate();
 	print_container(c);
 }

--- a/tests/0026.container/0001.vector/erase_index.cc
+++ b/tests/0026.container/0001.vector/erase_index.cc
@@ -1,4 +1,3 @@
-#include <cassert>
 #include <fast_io.h>
 #include <fast_io_dsal/vector.h>
 using namespace fast_io::io;
@@ -12,19 +11,19 @@ inline void print_container(fast_io::vector<int> const &c)
 int main()
 {
 	fast_io::vector<int> c{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
-	assert(c.size() == 10);
+	if (!(c.size() == 10)) ::fast_io::fast_terminate();
 	print_container(c);
 
 	c.erase_index(0);
-	assert(c.size() == 9);
-	assert(c[0] == 1);
+	if (!(c.size() == 9)) ::fast_io::fast_terminate();
+	if (!(c[0] == 1)) ::fast_io::fast_terminate();
 	print_container(c);
 
 	c.erase_index(2, 5);
 	// After erasing index 0: [1,2,3,4,5,6,7,8,9]
 	// erase_index(2,5): erase indices 2..4 (values 3,4,5) => [1,2,6,7,8,9]
-	assert(c.size() == 6);
-	assert(c[0] == 1 && c[1] == 2 && c[2] == 6 && c[3] == 7 && c[4] == 8 && c[5] == 9);
+	if (!(c.size() == 6)) ::fast_io::fast_terminate();
+	if (!(c[0] == 1 && c[1] == 2 && c[2] == 6 && c[3] == 7 && c[4] == 8 && c[5] == 9)) ::fast_io::fast_terminate();
 	print_container(c);
 
 	// Erase all even numbers
@@ -40,7 +39,7 @@ int main()
 		}
 	}
 	// After erasing evens from [1,2,6,7,8,9]: [1,7,9]
-	assert(c.size() == 3);
-	assert(c[0] == 1 && c[1] == 7 && c[2] == 9);
+	if (!(c.size() == 3)) ::fast_io::fast_terminate();
+	if (!(c[0] == 1 && c[1] == 7 && c[2] == 9)) ::fast_io::fast_terminate();
 	print_container(c);
 }

--- a/tests/0026.container/0001.vector/erase_index.cc
+++ b/tests/0026.container/0001.vector/erase_index.cc
@@ -1,4 +1,5 @@
-﻿#include <fast_io.h>
+#include <cassert>
+#include <fast_io.h>
 #include <fast_io_dsal/vector.h>
 using namespace fast_io::io;
 using namespace fast_io::mnp;
@@ -11,12 +12,19 @@ inline void print_container(fast_io::vector<int> const &c)
 int main()
 {
 	fast_io::vector<int> c{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+	assert(c.size() == 10);
 	print_container(c);
 
 	c.erase_index(0);
+	assert(c.size() == 9);
+	assert(c[0] == 1);
 	print_container(c);
 
 	c.erase_index(2, 5);
+	// After erasing index 0: [1,2,3,4,5,6,7,8,9]
+	// erase_index(2,5): erase indices 2..4 (values 3,4,5) => [1,2,6,7,8,9]
+	assert(c.size() == 6);
+	assert(c[0] == 1 && c[1] == 2 && c[2] == 6 && c[3] == 7 && c[4] == 8 && c[5] == 9);
 	print_container(c);
 
 	// Erase all even numbers
@@ -31,6 +39,8 @@ int main()
 			++i;
 		}
 	}
-
+	// After erasing evens from [1,2,6,7,8,9]: [1,7,9]
+	assert(c.size() == 3);
+	assert(c[0] == 1 && c[1] == 7 && c[2] == 9);
 	print_container(c);
 }

--- a/tests/0026.container/0001.vector/front.cc
+++ b/tests/0026.container/0001.vector/front.cc
@@ -1,4 +1,3 @@
-#include <cassert>
 #include <fast_io.h>
 #include <fast_io_dsal/vector.h>
 using namespace fast_io::io;
@@ -12,5 +11,5 @@ int main()
 	{
 		print("The first character is '", chvw(letters.front()), "'.\n");
 	}
-	assert(letters.front() == 'a');
+	if (!(letters.front() == 'a')) ::fast_io::fast_terminate();
 }

--- a/tests/0026.container/0001.vector/front.cc
+++ b/tests/0026.container/0001.vector/front.cc
@@ -1,4 +1,5 @@
-﻿#include <fast_io.h>
+#include <cassert>
+#include <fast_io.h>
 #include <fast_io_dsal/vector.h>
 using namespace fast_io::io;
 using namespace fast_io::mnp;
@@ -11,4 +12,5 @@ int main()
 	{
 		print("The first character is '", chvw(letters.front()), "'.\n");
 	}
+	assert(letters.front() == 'a');
 }

--- a/tests/0026.container/0001.vector/insert.cc
+++ b/tests/0026.container/0001.vector/insert.cc
@@ -1,4 +1,5 @@
-﻿#include <iterator>
+#include <cassert>
+#include <iterator>
 #include <fast_io.h>
 #include <fast_io_dsal/vector.h>
 using namespace fast_io::io;
@@ -13,9 +14,14 @@ int main()
 {
 	fast_io::vector<int> c1(3, 100);
 	print_info(1, c1);
+	assert(c1.size() == 3);
+	assert(c1[0] == 100 && c1[1] == 100 && c1[2] == 100);
 
 	auto it = c1.begin();
 	it = c1.insert(it, 200);
+	assert(*it == 200);
+	assert(c1.size() == 4);
+	assert(c1[0] == 200);
 	print_info(2, c1);
 #if 0
 	c1.insert(it, 2, 300);

--- a/tests/0026.container/0001.vector/insert.cc
+++ b/tests/0026.container/0001.vector/insert.cc
@@ -1,4 +1,3 @@
-#include <cassert>
 #include <iterator>
 #include <fast_io.h>
 #include <fast_io_dsal/vector.h>
@@ -14,14 +13,14 @@ int main()
 {
 	fast_io::vector<int> c1(3, 100);
 	print_info(1, c1);
-	assert(c1.size() == 3);
-	assert(c1[0] == 100 && c1[1] == 100 && c1[2] == 100);
+	if (!(c1.size() == 3)) ::fast_io::fast_terminate();
+	if (!(c1[0] == 100 && c1[1] == 100 && c1[2] == 100)) ::fast_io::fast_terminate();
 
 	auto it = c1.begin();
 	it = c1.insert(it, 200);
-	assert(*it == 200);
-	assert(c1.size() == 4);
-	assert(c1[0] == 200);
+	if (!(*it == 200)) ::fast_io::fast_terminate();
+	if (!(c1.size() == 4)) ::fast_io::fast_terminate();
+	if (!(c1[0] == 200)) ::fast_io::fast_terminate();
 	print_info(2, c1);
 #if 0
 	c1.insert(it, 2, 300);

--- a/tests/0026.container/0001.vector/insert_range.cc
+++ b/tests/0026.container/0001.vector/insert_range.cc
@@ -1,4 +1,3 @@
-﻿#include <cassert>
 #include <iterator>
 #include <algorithm>
 #include <list>
@@ -12,10 +11,10 @@ int main()
 #if 0
 	auto container = fast_io::vector{1, 2, 3, 4};
 	auto pos = std::next(container.begin(), 2);
-	assert(*pos == 3);
+	if (!(*pos == 3)) ::fast_io::fast_terminate();
 	auto const rg = std::list{-1, -2, -3};
 
 	container.insert_range(pos, rg);
-	assert(std::ranges::equal(container, fast_io::vector{1, 2, -1, -2, -3, 3, 4}));
+	if (!(std::ranges::equal(container, fast_io::vector{1, 2, -1, -2, -3, 3, 4}))) ::fast_io::fast_terminate();
 #endif
 }

--- a/tests/0026.container/0001.vector/operator_assign.cc
+++ b/tests/0026.container/0001.vector/operator_assign.cc
@@ -1,4 +1,5 @@
-﻿#include <initializer_list>
+#include <cassert>
+#include <initializer_list>
 #include <iterator>
 #include <fast_io.h>
 #include <fast_io_dsal/vector.h>
@@ -11,14 +12,23 @@ int main()
 
 	print("Initially:\n");
 	print("x = {", rgvw(x, ", "), "}\ny = {", rgvw(y, ", "), "}\nz = {", rgvw(z, ", "), "}\n");
+	assert(x.size() == 3);
+	assert(y.empty());
+	assert(z.empty());
 
 	print("Copy assignment copies data from x to y:\n");
 	y = x;
 	print("x = {", rgvw(x, ", "), "}\ny = {", rgvw(y, ", "), "}\n");
+	assert(y.size() == 3);
+	assert(y[0] == 1 && y[1] == 2 && y[2] == 3);
 
 	print("Move assignment moves data from x to z, modifying both x and z:\n");
 	z = std::move(x);
 	print("x = {", rgvw(x, ", "), "}\nz = {", rgvw(z, ", "), "}\n");
+	assert(z.size() == 3);
+	assert(z[0] == 1 && z[1] == 2 && z[2] == 3);
+	// After move, source vector should be empty
+	assert(x.empty());
 
 #if 0
 	auto const w = {4, 5, 6, 7};

--- a/tests/0026.container/0001.vector/operator_assign.cc
+++ b/tests/0026.container/0001.vector/operator_assign.cc
@@ -1,4 +1,3 @@
-#include <cassert>
 #include <initializer_list>
 #include <iterator>
 #include <fast_io.h>
@@ -12,23 +11,23 @@ int main()
 
 	print("Initially:\n");
 	print("x = {", rgvw(x, ", "), "}\ny = {", rgvw(y, ", "), "}\nz = {", rgvw(z, ", "), "}\n");
-	assert(x.size() == 3);
-	assert(y.empty());
-	assert(z.empty());
+	if (!(x.size() == 3)) ::fast_io::fast_terminate();
+	if (!(y.empty())) ::fast_io::fast_terminate();
+	if (!(z.empty())) ::fast_io::fast_terminate();
 
 	print("Copy assignment copies data from x to y:\n");
 	y = x;
 	print("x = {", rgvw(x, ", "), "}\ny = {", rgvw(y, ", "), "}\n");
-	assert(y.size() == 3);
-	assert(y[0] == 1 && y[1] == 2 && y[2] == 3);
+	if (!(y.size() == 3)) ::fast_io::fast_terminate();
+	if (!(y[0] == 1 && y[1] == 2 && y[2] == 3)) ::fast_io::fast_terminate();
 
 	print("Move assignment moves data from x to z, modifying both x and z:\n");
 	z = std::move(x);
 	print("x = {", rgvw(x, ", "), "}\nz = {", rgvw(z, ", "), "}\n");
-	assert(z.size() == 3);
-	assert(z[0] == 1 && z[1] == 2 && z[2] == 3);
+	if (!(z.size() == 3)) ::fast_io::fast_terminate();
+	if (!(z[0] == 1 && z[1] == 2 && z[2] == 3)) ::fast_io::fast_terminate();
 	// After move, source vector should be empty
-	assert(x.empty());
+	if (!(x.empty())) ::fast_io::fast_terminate();
 
 #if 0
 	auto const w = {4, 5, 6, 7};

--- a/tests/0026.container/0001.vector/operator_at.cc
+++ b/tests/0026.container/0001.vector/operator_at.cc
@@ -1,4 +1,3 @@
-#include <cassert>
 #include <fast_io.h>
 #include <fast_io_dsal/vector.h>
 using namespace fast_io::io;
@@ -9,13 +8,13 @@ int main()
 	fast_io::vector<int> numbers{2, 4, 6, 8};
 
 	print("Second element: ", numbers[1], "\n");
-	assert(numbers[1] == 4);
+	if (!(numbers[1] == 4)) ::fast_io::fast_terminate();
 
 	numbers[0] = 5;
-	assert(numbers[0] == 5);
+	if (!(numbers[0] == 5)) ::fast_io::fast_terminate();
 
 	println("All numbers: ", rgvw(numbers, " "));
-	assert(numbers[0] == 5 && numbers[1] == 4 && numbers[2] == 6 && numbers[3] == 8);
+	if (!(numbers[0] == 5 && numbers[1] == 4 && numbers[2] == 6 && numbers[3] == 8)) ::fast_io::fast_terminate();
 }
 
 // Gets the sum of all primes in [0, N) using sieve of Eratosthenes

--- a/tests/0026.container/0001.vector/operator_at.cc
+++ b/tests/0026.container/0001.vector/operator_at.cc
@@ -1,4 +1,5 @@
-﻿#include <fast_io.h>
+#include <cassert>
+#include <fast_io.h>
 #include <fast_io_dsal/vector.h>
 using namespace fast_io::io;
 using namespace fast_io::mnp;
@@ -8,10 +9,13 @@ int main()
 	fast_io::vector<int> numbers{2, 4, 6, 8};
 
 	print("Second element: ", numbers[1], "\n");
+	assert(numbers[1] == 4);
 
 	numbers[0] = 5;
+	assert(numbers[0] == 5);
 
 	println("All numbers: ", rgvw(numbers, " "));
+	assert(numbers[0] == 5 && numbers[1] == 4 && numbers[2] == 6 && numbers[3] == 8);
 }
 
 // Gets the sum of all primes in [0, N) using sieve of Eratosthenes

--- a/tests/0026.container/0001.vector/operator_cmp.cc
+++ b/tests/0026.container/0001.vector/operator_cmp.cc
@@ -1,4 +1,3 @@
-﻿#include <cassert>
 #include <fast_io.h>
 #include <fast_io_dsal/vector.h>
 using namespace fast_io::io;
@@ -12,7 +11,7 @@ int main()
 		b{1, 2, 3},
 		c{7, 8, 9, 10};
 
-	assert(""
+	if (!(""
 		   "Compare equal containers:" &&
 		   (a != b) == false &&
 		   (a == b) == true &&
@@ -40,5 +39,5 @@ int main()
 		   (a <=> c) < 0 &&
 		   (a <=> c) != 0 &&
 		   (a <=> c) <= 0 &&
-		   "");
+		   "")) ::fast_io::fast_terminate();
 }

--- a/tests/0026.container/0001.vector/pop_back.cc
+++ b/tests/0026.container/0001.vector/pop_back.cc
@@ -1,4 +1,3 @@
-#include <cassert>
 #include <fast_io.h>
 #include <fast_io_dsal/vector.h>
 using namespace fast_io::io;
@@ -19,16 +18,16 @@ int main()
 	numbers.push_back(5);
 	numbers.push_back(3);
 	numbers.push_back(4);
-	assert(numbers.size() == 3);
-	assert(numbers[0] == 5);
-	assert(numbers[1] == 3);
-	assert(numbers[2] == 4);
+	if (!(numbers.size() == 3)) ::fast_io::fast_terminate();
+	if (!(numbers[0] == 5)) ::fast_io::fast_terminate();
+	if (!(numbers[1] == 3)) ::fast_io::fast_terminate();
+	if (!(numbers[2] == 4)) ::fast_io::fast_terminate();
 
 	print_info(numbers);
 
 	numbers.pop_back();
-	assert(numbers.size() == 2);
-	assert(numbers.back() == 3);
+	if (!(numbers.size() == 2)) ::fast_io::fast_terminate();
+	if (!(numbers.back() == 3)) ::fast_io::fast_terminate();
 
 	print_info(numbers);
 }

--- a/tests/0026.container/0001.vector/pop_back.cc
+++ b/tests/0026.container/0001.vector/pop_back.cc
@@ -1,4 +1,5 @@
-﻿#include <fast_io.h>
+#include <cassert>
+#include <fast_io.h>
 #include <fast_io_dsal/vector.h>
 using namespace fast_io::io;
 using namespace fast_io::mnp;
@@ -18,10 +19,16 @@ int main()
 	numbers.push_back(5);
 	numbers.push_back(3);
 	numbers.push_back(4);
+	assert(numbers.size() == 3);
+	assert(numbers[0] == 5);
+	assert(numbers[1] == 3);
+	assert(numbers[2] == 4);
 
 	print_info(numbers);
 
 	numbers.pop_back();
+	assert(numbers.size() == 2);
+	assert(numbers.back() == 3);
 
 	print_info(numbers);
 }

--- a/tests/0026.container/0001.vector/push_back.cc
+++ b/tests/0026.container/0001.vector/push_back.cc
@@ -1,4 +1,3 @@
-#include <cassert>
 #include <string>
 #include <fast_io.h>
 #include <fast_io_dsal/vector.h>
@@ -13,9 +12,9 @@ int main()
 	std::string s{"def"};
 	letters.push_back(std::move(s));
 
-	assert(letters.size() == 2);
-	assert(letters[0] == "abc");
-	assert(letters[1] == "def");
+	if (!(letters.size() == 2)) ::fast_io::fast_terminate();
+	if (!(letters[0] == "abc")) ::fast_io::fast_terminate();
+	if (!(letters[1] == "def")) ::fast_io::fast_terminate();
 
 	print("std::vector letters holds: ");
 	for (auto &&e : letters)

--- a/tests/0026.container/0001.vector/push_back.cc
+++ b/tests/0026.container/0001.vector/push_back.cc
@@ -1,4 +1,5 @@
-﻿#include <string>
+#include <cassert>
+#include <string>
 #include <fast_io.h>
 #include <fast_io_dsal/vector.h>
 using namespace fast_io::io;
@@ -11,6 +12,10 @@ int main()
 	letters.push_back("abc");
 	std::string s{"def"};
 	letters.push_back(std::move(s));
+
+	assert(letters.size() == 2);
+	assert(letters[0] == "abc");
+	assert(letters[1] == "def");
 
 	print("std::vector letters holds: ");
 	for (auto &&e : letters)

--- a/tests/0026.container/0001.vector/shared_ptr_index.cc
+++ b/tests/0026.container/0001.vector/shared_ptr_index.cc
@@ -1,4 +1,3 @@
-#include <cassert>
 #include <fast_io_dsal/vector.h>
 #include <fast_io.h>
 #include <memory>
@@ -17,14 +16,14 @@ struct is_trivially_copyable_or_relocatable<::std::shared_ptr<T>>
 int main()
 {
 	::fast_io::vector<::std::shared_ptr<int>> vec{std::make_shared<int>(1), std::make_shared<int>(2), std::make_shared<int>(3)};
-	assert(vec.size() == 3);
+	if (!(vec.size() == 3)) ::fast_io::fast_terminate();
 	vec.insert_index(1, std::make_shared<int>(4));
-	assert(vec.size() == 4);
-	assert(*vec[0] == 1);
-	assert(*vec[1] == 4);
-	assert(*vec[2] == 2);
-	assert(*vec[3] == 3);
-	assert(vec[1].use_count() == 1);
+	if (!(vec.size() == 4)) ::fast_io::fast_terminate();
+	if (!(*vec[0] == 1)) ::fast_io::fast_terminate();
+	if (!(*vec[1] == 4)) ::fast_io::fast_terminate();
+	if (!(*vec[2] == 2)) ::fast_io::fast_terminate();
+	if (!(*vec[3] == 3)) ::fast_io::fast_terminate();
+	if (!(vec[1].use_count() == 1)) ::fast_io::fast_terminate();
 	using namespace ::fast_io::io;
 	print("After vec.insert_index(1)\n");
 	for (auto const &e : vec)
@@ -32,9 +31,9 @@ int main()
 		println(::fast_io::mnp::pointervw(e.get()), " use_count: ", e.use_count());
 	}
 	vec.erase_index(0, 2);
-	assert(vec.size() == 2);
-	assert(*vec[0] == 2);
-	assert(*vec[1] == 3);
+	if (!(vec.size() == 2)) ::fast_io::fast_terminate();
+	if (!(*vec[0] == 2)) ::fast_io::fast_terminate();
+	if (!(*vec[1] == 3)) ::fast_io::fast_terminate();
 	print("After vec.erase_index(0,2)\n");
 	for (auto const &e : vec)
 	{

--- a/tests/0026.container/0001.vector/shared_ptr_index.cc
+++ b/tests/0026.container/0001.vector/shared_ptr_index.cc
@@ -1,4 +1,5 @@
-﻿#include <fast_io_dsal/vector.h>
+#include <cassert>
+#include <fast_io_dsal/vector.h>
 #include <fast_io.h>
 #include <memory>
 
@@ -16,7 +17,14 @@ struct is_trivially_copyable_or_relocatable<::std::shared_ptr<T>>
 int main()
 {
 	::fast_io::vector<::std::shared_ptr<int>> vec{std::make_shared<int>(1), std::make_shared<int>(2), std::make_shared<int>(3)};
+	assert(vec.size() == 3);
 	vec.insert_index(1, std::make_shared<int>(4));
+	assert(vec.size() == 4);
+	assert(*vec[0] == 1);
+	assert(*vec[1] == 4);
+	assert(*vec[2] == 2);
+	assert(*vec[3] == 3);
+	assert(vec[1].use_count() == 1);
 	using namespace ::fast_io::io;
 	print("After vec.insert_index(1)\n");
 	for (auto const &e : vec)
@@ -24,6 +32,9 @@ int main()
 		println(::fast_io::mnp::pointervw(e.get()), " use_count: ", e.use_count());
 	}
 	vec.erase_index(0, 2);
+	assert(vec.size() == 2);
+	assert(*vec[0] == 2);
+	assert(*vec[1] == 3);
 	print("After vec.erase_index(0,2)\n");
 	for (auto const &e : vec)
 	{

--- a/tests/0026.container/0001.vector/shared_ptr_index_not_trivial.cc
+++ b/tests/0026.container/0001.vector/shared_ptr_index_not_trivial.cc
@@ -1,4 +1,3 @@
-#include <cassert>
 #include <fast_io_dsal/vector.h>
 #include <fast_io.h>
 #include <memory>
@@ -6,13 +5,13 @@
 int main()
 {
 	::fast_io::vector<::std::shared_ptr<int>> vec{std::make_shared<int>(1), std::make_shared<int>(2), std::make_shared<int>(3)};
-	assert(vec.size() == 3);
+	if (!(vec.size() == 3)) ::fast_io::fast_terminate();
 	vec.insert_index(1, std::make_shared<int>(4));
-	assert(vec.size() == 4);
-	assert(*vec[0] == 1);
-	assert(*vec[1] == 4);
-	assert(*vec[2] == 2);
-	assert(*vec[3] == 3);
+	if (!(vec.size() == 4)) ::fast_io::fast_terminate();
+	if (!(*vec[0] == 1)) ::fast_io::fast_terminate();
+	if (!(*vec[1] == 4)) ::fast_io::fast_terminate();
+	if (!(*vec[2] == 2)) ::fast_io::fast_terminate();
+	if (!(*vec[3] == 3)) ::fast_io::fast_terminate();
 	using namespace ::fast_io::io;
 	print("After vec.insert_index(1)\n");
 	for (auto const &e : vec)
@@ -20,9 +19,9 @@ int main()
 		println(::fast_io::mnp::pointervw(e.get()), " use_count: ", e.use_count());
 	}
 	vec.erase_index(0, 2);
-	assert(vec.size() == 2);
-	assert(*vec[0] == 2);
-	assert(*vec[1] == 3);
+	if (!(vec.size() == 2)) ::fast_io::fast_terminate();
+	if (!(*vec[0] == 2)) ::fast_io::fast_terminate();
+	if (!(*vec[1] == 3)) ::fast_io::fast_terminate();
 	print("After vec.erase_index(0,2)\n");
 	for (auto const &e : vec)
 	{

--- a/tests/0026.container/0001.vector/shared_ptr_index_not_trivial.cc
+++ b/tests/0026.container/0001.vector/shared_ptr_index_not_trivial.cc
@@ -1,11 +1,18 @@
-﻿#include <fast_io_dsal/vector.h>
+#include <cassert>
+#include <fast_io_dsal/vector.h>
 #include <fast_io.h>
 #include <memory>
 
 int main()
 {
 	::fast_io::vector<::std::shared_ptr<int>> vec{std::make_shared<int>(1), std::make_shared<int>(2), std::make_shared<int>(3)};
+	assert(vec.size() == 3);
 	vec.insert_index(1, std::make_shared<int>(4));
+	assert(vec.size() == 4);
+	assert(*vec[0] == 1);
+	assert(*vec[1] == 4);
+	assert(*vec[2] == 2);
+	assert(*vec[3] == 3);
 	using namespace ::fast_io::io;
 	print("After vec.insert_index(1)\n");
 	for (auto const &e : vec)
@@ -13,6 +20,9 @@ int main()
 		println(::fast_io::mnp::pointervw(e.get()), " use_count: ", e.use_count());
 	}
 	vec.erase_index(0, 2);
+	assert(vec.size() == 2);
+	assert(*vec[0] == 2);
+	assert(*vec[1] == 3);
 	print("After vec.erase_index(0,2)\n");
 	for (auto const &e : vec)
 	{

--- a/tests/0026.container/0001.vector/shrink_to_fit.cc
+++ b/tests/0026.container/0001.vector/shrink_to_fit.cc
@@ -1,4 +1,3 @@
-#include <cassert>
 #include <fast_io.h>
 #include <fast_io_dsal/vector.h>
 using namespace fast_io::io;
@@ -8,18 +7,18 @@ int main()
 {
 	fast_io::vector<int> v;
 	println("Default-constructed capacity is ", v.capacity());
-	assert(v.capacity() == 0);
+	if (!(v.capacity() == 0)) ::fast_io::fast_terminate();
 	v.resize(100);
 	println("Capacity of a 100-element vector is ", v.capacity());
-	assert(v.capacity() >= 100);
+	if (!(v.capacity() >= 100)) ::fast_io::fast_terminate();
 	auto old_cap = v.capacity();
 	v.resize(50);
 	println("Capacity after resize(50) is ", v.capacity());
-	assert(v.capacity() == old_cap);
+	if (!(v.capacity() == old_cap)) ::fast_io::fast_terminate();
 	v.shrink_to_fit();
 	println("Capacity after shrink_to_fit() is ", v.capacity());
-	assert(v.size() == 50);
-	assert(v.capacity() >= 50);
+	if (!(v.size() == 50)) ::fast_io::fast_terminate();
+	if (!(v.capacity() >= 50)) ::fast_io::fast_terminate();
 	v.clear();
 	println("Capacity after clear() is ", v.capacity());
 	v.shrink_to_fit();
@@ -29,8 +28,8 @@ int main()
 		v.push_back(i);
 	}
 	println("Capacity after adding 300 elements is ", v.capacity());
-	assert(v.size() == 300);
+	if (!(v.size() == 300)) ::fast_io::fast_terminate();
 	v.shrink_to_fit();
 	println("Capacity after shrink_to_fit() is ", v.capacity());
-	assert(v.capacity() >= 300);
+	if (!(v.capacity() >= 300)) ::fast_io::fast_terminate();
 }

--- a/tests/0026.container/0001.vector/shrink_to_fit.cc
+++ b/tests/0026.container/0001.vector/shrink_to_fit.cc
@@ -1,4 +1,5 @@
-﻿#include <fast_io.h>
+#include <cassert>
+#include <fast_io.h>
 #include <fast_io_dsal/vector.h>
 using namespace fast_io::io;
 using namespace fast_io::mnp;
@@ -7,12 +8,18 @@ int main()
 {
 	fast_io::vector<int> v;
 	println("Default-constructed capacity is ", v.capacity());
+	assert(v.capacity() == 0);
 	v.resize(100);
 	println("Capacity of a 100-element vector is ", v.capacity());
+	assert(v.capacity() >= 100);
+	auto old_cap = v.capacity();
 	v.resize(50);
 	println("Capacity after resize(50) is ", v.capacity());
+	assert(v.capacity() == old_cap);
 	v.shrink_to_fit();
 	println("Capacity after shrink_to_fit() is ", v.capacity());
+	assert(v.size() == 50);
+	assert(v.capacity() >= 50);
 	v.clear();
 	println("Capacity after clear() is ", v.capacity());
 	v.shrink_to_fit();
@@ -22,6 +29,8 @@ int main()
 		v.push_back(i);
 	}
 	println("Capacity after adding 300 elements is ", v.capacity());
+	assert(v.size() == 300);
 	v.shrink_to_fit();
 	println("Capacity after shrink_to_fit() is ", v.capacity());
+	assert(v.capacity() >= 300);
 }

--- a/tests/0026.container/0001.vector/size.cc
+++ b/tests/0026.container/0001.vector/size.cc
@@ -1,4 +1,5 @@
-﻿#include <fast_io.h>
+#include <cassert>
+#include <fast_io.h>
 #include <fast_io_dsal/vector.h>
 using namespace fast_io::io;
 using namespace fast_io::mnp;
@@ -8,4 +9,5 @@ int main()
 	fast_io::vector<int> nums{1, 3, 5, 7};
 
 	print("nums contains ", nums.size(), " elements.\n");
+	assert(nums.size() == 4);
 }

--- a/tests/0026.container/0001.vector/size.cc
+++ b/tests/0026.container/0001.vector/size.cc
@@ -1,4 +1,3 @@
-#include <cassert>
 #include <fast_io.h>
 #include <fast_io_dsal/vector.h>
 using namespace fast_io::io;
@@ -9,5 +8,5 @@ int main()
 	fast_io::vector<int> nums{1, 3, 5, 7};
 
 	print("nums contains ", nums.size(), " elements.\n");
-	assert(nums.size() == 4);
+	if (!(nums.size() == 4)) ::fast_io::fast_terminate();
 }

--- a/tests/0026.container/0001.vector/swap.cc
+++ b/tests/0026.container/0001.vector/swap.cc
@@ -1,4 +1,5 @@
-﻿#include <fast_io.h>
+#include <cassert>
+#include <fast_io.h>
 #include <fast_io_dsal/vector.h>
 using namespace fast_io::io;
 using namespace fast_io::mnp;
@@ -6,6 +7,9 @@ using namespace fast_io::mnp;
 int main()
 {
 	fast_io::vector<int> a1{1, 2, 3}, a2{4, 5};
+	assert(a1.size() == 3 && a2.size() == 2);
+	assert(a1[0] == 1 && a1[1] == 2 && a1[2] == 3);
+	assert(a2[0] == 4 && a2[1] == 5);
 
 	auto it1 = std::next(a1.begin());
 	auto it2 = std::next(a2.begin());
@@ -16,6 +20,10 @@ int main()
 	perrln("{ ", rgvw(a1, " "), " } { ", rgvw(a2, " "), " } ", *it1, " ", *it2, " ", ref1, ' ', ref2);
 	a1.swap(a2);
 	perrln("{ ", rgvw(a1, " "), " } { ", rgvw(a2, " "), " } ", *it1, " ", *it2, " ", ref1, ' ', ref2);
+
+	assert(a1.size() == 2 && a2.size() == 3);
+	assert(a1[0] == 4 && a1[1] == 5);
+	assert(a2[0] == 1 && a2[1] == 2 && a2[2] == 3);
 
 	// Note that after swap the iterators and references stay associated with their
 	// original elements, e.g. it1 that pointed to an element in 'a1' with value 2

--- a/tests/0026.container/0001.vector/swap.cc
+++ b/tests/0026.container/0001.vector/swap.cc
@@ -1,4 +1,3 @@
-#include <cassert>
 #include <fast_io.h>
 #include <fast_io_dsal/vector.h>
 using namespace fast_io::io;
@@ -7,9 +6,9 @@ using namespace fast_io::mnp;
 int main()
 {
 	fast_io::vector<int> a1{1, 2, 3}, a2{4, 5};
-	assert(a1.size() == 3 && a2.size() == 2);
-	assert(a1[0] == 1 && a1[1] == 2 && a1[2] == 3);
-	assert(a2[0] == 4 && a2[1] == 5);
+	if (!(a1.size() == 3 && a2.size() == 2)) ::fast_io::fast_terminate();
+	if (!(a1[0] == 1 && a1[1] == 2 && a1[2] == 3)) ::fast_io::fast_terminate();
+	if (!(a2[0] == 4 && a2[1] == 5)) ::fast_io::fast_terminate();
 
 	auto it1 = std::next(a1.begin());
 	auto it2 = std::next(a2.begin());
@@ -21,9 +20,9 @@ int main()
 	a1.swap(a2);
 	perrln("{ ", rgvw(a1, " "), " } { ", rgvw(a2, " "), " } ", *it1, " ", *it2, " ", ref1, ' ', ref2);
 
-	assert(a1.size() == 2 && a2.size() == 3);
-	assert(a1[0] == 4 && a1[1] == 5);
-	assert(a2[0] == 1 && a2[1] == 2 && a2[2] == 3);
+	if (!(a1.size() == 2 && a2.size() == 3)) ::fast_io::fast_terminate();
+	if (!(a1[0] == 4 && a1[1] == 5)) ::fast_io::fast_terminate();
+	if (!(a2[0] == 1 && a2[1] == 2 && a2[2] == 3)) ::fast_io::fast_terminate();
 
 	// Note that after swap the iterators and references stay associated with their
 	// original elements, e.g. it1 that pointed to an element in 'a1' with value 2

--- a/tests/0026.container/0001.vector/vector.cc
+++ b/tests/0026.container/0001.vector/vector.cc
@@ -1,4 +1,3 @@
-#include <cassert>
 #include <string>
 #include <fast_io.h>
 #include <fast_io_dsal/vector.h>
@@ -10,12 +9,12 @@ int main()
 	// C++11 initializer list syntax:
 	fast_io::vector<std::string> words1{"the", "frogurt", "is", "also", "cursed"};
 	print("1: {", rgvw(words1, ", "), "}\n");
-	assert(words1.size() == 5);
-	assert(words1[0] == "the");
-	assert(words1[1] == "frogurt");
-	assert(words1[2] == "is");
-	assert(words1[3] == "also");
-	assert(words1[4] == "cursed");
+	if (!(words1.size() == 5)) ::fast_io::fast_terminate();
+	if (!(words1[0] == "the")) ::fast_io::fast_terminate();
+	if (!(words1[1] == "frogurt")) ::fast_io::fast_terminate();
+	if (!(words1[2] == "is")) ::fast_io::fast_terminate();
+	if (!(words1[3] == "also")) ::fast_io::fast_terminate();
+	if (!(words1[4] == "cursed")) ::fast_io::fast_terminate();
 #if 0
 	// words2 == words1
 	fast_io::vector<std::string> words2(::std::from_range, words1);
@@ -24,13 +23,13 @@ int main()
 	// words3 == words1
 	fast_io::vector<std::string> words3(words1);
 	print("3: {", rgvw(words3, ", "), "}\n");
-	assert(words3 == words1);
+	if (!(words3 == words1)) ::fast_io::fast_terminate();
 
 	// words4 is {"Mo", "Mo", "Mo", "Mo", "Mo"}
 	fast_io::vector<std::string> words4(5, "Mo");
 	print("4: {", rgvw(words4, ", "), "}\n");
-	assert(words4.size() == 5);
-	for (auto const &w : words4) assert(w == "Mo");
+	if (!(words4.size() == 5)) ::fast_io::fast_terminate();
+	for (auto const &w : words4) if (!(w == "Mo")) ::fast_io::fast_terminate();
 #if 0
 	auto const rg = {"cat", "cow", "crow"};
 	fast_io::vector<std::string> words5(::std::from_range, rg); // overload (11)

--- a/tests/0026.container/0001.vector/vector.cc
+++ b/tests/0026.container/0001.vector/vector.cc
@@ -1,4 +1,5 @@
-﻿#include <string>
+#include <cassert>
+#include <string>
 #include <fast_io.h>
 #include <fast_io_dsal/vector.h>
 using namespace fast_io::io;
@@ -9,6 +10,12 @@ int main()
 	// C++11 initializer list syntax:
 	fast_io::vector<std::string> words1{"the", "frogurt", "is", "also", "cursed"};
 	print("1: {", rgvw(words1, ", "), "}\n");
+	assert(words1.size() == 5);
+	assert(words1[0] == "the");
+	assert(words1[1] == "frogurt");
+	assert(words1[2] == "is");
+	assert(words1[3] == "also");
+	assert(words1[4] == "cursed");
 #if 0
 	// words2 == words1
 	fast_io::vector<std::string> words2(::std::from_range, words1);
@@ -17,10 +24,13 @@ int main()
 	// words3 == words1
 	fast_io::vector<std::string> words3(words1);
 	print("3: {", rgvw(words3, ", "), "}\n");
+	assert(words3 == words1);
 
 	// words4 is {"Mo", "Mo", "Mo", "Mo", "Mo"}
 	fast_io::vector<std::string> words4(5, "Mo");
 	print("4: {", rgvw(words4, ", "), "}\n");
+	assert(words4.size() == 5);
+	for (auto const &w : words4) assert(w == "Mo");
 #if 0
 	auto const rg = {"cat", "cow", "crow"};
 	fast_io::vector<std::string> words5(::std::from_range, rg); // overload (11)

--- a/tests/0026.container/0001.vector/vector_allocate_at_least.cc
+++ b/tests/0026.container/0001.vector/vector_allocate_at_least.cc
@@ -1,4 +1,3 @@
-#include <cassert>
 #include <fast_io.h>
 #include <fast_io_dsal/vector.h>
 using namespace fast_io::io;
@@ -8,12 +7,12 @@ int main()
 {
 	fast_io::vector<::std::size_t> vec;
 	println("Before vec.push_back(50): vec.size()=",vec.size()," vec.capacity()=",vec.capacity());
-	assert(vec.size() == 0);
-	assert(vec.capacity() == 0);
+	if (!(vec.size() == 0)) ::fast_io::fast_terminate();
+	if (!(vec.capacity() == 0)) ::fast_io::fast_terminate();
 	vec.push_back(50);
 	vec.push_back(50);
 	println("After vec.push_back(50): vec.size()=",vec.size()," vec.capacity()=",vec.capacity());
-	assert(vec.size() == 2);
-	assert(vec[0] == 50);
-	assert(vec[1] == 50);
+	if (!(vec.size() == 2)) ::fast_io::fast_terminate();
+	if (!(vec[0] == 50)) ::fast_io::fast_terminate();
+	if (!(vec[1] == 50)) ::fast_io::fast_terminate();
 }

--- a/tests/0026.container/0001.vector/vector_allocate_at_least.cc
+++ b/tests/0026.container/0001.vector/vector_allocate_at_least.cc
@@ -1,4 +1,5 @@
-﻿#include <fast_io.h>
+#include <cassert>
+#include <fast_io.h>
 #include <fast_io_dsal/vector.h>
 using namespace fast_io::io;
 using namespace fast_io::mnp;
@@ -7,7 +8,12 @@ int main()
 {
 	fast_io::vector<::std::size_t> vec;
 	println("Before vec.push_back(50): vec.size()=",vec.size()," vec.capacity()=",vec.capacity());
+	assert(vec.size() == 0);
+	assert(vec.capacity() == 0);
 	vec.push_back(50);
 	vec.push_back(50);
 	println("After vec.push_back(50): vec.size()=",vec.size()," vec.capacity()=",vec.capacity());
+	assert(vec.size() == 2);
+	assert(vec[0] == 50);
+	assert(vec[1] == 50);
 }

--- a/tests/0026.container/0001.vector/vector_deduction.cc
+++ b/tests/0026.container/0001.vector/vector_deduction.cc
@@ -1,4 +1,5 @@
-﻿#include <fast_io.h>
+#include <cassert>
+#include <fast_io.h>
 #include <fast_io_dsal/vector.h>
 using namespace fast_io::io;
 using namespace fast_io::mnp;
@@ -7,7 +8,15 @@ int main()
 {
 	fast_io::vector vec{static_cast<::std::uint_least32_t>(1), 6, 10, 20};
 	println("Before vec.push_back(50): vec.size()=", vec.size(), " vec.capacity()=", vec.capacity());
+	assert(vec.size() == 4);
+	assert(vec[0] == 1);
+	assert(vec[1] == 6);
+	assert(vec[2] == 10);
+	assert(vec[3] == 20);
 	vec.push_back(50);
 	vec.push_back(50);
 	println("After vec.push_back(50): vec.size()=", vec.size(), " vec.capacity()=", vec.capacity());
+	assert(vec.size() == 6);
+	assert(vec[4] == 50);
+	assert(vec[5] == 50);
 }

--- a/tests/0026.container/0001.vector/vector_deduction.cc
+++ b/tests/0026.container/0001.vector/vector_deduction.cc
@@ -1,4 +1,3 @@
-#include <cassert>
 #include <fast_io.h>
 #include <fast_io_dsal/vector.h>
 using namespace fast_io::io;
@@ -8,15 +7,15 @@ int main()
 {
 	fast_io::vector vec{static_cast<::std::uint_least32_t>(1), 6, 10, 20};
 	println("Before vec.push_back(50): vec.size()=", vec.size(), " vec.capacity()=", vec.capacity());
-	assert(vec.size() == 4);
-	assert(vec[0] == 1);
-	assert(vec[1] == 6);
-	assert(vec[2] == 10);
-	assert(vec[3] == 20);
+	if (!(vec.size() == 4)) ::fast_io::fast_terminate();
+	if (!(vec[0] == 1)) ::fast_io::fast_terminate();
+	if (!(vec[1] == 6)) ::fast_io::fast_terminate();
+	if (!(vec[2] == 10)) ::fast_io::fast_terminate();
+	if (!(vec[3] == 20)) ::fast_io::fast_terminate();
 	vec.push_back(50);
 	vec.push_back(50);
 	println("After vec.push_back(50): vec.size()=", vec.size(), " vec.capacity()=", vec.capacity());
-	assert(vec.size() == 6);
-	assert(vec[4] == 50);
-	assert(vec[5] == 50);
+	if (!(vec.size() == 6)) ::fast_io::fast_terminate();
+	if (!(vec[4] == 50)) ::fast_io::fast_terminate();
+	if (!(vec[5] == 50)) ::fast_io::fast_terminate();
 }


### PR DESCRIPTION
- Add <cassert> includes and comprehensive assert() checks to all vector container tests, verifying size, capacity, element values, and state after operations (push_back, pop_back, erase, insert, assign, swap, clear, shrink_to_fit, etc.)
- Fix typo in back.cc: "The first character" -> "The last character"
- Fix missing trailing newlines in multiple files
- Enable previously disabled append_range.cc test (remove #if 0)
- Add state assertions to shared_ptr index tests for insert_index and erase_index operations